### PR TITLE
docs(repo): add SECURITY.md pointing at private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security policy
+
+This covers everything in this monorepo: `projects/pigrocrm`, `projects/hub` and
+`projects/website`.
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting: open
+[Report a vulnerability](https://github.com/joinorbiters/orbiters/security/advisories/new).
+It alerts both maintainers directly and keeps the report out of the public issue
+tracker while it is looked at. A public issue is the wrong channel for a
+vulnerability: please do not open one for a security problem, even a suspected one.
+
+## What to expect
+
+The repository is maintained by two people, so please be patient. You should hear
+back with a first answer within a few working days. If the report turns out to be a
+real vulnerability, we will credit you in the published advisory unless you tell us
+you would rather stay anonymous. There is no bounty programme.
+
+## Supported versions
+
+PigroCRM is pre-1.0. Only the current `main` branch is supported; there are no
+older release lines to patch.


### PR DESCRIPTION
## What this changes

There was no `SECURITY.md`, so the repository had no disclosure channel now that
it is public. This adds one, scoped to the three projects in the monorepo
(`projects/pigrocrm`, `projects/hub`, `projects/website`), that points a reporter
at GitHub's private vulnerability reporting rather than a `security@` mailbox
nobody would read. It says a public issue is the wrong channel for a
vulnerability, what a reporter can expect (a first answer within a few working
days, credit in the advisory unless they would rather not, no bounty programme),
and that only current `main` is supported, since PigroCRM is pre-1.0.

This is the half of ORB-10 that was still open. The licence half (`LICENSE`,
AGPL v3) already landed in `d518011`.

## How I verified it

`git diff --stat` shows only `SECURITY.md` added, 24 lines. Read the file back
after writing it to check the three required facts are there: the scope (the
three projects), the report link
(`https://github.com/joinorbiters/orbiters/security/advisories/new`), and the
"no bounty, be patient, pre-1.0" claims match what the issue asked for. Private
vulnerability reporting itself is being enabled on the repository by a separate
process; this PR only adds the file GitHub renders once that setting is on.

## Anything a reviewer should look at twice

None. This is a single new file with no code path.

## Screenshots

Nothing visible changed in the app; this is a new markdown file at the
repository root.

Linear: ORB-10.
