### PR TITLE
fix(website): the self-hosting link points at real installation steps

### DIFF
--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -210,7 +210,7 @@
             <a class="quiet-link" href="https://pigro.joinorbiters.com/app/registrati"
               >Crea il tuo spazio PigroCRM</a
             >. Preferisci averlo sul tuo server? È open source e self-hosted quando vuoi:
-            <a class="quiet-link" href="https://github.com/joinorbiters/orbiters#installazione"
+            <a class="quiet-link" href="https://github.com/joinorbiters/orbiters/blob/main/projects/pigrocrm/README.md#deploy"
               >le istruzioni sono su GitHub</a
             >.
           </p>


### PR DESCRIPTION
## What this changes

The landing page's self-hosting sentence linked to `https://github.com/joinorbiters/orbiters#installazione`, an anchor that never existed: the monorepo root README is about the monorepo and never explains installing PigroCRM. The link now points at `projects/pigrocrm/README.md#deploy` on `main`, which is where the actual installation steps live (`## Deploy` and its subsections). The other defect this issue reported, stale `joinorbiters/pigrocrm` URLs baked into `projects/website/dist/index.html` and `projects/pigrocrm/apps/web/dist-landing/index.html`, is already resolved: `dist/` is gitignored and neither file is tracked in the public repository, so there was nothing to rebuild or hand-edit.

## How I verified it

`curl -s -o /dev/null -w '%{http_code}' 'https://github.com/joinorbiters/orbiters/blob/main/projects/pigrocrm/README.md#deploy'` answers `200`, and `## Deploy` is a real heading in `projects/pigrocrm/README.md` (line 36), so the anchor GitHub derives from it resolves to that section. `git grep -n "joinorbiters/pigrocrm"` across the tracked tree returns nothing. `pnpm --filter website test` (vitest): 10 files, 188 tests, all passed, including `landing-pages.test.ts`.

## Anything a reviewer should look at twice

I linked to the `## Deploy` section rather than a narrower step inside it, because that's the section a self-hoster actually needs from the top (prerequisites through first login), not just one subsection.

## Screenshots

Nothing visible changed except an `href` attribute; the link's text and position on the page are the same. No before/after pair captured.

Linear: ORB-65.
