### PR TITLE
docs(hub): the hub has a README, and the root index points at it

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The monorepo for Orbiters' products.
 |---|---|---|
 | [`projects/pigrocrm`](projects/pigrocrm) | PigroCRM — an AI-first CRM for Italian freelancers, consultants and small startups. Everything the web UI can do is also reachable over REST and over MCP. | Python · FastAPI · SQLAlchemy · PostgreSQL · React · Vite |
 | [`projects/website`](projects/website) | joinorbiters.com — the public site: the Orbiters community page, the pages the product signs itself with, and the signup form. Static pages, deliberately no framework. | HTML · CSS · Vite |
+| [`projects/hub`](projects/hub/README.md) | The Orbiters hub, at joinorbiters.com/hub — the freelancer and company signup wizards, and the admin area that reads them. | Python · FastAPI · SQLAlchemy · PostgreSQL · React · Vite |
 | [`shared/brand`](shared/brand) | The palette, the typeface and the four-tile mark, read by both surfaces so there is one source and no copy. | CSS |
 
 ## Getting started

--- a/projects/hub/README.md
+++ b/projects/hub/README.md
@@ -1,0 +1,114 @@
+# Orbiters hub
+
+Orbiters, the freelance community, as a product of its own: the signup form the
+community site collects, the freelancer and company wizards, and the admin area that
+reads them. Served at `joinorbiters.com/hub/`. Split out of PigroCRM on 2026-09-09 so
+the two products change independently — its own settings (`ORBITERS_*`), its own
+Postgres, its own Alembic history, its own API and MCP server. Nothing here imports
+PigroCRM, and PigroCRM imports nothing from here.
+
+The design record is
+[`docs/superpowers/specs/2026-09-09-orbiters-hub-design.md`](docs/superpowers/specs/2026-09-09-orbiters-hub-design.md).
+Read it before changing the shape of anything here; this file does not restate it.
+
+## What it does
+
+Three public flows and the admin area behind them:
+
+- `/hub/` — the chooser: «Sono un freelance» / «Cerco persone per un progetto».
+- `/hub/freelance` — the freelancer wizard (CV upload included), ending at `/hub/grazie`.
+- `/hub/aziende` — the company wizard.
+- `/hub/admin/login` and the freelancer, company and signup lists behind it — a cookie
+  session, created with `orbiters createadmin` (below).
+
+`POST /api/orbiters/signups` is the community site's signup endpoint, moved here
+unchanged on 2026-09-09: the website's form and the ChatGPT Ads conversion still post
+to the same path.
+
+## Layout
+
+```
+packages/core/   orbiters_core: models, Alembic migrations, services, the ad conversion
+apps/api/        orbiters_api: FastAPI, one process, its own database
+apps/mcp/        orbiters_mcp: stdio, the same services in process
+apps/web/        pnpm package `hub`: the SPA at joinorbiters.com/hub/
+```
+
+`packages/core` imports neither adapter, and neither adapter imports the other.
+
+## Running it
+
+Python, from the repository root:
+
+```
+uv sync --frozen
+uv run pytest -q projects/hub/packages/core/tests projects/hub/apps/api/tests projects/hub/apps/mcp/tests
+uv run --env-file projects/hub/.env uvicorn orbiters_api.main:app --port 8010
+```
+
+The tests bring a `testcontainers` Postgres to `head` with this package's migrations,
+never with `create_all`.
+
+Web, also from the root:
+
+```
+pnpm --filter hub dev      # :5180, with /api proxied to a running hub API on :8084
+pnpm --filter hub build
+pnpm --filter hub test
+pnpm --filter hub lint
+```
+
+The full stack, its own Postgres included, from this directory:
+
+```
+cd projects/hub
+docker compose -p orbiters up -d --build
+```
+
+`-p orbiters` is not decorative: without it compose names the stack after the
+directory, and a second stack starts beside the one already running rather than
+joining it.
+
+## Ports and the environment file
+
+Loopback only, production values (`docs/adding-a-project.md` §7 has preview's):
+
+| Service | Port |
+|---|---|
+| api | 8084 |
+| web | 8085 |
+| Postgres | 55435 |
+
+`.env.example` lists every variable the compose file needs: `POSTGRES_*`,
+`ORBITERS_DATABASE_URL`, the ports above, the ChatGPT Ads pair, and
+`ORBITERS_DATA_DIR` — Postgres' data directory, outside the repository, with no
+default in `docker-compose.yml`, so a `.env` that forgets it fails the stack rather
+than mounting an empty one. The `.env` itself is never in the repository. Locally it
+is `projects/hub/.env`, beside the compose file. On a server it is
+`${DEPLOY_PATH}/.env`, the root of that environment's checkout, two levels above the
+compose file: the deploy passes `--env-file` explicitly and never rsyncs one.
+
+The first administrator, once the stack is up:
+
+```
+docker compose -p orbiters exec api uv run --no-sync orbiters createadmin --email you@example.com --nome "Nome Cognome"
+```
+
+Asks for the password on the terminal, twice, and never takes it as an argument.
+
+## Deploy
+
+`.github/workflows/deploy-hub.yml`: preview on a push to `main` that touched the hub,
+production on a tag `hub-v<semver>` (`hub-v0.1.0` is out already). Both call the
+shared `_deploy-compose.yml`. The production compose project is `orbiters`, not
+`hub` — the name the stack first went up under by hand on 2026-09-09 (ORB-17), since
+a different name here would start a second stack beside the running one. The
+preview's is `orbiters-preview`. `GET /health` touches the database on purpose, so a
+green deploy means Postgres is up and migrated, not only that uvicorn answered.
+
+## Status
+
+Shipped: `hub-v0.1.0` is deployed. What is still open — CV retention, the privacy
+paragraph the wizard has to link before the CV step, whether the signup-listing MCP
+tool moves out of PigroCRM's server — and the decisions taken with Ivan are in
+[`docs/superpowers/specs/`](docs/superpowers/specs/).


### PR DESCRIPTION
## What this changes

`projects/hub` had no README: the only prose about the hub was `AGENTS.md`, written for an agent already inside the repository rather than for somebody deciding what this is, and the root README's project table had no row for it at all. This adds `projects/hub/README.md` — what the hub is, its three public flows (the signup, the freelancer wizard, the company wizard) and the admin behind them, its layout, how to run and test it locally, how to bring up the full stack with its own Postgres, its ports, where its `.env` lives, and how it deploys (`hub-v<semver>` tags, the `orbiters` compose project) — and points at `docs/superpowers/specs/2026-09-09-orbiters-hub-design.md` for the design record instead of restating it. The root README gets a hub row, linking to the new README directly rather than the bare directory.

## How I verified it

In a fresh clone, on this branch:

- `uv sync --frozen` — resolves clean.
- `uv run pytest -q projects/hub/packages/core/tests projects/hub/apps/api/tests projects/hub/apps/mcp/tests` — 135 passed.
- `pnpm install --frozen-lockfile`, then `pnpm --filter hub build`, `pnpm --filter hub test` (17 passed), `pnpm --filter hub lint` — all green.
- `docker compose -p orbiters up -d --build` (against a throwaway `.env` on non-default ports so it wouldn't collide with anything else on the box): the stack came up, `alembic upgrade head` ran migrations 0001-0004 on start-up, `GET /health` returned `{"status":"ok"}`, the web container served `/hub/` with a 200, and `docker compose exec api uv run --no-sync orbiters createadmin --email test@example.com --nome "Test Admin"` created an admin (`Amministratore creato: test@example.com`). Torn down after with `docker compose down -v`.

Every other claim in the README (the route list, the ports table, the deploy triggers and tag pattern, the compose project names, where `.env` lives on a server) is taken verbatim or paraphrased from `projects/hub/AGENTS.md`, the design spec, `docker-compose.yml`, `.env.example`, `deploy-hub.yml` and `docs/adding-a-project.md` §7 — cited inline where it isn't obvious from context.

## Anything a reviewer should look at twice

The root README table's other two rows link to their project's bare directory (GitHub renders the README when browsing one); the hub's new row links straight to `projects/hub/README.md` instead, per the issue's ask. That makes the hub row's link target inconsistent in shape with its neighbours even though the rendered result on GitHub is the same either way — flagging the inconsistency rather than silently picking one.

## Screenshots

None: this is documentation only, no UI changed.

Linear: ORB-35.