### PR TITLE
chore(pigrocrm): the setup script's domain has no default left to leak

### DIFF
--- a/projects/pigrocrm/README.md
+++ b/projects/pigrocrm/README.md
@@ -89,13 +89,12 @@ listening only on `127.0.0.1:8080` — not yet reachable from the internet).
 ### 3. Configure nginx on the host
 
 ```
-sudo bash deploy/setup-server.sh
+sudo PIGROCRM_DOMAIN=tuodominio.it bash deploy/setup-server.sh
 ```
 
-Writes a vhost that acts as a reverse proxy to `127.0.0.1:8080`, for now only over HTTP. Uses the
-default domain (`pigrocrm.example.com`) unless `PIGROCRM_DOMAIN` is set:
-`sudo PIGROCRM_DOMAIN=tuodominio.it bash deploy/setup-server.sh`, and it has to be passed, because the
-default is not this server's domain.
+Writes a vhost that acts as a reverse proxy to `127.0.0.1:8080`, for now only over HTTP.
+`PIGROCRM_DOMAIN` is required: the script refuses to run without it, because a public
+repository's setup script defaulting to somebody's domain is worse than asking.
 
 **One-time step: the automatic deploy does not run it.** Re-running it on every push
 would rewrite the reverse proxy on every commit, and the guard that's meant to protect the

--- a/projects/pigrocrm/deploy/setup-server.sh
+++ b/projects/pigrocrm/deploy/setup-server.sh
@@ -19,7 +19,11 @@
 # `listen 443 ssl` shows up in it (certbot's own signature), leave it alone.
 set -euo pipefail
 
-DOMAIN="${PIGROCRM_DOMAIN:-pigrocrm.example.com}"
+if [ -z "${PIGROCRM_DOMAIN:-}" ]; then
+  echo "PIGROCRM_DOMAIN must be set, e.g. PIGROCRM_DOMAIN=tuodominio.it bash deploy/setup-server.sh -- there is no default, so a fresh install never points at somebody else's domain." >&2
+  exit 1
+fi
+DOMAIN="$PIGROCRM_DOMAIN"
 CONF="/etc/nginx/sites-available/${DOMAIN}"
 
 if [ -f "$CONF" ] && grep -q 'listen 443 ssl' "$CONF"; then


### PR DESCRIPTION
## What this changes

ORB-51 audited the repository for absolute production paths, a default domain that pointed at somebody's private setup, and stale references to the tool PigroCRM replaced. Most of it was already fixed by an earlier sanitisation pass (2026-09-09/10), before this issue was even picked up. The one thing still open: `deploy/setup-server.sh` had already stopped defaulting `PIGROCRM_DOMAIN` to a real person's domain, but it still silently fell back to the reserved placeholder (`pigrocrm.example.com`) when the variable was unset, even though the README already told the operator the value always has to be passed. Now the script refuses to run without `PIGROCRM_DOMAIN` and says why, so a fresh install can never come up pointed at any domain nobody chose. The README's step 3 is updated to match: the command line now always carries `PIGROCRM_DOMAIN=`.

## How I verified it

- `bash -n projects/pigrocrm/deploy/setup-server.sh` and `shellcheck projects/pigrocrm/deploy/setup-server.sh`: both clean.
- `orbiters-identity-scan .` at the repository root: `identity-scan: clean against 28 names, 3 path(s) allowed`, exit 0.
- `grep -rn humancraft.tech .`: the only hits left are `projects/website/src/privacy.html`, `projects/website/src/termini.html` (Italian law requires the titolare del trattamento there) and the test that allow-lists that origin for those two pages.
- Read every item ORB-51 names and checked each by file and line:
  - `projects/pigrocrm/README.md:152` and `.../notes/2026-09-09-gmail-cron-runbook.md:19` (`/opt/pigrocrm/projects/pigrocrm`): already derived to `$DEPLOY_PATH/projects/pigrocrm` by commit 622d507, before this branch existed.
  - The same two files' `/var/log/pigrocrm-gmail-sync.log`: left as is. It is a generic Linux log-directory convention illustrated for the operator's own crontab, not this production host's real layout, and the same commit (622d507) that derived the `/opt/pigrocrm` path on these exact lines deliberately left this one alone.
  - `.../plans/2026-08-10-slice-2-documenti-e-template.md` (`/home/dev/...`): outside my ownership for this PR (`plans/`, not `notes/`); left untouched, flagging for whoever owns it.
  - `.../notes/2026-09-08-ui-revision-screenshots.md` (`/home/dev/...`): already clean, only relative `.playwright-mcp/ui-rev/` paths remain.
  - `projects/pigrocrm/deploy/setup-server.sh:22` and `README.md:96` (`pigrocrm.humancraft.tech` default): the domain value was already swapped to a reserved placeholder; this PR removes the fallback entirely, per the issue's own "make the domain a required variable with no default."
  - `.reference-mitra` mentions (`.gitignore`, `Dockerfile.api`, the slice 1b plan): `grep -rn mitra` across the whole tree returns nothing; already gone repository-wide.
  - `projects/hub/AGENTS.md:63` (`/opt/hub/.env`) and `projects/hub/.env.example:22` / hub design spec (`/srv/orbiters-data/postgres`): outside my ownership (hub project); the `/opt/hub/.env` reference is already gone, `/srv/orbiters-data/postgres` is still present. Left for whoever owns `projects/hub`.

## Anything a reviewer should look at twice

The issue's own "Fix" line asked for "a required variable with no default"; my task's restated acceptance criteria described the already-done "swap to a reserved example domain" as sufficient on its own. I did both: I verified nothing in `.github/` invokes `setup-server.sh` (it is a documented one-time manual step, never called by `ci-deploy.yml` or any current deploy workflow — that workflow name is itself stale, superseded by `_deploy-compose.yml` / `deploy-pigrocrm.yml`, which I did not touch since it is outside this issue's scope), so requiring the variable cannot break an automated deploy.

## Screenshots

Nothing visible changed: this is a deploy script and its README instructions, nothing user-facing.

Linear: ORB-51.