### PR TITLE
chore(repo): the last three places that still named a host path or a dead workflow

### DIFF
--- a/projects/hub/.env.example
+++ b/projects/hub/.env.example
@@ -28,7 +28,7 @@ POSTGRES_DB=orbiters
 # Postgres data on the host, outside Docker and outside the repository. Required: the
 # compose file has no default for it, so a stack whose `.env` forgets it refuses to
 # start rather than coming up on an empty directory, or on another stack's data.
-ORBITERS_DATA_DIR=/srv/orbiters-data/postgres
+ORBITERS_DATA_DIR=/absolute/path/to/orbiters-data/postgres
 # Host ports, loopback only: the host's nginx is what faces the internet. These are
 # production's (`docs/adding-a-project.md` §7 has the table for every project).
 ORBITERS_DB_PORT=127.0.0.1:55435

--- a/projects/hub/docs/superpowers/specs/2026-09-09-orbiters-hub-design.md
+++ b/projects/hub/docs/superpowers/specs/2026-09-09-orbiters-hub-design.md
@@ -150,8 +150,9 @@ hub.
 
 ### Deploy
 
-- `projects/hub/docker-compose.yml`: `db` (its own Postgres, data under
-  `/srv/orbiters-data/postgres`), `api`, `web` on `127.0.0.1:8084`.
+- `projects/hub/docker-compose.yml`: `db` (its own Postgres, data under the host
+  directory `ORBITERS_DATA_DIR` names, outside the repository), `api`, `web` on
+  `127.0.0.1:8084`.
 - Host nginx `joinorbiters.conf`: `location ^~ /hub/` → 8084; `location ^~ /api/hub/`
   and `location = /api/orbiters/signups` → the hub API (the latter re-pointed from the
   PigroCRM API). Nothing on pigro.joinorbiters.com changes.

--- a/projects/pigrocrm/README.md
+++ b/projects/pigrocrm/README.md
@@ -46,12 +46,14 @@ in this order.
 - The user running the deploy has to belong to the `docker` group **and** has to be `root` (or
   have sudo equivalent): `deploy/setup-server.sh` writes to `/etc/nginx/sites-available/`,
   creates the symlink in `sites-enabled/`, runs `nginx -t` and `systemctl reload nginx`, all
-  operations that require root privileges. `ci-deploy.yml` runs this same script over
-  SSH assuming that the user configured in `PIGROCRM_USER` already has it; this repository does not
-  try to bypass the requirement with non-interactive `sudo`, because that would only work assuming
-  that every target server already has a passwordless sudoers rule preconfigured for
-  exactly these commands — an assumption that can't be verified from here, and is equivalent to the
-  requirement above under a different name.
+  operations that require root privileges. No workflow runs this script: it is a one-time
+  manual step over SSH, and the deploy (`deploy-pigrocrm.yml`, through
+  `_deploy-compose.yml`) only rsyncs the tree and rebuilds the stack as the environment's
+  `DEPLOY_USER`. This repository does not try to bypass the root requirement with
+  non-interactive `sudo`, because that would only work assuming that every target server
+  already has a passwordless sudoers rule preconfigured for exactly these commands, an
+  assumption that cannot be verified from here and is equivalent to the requirement above
+  under a different name.
 - **`pg_trgm`.** The migrations run `CREATE EXTENSION IF NOT EXISTS pg_trgm`
   when the API starts up. On the compose's `postgres:17-alpine` image the user
   `pigrocrm` is superuser and it works without intervention. On a managed PostgreSQL it takes


### PR DESCRIPTION
## What this changes

I finished ORB-51's own list. #4 took the domain default and the two `/opt` paths; this takes what it left: `projects/hub/.env.example` shipped `/srv/orbiters-data/postgres` as the value a reader copies, the hub design spec named the same absolute path, and `projects/pigrocrm/README.md` claimed `ci-deploy.yml` runs `deploy/setup-server.sh` over SSH as `PIGROCRM_USER`, where all three of those are gone: no workflow invokes that script, the deploy is `deploy-pigrocrm.yml` through `_deploy-compose.yml`, and that secret does not exist on this repository.

The `/Users/...` paths ORB-51 also lists in the slice-2 plan need no change: the sanitisation replaced the real home with a placeholder one, so they reveal nothing, and a dated plan is a record rather than documentation. The `ci-deploy.yml` mentions inside the dated plans and specs stay for the same reason: that workflow existed when they were written.

## How I verified it

`grep -rn '/srv/orbiters-data'` now returns nothing. `grep -rn 'ci-deploy.yml' --include='*.md'` returns only the dated plans and specs, no live documentation. `grep -rn 'setup-server' .github/` returns nothing, which is the claim the README sentence now makes. `orbiters-identity-scan .` exits 0, clean against 28 names.

## Anything a reviewer should look at twice

The placeholder I put in `projects/hub/.env.example` is English (`/absolute/path/to/orbiters-data/postgres`) while PigroCRM's equivalent is Italian (`/percorso/assoluto/...`). I left PigroCRM alone rather than mixing a translation into this change, so the two `.env.example` files now differ in the language of a placeholder.

## Screenshots

Nothing visible changed: this is three lines of documentation and one `.env.example` default.