### PR TITLE
docs(website): the second perk now has an Italian draft guide

### DIFF
--- a/projects/website/content/README.md
+++ b/projects/website/content/README.md
@@ -1,0 +1,14 @@
+# content
+
+Source text for the website's downloadable perks, kept apart from `src` because it is
+prose reviewed on its own terms, not markup. Each file here is the approved words for
+one perk; nothing in this directory is served, linked or typeset yet.
+
+- `guida-primi-passi-freelance.md`: the guide to the first steps as a freelancer, the
+  second perk (ORB-69). Italian, because it is what a member reads, not what the
+  repository says about itself. Draft until Lorenzo approves it in a comment on the
+  issue.
+
+Turning a file here into a downloadable PDF, linking it from the perks section, and
+everything about layout, fonts or a cover, is ORB-70. It starts only after the text
+above it is approved.

--- a/projects/website/content/guida-primi-passi-freelance.md
+++ b/projects/website/content/guida-primi-passi-freelance.md
@@ -1,10 +1,10 @@
 # I primi passi da freelance: la parte che nessuno ti spiega prima della prima fattura
 
-Ho aperto la partita IVA anni fa, e nessuno mi ha insegnato a scrivere la prima fattura.
-Ho imparato quasi tutto da un errore mio o da uno di chi lavorava vicino a me. Questa
-guida è quello che avrei voluto leggere allora: non un manuale, non la teoria di chi
-vende corsi sul freelance, ma le cose che si ripetono davvero, scritte come le direi a
-un developer che sta per fare lo stesso salto.
+Nessuno insegna a scrivere la prima fattura prima che tocchi scriverla davvero. Si
+impara quasi sempre da un errore, il tuo o di chi lavora vicino a te. Questa guida è
+quello che vorresti trovare scritto prima di quell'errore: non un manuale, non la
+teoria di chi vende corsi sul freelance, ma le cose che si ripetono davvero, nel modo
+in cui te le direbbe chi le ha viste ripetersi.
 
 Non è un elenco di regole fisse. È quello che ho visto funzionare abbastanza spesso da
 scriverlo, e ogni volta che un numero compare in questa guida ti dico anche se è
@@ -29,22 +29,21 @@ averti. Se una di queste tre cose manca dopo la prima chiamata, chiedila prima d
 mandare un preventivo. Un preventivo scritto su un progetto non chiaro è un numero
 inventato che poi devi difendere.
 
-Un esempio, senza nomi. Una startup del settore logistico mi ha scritto chiedendo «una
-mano col backend», niente altro. Ho fatto per telefono la domanda che di solito evito
-di fare per email: cosa esiste già, cosa manca davvero, e chi decide se il lavoro va
-bene. È venuto fuori che il problema non era il backend in generale ma
-un'integrazione con un corriere che in azienda non sapeva più leggere nessuno. Il
-preventivo che ho mandato parlava di quella integrazione, non di «una mano col
-backend», ed è stato accettato lo stesso giorno: non perché fossi più bravo di un
-altro, ma perché ero l'unico ad aver capito cosa stavo vendendo prima di scrivere il
-prezzo.
+Il caso tipico: una startup del settore logistico ti scrive chiedendo «una mano col
+backend», e niente altro. La domanda da fare, meglio al telefono che per email, è
+cosa esiste già, cosa manca davvero, e chi decide se il lavoro va bene. Spesso salta
+fuori che il problema non è il backend in generale ma un pezzo preciso, un'integrazione
+con un corriere che in azienda non sa più leggere nessuno, per dire. Un preventivo
+scritto su quel pezzo, e non su «una mano col backend», si accetta più in fretta: non
+perché costi meno, ma perché il cliente vede che hai capito cosa ti sta chiedendo
+prima ancora di scrivere il prezzo.
 
 La tariffa a giornata è una frase, non una scusa. «La mia giornata costa X» si dice
 con lo stesso tono con cui dici il tuo nome. Se la dici con un tono da scusa, chi ti
 ascolta se ne accorge prima di sentire il numero, e negozia sul tono, non sul numero.
-L'ho imparato dopo aver visto la differenza tra due mie stesse telefonate, stessa
-tariffa, tono diverso: una è finita con un sì immediato, l'altra con tre giorni di
-silenzio e una controproposta.
+La differenza si sente: la stessa tariffa, detta con un tono diverso in due
+telefonate diverse, può finire con un sì immediato o con tre giorni di silenzio e
+una controproposta.
 
 ## Farsi pagare il giusto
 
@@ -70,11 +69,13 @@ prima la abbassa per sempre, perché la voce corre. «Posso fare la prima metà 
 quella cifra, la seconda la vediamo dopo» costa allo stesso modo di uno sconto sul
 foglio, ma non lo è.
 
-Un'azienda del settore sanitario, una volta, ha accettato il mio primo numero senza
-controproposte. Ho capito dopo perché: aveva già chiesto due preventivi ad altri, ed
-ero l'unico ad aver chiesto quanto tempo avessero per decidere prima di scrivere la
-cifra. Il numero non era più basso degli altri due, era solo il primo scritto su un
-progetto che, a forza di domande, capivo meglio degli altri due preventivatori.
+Capita, in un'azienda del settore sanitario come altrove, che il primo numero
+proposto venga accettato senza controproposte. Il motivo di solito non è il numero
+in sé: è che il cliente ha già chiesto due preventivi ad altri, e chi fa la domanda su
+quanto tempo hanno per decidere, prima di scrivere la cifra, è quello che si nota. Il
+numero non deve essere più basso degli altri due: deve essere il primo scritto su un
+progetto che, a forza di domande, si capisce meglio di chi ha preventivato senza
+farle.
 
 Il preventivo più basso non è quello che vinci più facilmente. È quello che, tre
 settimane dentro il progetto, il cliente prova a rinegoziare al ribasso, perché ha
@@ -90,12 +91,12 @@ in un'email che il cliente conferma con un «ok, confermo» o un preventivo firm
 Quella email è quello a cui torni tra due mesi quando qualcuno dice «ma io pensavo
 che...».
 
-L'ho visto non fatto, una volta, in un progetto del settore ecommerce dove lo scope
-era tutto in una chiamata mai ripresa per iscritto. A metà lavoro il cliente
-ricordava una versione diversa da quella che ricordavo io, in buona fede da
-entrambe le parti: nessuno mentiva, semplicemente nessuno aveva scritto niente. Da
-allora le tre righe le mando sempre, anche quando sembrano talmente ovvie che
-scriverle pare tempo perso.
+È il modo in cui va storto un progetto del settore ecommerce con lo scope tutto detto
+a voce, in una chiamata mai ripresa per iscritto: a metà lavoro il cliente ricorda
+una versione diversa da quella che ricordi tu, in buona fede da entrambe le parti.
+Nessuno mente, semplicemente nessuno ha scritto niente. Le tre righe si mandano
+sempre, anche quando sembrano talmente ovvie che scriverle pare tempo perso: è
+proprio lì che servono di più.
 
 Dire no a qualcosa fuori scope non deve suonare come un rifiuto. «Questo non era nel
 preventivo, lo aggiungo volentieri come attività separata» tiene la porta aperta e
@@ -115,9 +116,9 @@ Chiudere bene un incarico conta più di quanto sembri quando lo stai chiudendo. 
 breve riassunto di cosa è stato consegnato, cosa resta aperto, e a chi passare le
 credenziali, mandato anche quando il rapporto è finito bene, è quello che fa dire al
 cliente «con questa persona rifarei un progetto» quando qualcuno gli chiede un
-riferimento. L'ho visto succedere al contrario: un progetto finito bene ma chiuso di
-fretta, senza un passaggio di consegne, diventato nella memoria del cliente «quello
-che è sparito».
+riferimento. Succede anche al contrario: un progetto finito bene ma chiuso di fretta,
+senza un passaggio di consegne, resta nella memoria del cliente come «quello che è
+sparito».
 
 ## Le richieste tipiche
 
@@ -200,12 +201,12 @@ davanti a cui pensare ad alta voce quando un progetto va storto, e la tentazione
 risolvere tutto in testa, da solo, anche quando la soluzione più veloce è chiedere a
 qualcuno che ha già visto lo stesso problema.
 
-Mi è capitato con un contratto che non capivo, una clausola di esclusiva scritta in
-un modo che sembrava vietarmi di lavorare per chiunque altro nello stesso settore per
-un anno intero. Da solo ci avrei messo un pomeriggio a decidere se firmarla o
-discuterla. Chiesto a chi ne aveva già vista una simile, la risposta è arrivata in
-dieci minuti: clausola normale in quel tipo di contratto, ma il periodo si negozia
-quasi sempre a tre mesi, e infatti a tre mesi è finita.
+Succede con un contratto che non si capisce fino in fondo: una clausola di esclusiva
+scritta in un modo che sembra vietare di lavorare per chiunque altro nello stesso
+settore per un anno intero. Da soli, decidere se firmarla o discuterla può costare un
+pomeriggio intero. Chiesto a chi ne ha già vista una simile, la risposta arriva in
+dieci minuti: è una clausola normale in quel tipo di contratto, ma il periodo si
+negozia quasi sempre a tre mesi, non ai dodici della prima bozza.
 
 Chiedere a chi c'è già passato non è ammettere di non farcela, è la scorciatoia che
 chi lavora in un'azienda ha gratis e tu no: un collega che ti dice in due minuti

--- a/projects/website/content/guida-primi-passi-freelance.md
+++ b/projects/website/content/guida-primi-passi-freelance.md
@@ -1,0 +1,232 @@
+# I primi passi da freelance: la parte che nessuno ti spiega prima della prima fattura
+
+Ho aperto la partita IVA anni fa, e nessuno mi ha insegnato a scrivere la prima fattura.
+Ho imparato quasi tutto da un errore mio o da uno di chi lavorava vicino a me. Questa
+guida è quello che avrei voluto leggere allora: non un manuale, non la teoria di chi
+vende corsi sul freelance, ma le cose che si ripetono davvero, scritte come le direi a
+un developer che sta per fare lo stesso salto.
+
+Non è un elenco di regole fisse. È quello che ho visto funzionare abbastanza spesso da
+scriverlo, e ogni volta che un numero compare in questa guida ti dico anche se è
+un'abitudine o una regola, perché non sono la stessa cosa e confonderle costa caro.
+
+Si legge in venti minuti, tutta insieme la prima volta. Poi torna a leggerne una
+sezione sola, quando ti serve proprio quella.
+
+## Vendersi
+
+Non hai bisogno di un portfolio con i loghi delle aziende per cui hai lavorato. Hai
+bisogno di una frase che dica cosa fai, a chi lo fai, e con che risultato, e la maggior
+parte dei portfolio non dice nessuna delle tre. «Sviluppo backend» non è una frase,
+è una categoria. «Costruisco e mantengo API per prodotti B2B, l'ultima gestiva
+pagamenti per un'azienda del settore assicurativo» è una frase, ed è quella che un
+CTO che ti legge su LinkedIn capisce in tre secondi senza doverti scrivere per
+chiedere di più.
+
+Una prima conversazione con un'azienda non ha bisogno di molto altro: cosa hanno già
+costruito, cosa vogliono che tu faccia esattamente, e per quanto tempo pensano di
+averti. Se una di queste tre cose manca dopo la prima chiamata, chiedila prima di
+mandare un preventivo. Un preventivo scritto su un progetto non chiaro è un numero
+inventato che poi devi difendere.
+
+Un esempio, senza nomi. Una startup del settore logistico mi ha scritto chiedendo «una
+mano col backend», niente altro. Ho fatto per telefono la domanda che di solito evito
+di fare per email: cosa esiste già, cosa manca davvero, e chi decide se il lavoro va
+bene. È venuto fuori che il problema non era il backend in generale ma
+un'integrazione con un corriere che in azienda non sapeva più leggere nessuno. Il
+preventivo che ho mandato parlava di quella integrazione, non di «una mano col
+backend», ed è stato accettato lo stesso giorno: non perché fossi più bravo di un
+altro, ma perché ero l'unico ad aver capito cosa stavo vendendo prima di scrivere il
+prezzo.
+
+La tariffa a giornata è una frase, non una scusa. «La mia giornata costa X» si dice
+con lo stesso tono con cui dici il tuo nome. Se la dici con un tono da scusa, chi ti
+ascolta se ne accorge prima di sentire il numero, e negozia sul tono, non sul numero.
+L'ho imparato dopo aver visto la differenza tra due mie stesse telefonate, stessa
+tariffa, tono diverso: una è finita con un sì immediato, l'altra con tre giorni di
+silenzio e una controproposta.
+
+## Farsi pagare il giusto
+
+Il numero non arriva da una tabella. Arriva da tre cose che sommi: quanto ti serve
+guadagnare in un anno lavorando un numero di giorni ragionevole (non 220, un
+freelance che lavora 220 giorni l'anno sta contando male le ferie e la malattia),
+quanto vale sul mercato quello che sai fare, e quanto è urgente o difficile il
+progetto specifico. La prima cifra è tua e la conosci solo tu. La seconda la trovi
+chiedendo in giro, a chi fa lavori simili al tuo, quanto si fa pagare: è la domanda
+più scomoda da fare e la più utile da avere risposta.
+
+Quando il numero viene rifiutato, la prima cosa da capire è se è stato rifiutato il
+prezzo o il progetto. Sono due conversazioni diverse. Se è il prezzo, la risposta
+onesta è una di due: o il cliente ha un budget reale più basso e allora si negozia lo
+scope, oppure sta solo provando ad abbassarti e allora tenere il numero è la risposta
+giusta più spesso di quanto sembri.
+
+Uno sconto e uno scope più corto non sono la stessa cosa, anche se dall'esterno
+sembrano finire nello stesso posto: meno soldi in fattura. Uno sconto dice che il tuo
+lavoro vale meno di quanto hai detto. Uno scope più corto dice che il cliente compra
+meno lavoro. La seconda frase protegge la tua tariffa per il prossimo cliente, la
+prima la abbassa per sempre, perché la voce corre. «Posso fare la prima metà per
+quella cifra, la seconda la vediamo dopo» costa allo stesso modo di uno sconto sul
+foglio, ma non lo è.
+
+Un'azienda del settore sanitario, una volta, ha accettato il mio primo numero senza
+controproposte. Ho capito dopo perché: aveva già chiesto due preventivi ad altri, ed
+ero l'unico ad aver chiesto quanto tempo avessero per decidere prima di scrivere la
+cifra. Il numero non era più basso degli altri due, era solo il primo scritto su un
+progetto che, a forza di domande, capivo meglio degli altri due preventivatori.
+
+Il preventivo più basso non è quello che vinci più facilmente. È quello che, tre
+settimane dentro il progetto, il cliente prova a rinegoziare al ribasso, perché ha
+già capito quanto vale il lavoro rispetto a quanto ti sta pagando e il conto non
+torna più a lui. Un prezzo giusto tenuto fin dall'inizio è quello che nessuno prova a
+riaprire.
+
+## Gestire il cliente
+
+Prima di iniziare, scrivi cosa consegni, entro quando, e cosa succede se una delle
+due parti cambia idea a metà. Non serve un contratto da avvocato: bastano tre righe
+in un'email che il cliente conferma con un «ok, confermo» o un preventivo firmato.
+Quella email è quello a cui torni tra due mesi quando qualcuno dice «ma io pensavo
+che...».
+
+L'ho visto non fatto, una volta, in un progetto del settore ecommerce dove lo scope
+era tutto in una chiamata mai ripresa per iscritto. A metà lavoro il cliente
+ricordava una versione diversa da quella che ricordavo io, in buona fede da
+entrambe le parti: nessuno mentiva, semplicemente nessuno aveva scritto niente. Da
+allora le tre righe le mando sempre, anche quando sembrano talmente ovvie che
+scriverle pare tempo perso.
+
+Dire no a qualcosa fuori scope non deve suonare come un rifiuto. «Questo non era nel
+preventivo, lo aggiungo volentieri come attività separata» tiene la porta aperta e
+protegge il tempo che hai già venduto. Il no che perde un cliente non è quello detto
+con chiarezza, è quello detto tardi, dopo che hai già fatto il lavoro gratis due
+volte e la terza ti stanca visibilmente.
+
+Quando una decisione non arriva, il progetto non si ferma da solo, si ferma perché
+tu smetti di lavorare o continui a lavorare senza sapere su cosa. Nessuna delle due è
+buona. La terza opzione è scrivere una data: «se non ho una risposta entro venerdì,
+vado avanti con l'opzione A», mandata prima che il ritardo diventi un problema, non
+dopo. Un cliente che non decide di solito non lo fa apposta: ha altre dieci cose
+aperte, e la tua email con una data dentro è quella che gli fa dare la priorità alla
+tua.
+
+Chiudere bene un incarico conta più di quanto sembri quando lo stai chiudendo. Un
+breve riassunto di cosa è stato consegnato, cosa resta aperto, e a chi passare le
+credenziali, mandato anche quando il rapporto è finito bene, è quello che fa dire al
+cliente «con questa persona rifarei un progetto» quando qualcuno gli chiede un
+riferimento. L'ho visto succedere al contrario: un progetto finito bene ma chiuso di
+fretta, senza un passaggio di consegne, diventato nella memoria del cliente «quello
+che è sparito».
+
+## Le richieste tipiche
+
+Ce ne sono quattro che senti quasi sempre, nello stesso ordine in cui le sentirai tu.
+Tienile da qualche parte a portata di mano, in un'app di note o in cima a un
+documento che riapri spesso: la prima volta che le usi costano fatica pensarci su, la
+seconda sono già un riflesso.
+
+**«Ci fai un preventivo indicativo?»** Un preventivo indicativo non esiste: o è un
+numero su cui ti impegni, o è una stima che il cliente userà come se fosse un
+impegno. «Ti do una forchetta con un margine del 30%, il numero preciso lo abbiamo
+dopo che vediamo insieme cosa serve davvero» dice la verità e non ti lega a un numero
+tirato a caso.
+
+**«Puoi partire e poi vediamo?»** Partire senza un accordo scritto è lavorare gratis
+finché qualcuno decide di formalizzare, e a volte quel qualcuno non decide mai.
+«Parto appena ci scambiamo due righe su cosa consegno ed entro quando, anche
+informali» sposta la richiesta da un favore a una formalità di cinque minuti, che
+quasi nessuno rifiuta se gliela chiedi così.
+
+**«Ti pagheremo a fine progetto.»** Su un progetto lungo questo significa fare da
+banca al cliente per mesi, con il rischio tutto tuo. «Fatturo per milestone, la
+prima a metà lavoro» è una frase che sposta il rischio dov'è giusto che stia, e che
+un cliente serio accetta senza discutere: chi discute su questo sta dicendo qualcosa
+sulla propria liquidità che vale la pena sentire prima di iniziare, non dopo.
+
+**«Ci sarebbe solo una piccola aggiunta.»** Le piccole aggiunte non sono il
+problema, è il numero di piccole aggiunte gratuite che alla fine pesa quanto una
+seconda consegna. «Questa la faccio io ora, gratis, la prossima la mettiamo in
+conto» è una frase che dici una volta sola, la prima volta che succede: dopo,
+diventa la regola implicita che nessuno deve più negoziare ogni volta, e le aggiunte
+successive finiscono nella stessa email dove tieni traccia dello scope.
+
+## Farsi pagare, e in tempo
+
+I termini di pagamento si scrivono nel preventivo, non si scoprono in fattura. Trenta
+giorni data fattura è un'abitudine diffusa, non una regola: puoi chiederne quindici,
+puoi accettarne sessanta se il cliente è un'azienda grande con un processo lento e il
+progetto ne vale la pena, ma è una scelta che fai prima, non un termine che ti arriva
+addosso dopo.
+
+Un acconto all'ordine, tra il 20 e il 30% del totale, è un'altra abitudine e non una
+legge: serve a dire che il cliente è impegnato quanto te prima che tu spenda il primo
+giorno di lavoro. Su un progetto breve puoi saltarlo, su uno lungo con un cliente
+nuovo io non lo salto quasi mai.
+
+Non serve un sistema complicato per tenere il conto di chi ti deve cosa: un foglio con
+quattro colonne, cliente, importo, scadenza, stato, aggiornato ogni settimana, basta.
+Il problema non è mai lo strumento, è l'abitudine di aprirlo anche quando non hai
+voglia, specialmente a fine mese quando le fatture da emettere si accumulano tutte
+insieme e la tentazione è rimandarle alla settimana dopo.
+
+La prima fattura in ritardo va gestita il giorno dopo la scadenza, non un mese dopo.
+Un promemoria breve, senza scuse per averlo mandato: «la fattura X risulta ancora
+aperta, mi confermi quando prevedete il pagamento?» è normale amministrazione, non
+un conflitto. Aspettare un mese prima di scriverlo trasforma un promemoria in una
+lite, perché a quel punto il cliente sente che hai aspettato apposta e tu sei
+arrabbiato per davvero.
+
+L'abitudine amministrativa noiosa, quella di tenere aggiornato lo stato di ogni
+fattura invece di ricordartelo a memoria, è quella che tiene l'anno calmo. Non
+perché eviti i clienti che pagano tardi, esistono comunque, ma perché te ne accorgi
+il giorno dopo la scadenza e non tre mesi dopo quando i conti dell'anno non tornano
+e non ricordi più chi ti deve cosa.
+
+## Essere autonomi
+
+La parte tecnica del lavoro è quella per cui sei stato assunto. La parte che nessuno
+ti prepara è decidere da solo la tua settimana: quando lavori, quando ti fermi,
+quanto tempo lasci vuoto per il cliente che arriva senza preavviso. Nessuno te lo
+chiede, e proprio per questo nessuno te lo impedisce se non decidi tu i confini.
+
+Un'abitudine che aiuta più di quanto sembri: bloccare in calendario le ore in cui non
+rispondi, non solo quelle in cui lavori. Un cliente che scrive alle nove di sera non
+aspetta una risposta alle nove di sera solo perché gliel'hai data una volta; se
+gliel'hai data una volta, la aspetterà ogni volta.
+
+La solitudine è reale, ed è più forte nei primi mesi che dopo. Non hai un collega
+davanti a cui pensare ad alta voce quando un progetto va storto, e la tentazione è
+risolvere tutto in testa, da solo, anche quando la soluzione più veloce è chiedere a
+qualcuno che ha già visto lo stesso problema.
+
+Mi è capitato con un contratto che non capivo, una clausola di esclusiva scritta in
+un modo che sembrava vietarmi di lavorare per chiunque altro nello stesso settore per
+un anno intero. Da solo ci avrei messo un pomeriggio a decidere se firmarla o
+discuterla. Chiesto a chi ne aveva già vista una simile, la risposta è arrivata in
+dieci minuti: clausola normale in quel tipo di contratto, ma il periodo si negozia
+quasi sempre a tre mesi, e infatti a tre mesi è finita.
+
+Chiedere a chi c'è già passato non è ammettere di non farcela, è la scorciatoia che
+chi lavora in un'azienda ha gratis e tu no: un collega che ti dice in due minuti
+«quella clausola l'ho firmata anche io e mi è costata cara» ti risparmia lo stesso
+errore. Vale per un contratto, vale per una tariffa, vale per un cliente che chiede
+troppo: qualcuno lo ha già vissuto prima di te.
+
+Ed è per questo che una comunità è uno strumento pratico, non un'idea carina da avere
+in più. Non serve solo per sentirsi meno soli, anche se aiuta anche quello: serve
+perché la domanda che ti costerebbe un errore, fatta alla persona giusta prima di
+agire invece che dopo, te lo fa evitare del tutto.
+
+## Cos'è Orbiters
+
+Orbiters è la community di chi fa software in proprio: developer, AI engineer, CTO e
+fractional CTO, costruita da chi fa lo stesso lavoro. Dentro trovi progetti portati
+da persone che conoscono l'azienda che li propone, non presi da una bacheca, persone
+che hanno già avuto la stessa telefonata difficile che stai per avere tu, e
+PigroCRM, lo strumento per fatturare e farti pagare, gratis per chi è dentro.
+
+Se stai per fare il salto o l'hai appena fatto, entri da qui:
+[orbiters.com/hub/freelance](/hub/freelance). Se hai un progetto e cerchi la persona
+giusta per farlo, si comincia da qui:
+[orbiters.com/hub/aziende](/hub/aziende).


### PR DESCRIPTION
## What this changes

The perks section had only PigroCRM. This adds the source text of the second
perk: a Markdown guide to the first steps as a freelancer, under
`projects/website/content/` (new directory). It is in Italian, since it is
product surface a reader downloads, not documentation about the repository.
It covers the six sections the issue names, in its order: vendersi, farsi
pagare il giusto, gestire il cliente, le richieste tipiche, farsi pagare in
tempo, essere autonomi, and closes by naming what Orbiters is and linking
`/hub/freelance` and `/hub/aziende`. A short `README.md` in the new
directory says what lives there and that ORB-70 does the typesetting.

**Update, second commit:** the first draft told six passages (the opening
plus five anecdotes) as Lorenzo's own first-person memories, and every one
of them was invented by me, not something he actually lived. A reader has
no way to tell an invented memory from a real one, on a page that will
carry his name, so that is not something to put in front of him as if it
were his own voice. The second commit rewrites the opening and all six
passages as general patterns in the second or impersonal person ("succede
che", "capita, in un'azienda del settore X", "ti scrive chiedendo"),
keeping every concrete detail, since the detail is what makes the advice
usable, while asserting nothing about anybody's specific past. Places where
a real anecdote of his would make the guide stronger than the pattern now
sitting there:

- The opening (was: "ho aperto la partita IVA anni fa..."), two or three
  sentences of how he actually started, if he wants one there at all.
- Vendersi: the logistics-startup story ("una mano col backend").
- Vendersi: the two-phone-calls contrast on tone and the day rate.
- Farsi pagare il giusto: the healthcare client who accepted the first
  number.
- Gestire il cliente: the ecommerce project with an unwritten scope, and
  the project that closed well but was handed off badly.
- Essere autonomi: the exclusivity clause negotiated down from a year to
  three months.

This is a draft for Lorenzo to approve on the issue before anything else
touches it. Nothing links to the file, nothing renders it, and it changes
no code.

## How I verified it

- `preflight --list` on this branch against `origin/main`: two changed
  paths, both under `projects/website/content/`. It selects the website
  project's checks (`website-lint`, `website-unit`, `website-build`,
  `website-types`, `website-e2e`, `website-image`) purely on the path
  filter, and `identity-names`. I ran the two checks this kind of change
  actually needs and that the issue calls out by name, and left the
  website's own build/lint/e2e/image checks alone since nothing in
  `projects/website/src` changed and those are the expensive tier this
  issue exists to keep separate from the words.
- `orbiters-identity-scan .`: `identity-scan: clean against 28 names, 3
  path(s) allowed`, on both commits.
- `uv run pytest -q projects/pigrocrm/packages/core/tests/test_no_real_identity_in_the_repository.py`:
  `3 passed`, on both commits.
- Word count moved from 2,434 to 2,453 words after the rewrite: the fix
  kept the concrete detail, so length barely changed.

## Anything a reviewer should look at twice

Whether the six rewritten passages still read naturally as "succede che"
patterns rather than sounding like a hedge. I kept the concrete sector and
outcome for each (logistics, healthcare, ecommerce, the exclusivity
clause) because that is what the brief asked for when a real anecdote was
not available to me; the six places listed above are exactly where a
sentence or two of Lorenzo's real experience would read stronger than the
generic pattern, and he can drop one in without touching the surrounding
paragraph. The remaining open questions (voice calibration against his
LinkedIn, whether the payment-term and deposit habits match his own
practice, the target length) are in the Linear comment on ORB-69.

## What did not change, on purpose

No layout, no PDF, no fonts, no cover, no link from any page to this file,
no test. The issue keeps those out on purpose so the text can be judged as
text; they are ORB-70.

## Screenshots

Nothing visible changed. This is a Markdown source with no page that
renders it yet.

Linear: ORB-69.
