### PR TITLE
fix(website): the header and footer links read as bordered controls

### DIFF
--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -50,7 +50,7 @@
             </p>
             <p class="actions">
               <a class="cta" href="/hub/freelance">Entra come talento</a>
-              <a class="cta secondary" href="/hub/aziende">Cerchi persone? Raccontaci il progetto</a>
+              <a class="cta secondary" href="/hub/aziende">Cerchi persone?</a>
             </p>
             <p class="fine">
               Due minuti, una domanda alla volta. Ti chiediamo il CV e quanto costa una tua

--- a/projects/website/src/landing-style.test.ts
+++ b/projects/website/src/landing-style.test.ts
@@ -190,9 +190,16 @@ describe('the landing shares the product system', () => {
     expect(hover).toMatch(/background-color:\s*var\(--landing-ink\)/)
     expect(hover).toMatch(/color:\s*var\(--landing-cta-ink\)/)
 
+    // The brand doesn't invert on hover the way the two links do: half its glyph
+    // is drawn in the same colour as the ink ground, so it gets an offset shadow
+    // instead, still without a blur.
+    expect(rule('.brand:hover')).toMatch(/box-shadow:\s*4px 4px 0 var\(--landing-ink\)/)
+
     // The same class doubles as an inline citation in privacy.html and
     // termini.html's running text, which must stay underlined prose rather
-    // than turn into a button mid-sentence.
+    // than turn into a button mid-sentence: a later edit that moves the box
+    // properties onto the generic rule would be the regression to catch.
     expect(rule('.quiet-link')).toMatch(/text-decoration:\s*underline/)
+    expect(rule('.quiet-link')).not.toMatch(/border-width|min-height|display:/)
   })
 })

--- a/projects/website/src/landing-style.test.ts
+++ b/projects/website/src/landing-style.test.ts
@@ -165,4 +165,34 @@ describe('the landing shares the product system', () => {
     expect(rule('.cta')).not.toMatch(/border-radius/)
     expect(rule('.cta:hover')).toMatch(/background-color:\s*var\(--landing-ink\)/)
   })
+
+  it('draws the header and footer links as bordered controls, not a borderless patch (ORB-64)', () => {
+    // The brand, "Accedi" and the footer links used to be `.top a, footer
+    // .quiet-link` with a background colour and nothing else: no border, no
+    // hover surface, and the brand caught the same treatment though it isn't a
+    // control. This is the shell all three share now.
+    const shell = css.match(
+      /\.brand,\s*\.top \.quiet-link,\s*footer \.quiet-link\s*\{([^}]*)\}/,
+    )?.[1]
+    expect(shell, 'the header/footer control shell rule was not found').toBeTruthy()
+    expect(shell).toMatch(/background-color:\s*var\(--landing-surface\)/)
+    expect(shell).toMatch(/border-width:\s*2px/)
+    // 44px, the touch-target floor: at the footer's smaller type the padding
+    // alone falls short, so the floor is explicit rather than incidental.
+    expect(shell).toMatch(/min-height:\s*2\.75rem/)
+    // No shadow at this tier: that is `.box`/`.card`'s signal, not a link's.
+    expect(shell).not.toMatch(/box-shadow/)
+
+    const hover = css.match(
+      /\.top \.quiet-link:hover,\s*footer \.quiet-link:hover\s*\{([^}]*)\}/,
+    )?.[1]
+    expect(hover, 'the header/footer hover rule was not found').toBeTruthy()
+    expect(hover).toMatch(/background-color:\s*var\(--landing-ink\)/)
+    expect(hover).toMatch(/color:\s*var\(--landing-cta-ink\)/)
+
+    // The same class doubles as an inline citation in privacy.html and
+    // termini.html's running text, which must stay underlined prose rather
+    // than turn into a button mid-sentence.
+    expect(rule('.quiet-link')).toMatch(/text-decoration:\s*underline/)
+  })
 })

--- a/projects/website/src/landing.css
+++ b/projects/website/src/landing.css
@@ -126,16 +126,25 @@ footer .quiet-link {
   text-decoration: none;
 }
 
+/* An offset shadow, not the ink-invert the two links get below: the glyph draws two
+   of its four tiles in `--color-prussian-blue`, the same colour as `--landing-ink`,
+   so inverting the ground would erase half the mark. */
+.brand:hover {
+  box-shadow: 4px 4px 0 var(--landing-ink);
+}
+
 .top .quiet-link,
 footer .quiet-link {
   text-decoration: none;
 }
 
 /* Plain inline flow otherwise (privacy.html and termini.html's two-link footers
-   carry no gap of their own), so the boxes need their own breathing room; on
-   index.html's four-link footer this only adds to the flex `gap` already there. */
-footer .quiet-link {
-  margin-inline: 0.2rem;
+   carry no gap of their own), so consecutive links need their own breathing room;
+   the first stays flush with the content edge. On index.html's four-link footer,
+   which already carries a flex `gap`, the DOM adjacency still matches and this
+   only adds a negligible amount on top. */
+footer .quiet-link + .quiet-link {
+  margin-inline-start: 0.4rem;
 }
 
 .top .quiet-link:hover,

--- a/projects/website/src/landing.css
+++ b/projects/website/src/landing.css
@@ -90,7 +90,7 @@ code {
   overflow-wrap: anywhere;
 }
 
-/* --- Header: the brand and one link. */
+/* --- Header: the brand and one link, both real controls on the field. */
 .top {
   display: flex;
   align-items: center;
@@ -98,23 +98,50 @@ code {
   padding-block: 1.25rem;
 }
 
-/* The header and the footer sit on the field, so each link carries a sliver of the
-   page's own ground behind it and stays readable over a dark tile: the same move
-   orbiters.css makes for its footer. */
-.top a,
+/* The header and the footer sit on the field, so each control carries a sliver of
+   the page's own ground behind it and stays readable over a dark tile: the same
+   move orbiters.css makes for its footer. A border is what turns that sliver into
+   a control instead of a hole punched through the tiles, and this tier carries no
+   shadow, the same as the two hero doors below: a shadow reads as `.box`/`.card`,
+   not as a link. `min-height` clears the 44px touch-target floor even at the
+   footer's smaller type, where the padding alone would not. Scoped to `.quiet-link`
+   rather than to every `a` in `.top`, so the brand gets its own rule instead of
+   inheriting a patch meant for a control it isn't. */
+.brand,
+.top .quiet-link,
 footer .quiet-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
   background-color: var(--landing-surface);
-  padding: 0.2rem 0.45rem;
+  border-width: 2px;
+  padding-inline: 0.75rem;
 }
 
 .brand {
-  display: inline-flex;
-  align-items: center;
   gap: 0.6rem;
   font-size: 1.125rem;
   font-weight: 500;
   color: var(--landing-ink);
   text-decoration: none;
+}
+
+.top .quiet-link,
+footer .quiet-link {
+  text-decoration: none;
+}
+
+/* Plain inline flow otherwise (privacy.html and termini.html's two-link footers
+   carry no gap of their own), so the boxes need their own breathing room; on
+   index.html's four-link footer this only adds to the flex `gap` already there. */
+footer .quiet-link {
+  margin-inline: 0.2rem;
+}
+
+.top .quiet-link:hover,
+footer .quiet-link:hover {
+  background-color: var(--landing-ink);
+  color: var(--landing-cta-ink);
 }
 
 /* --- Hero: the field behind, one box in front. */
@@ -270,6 +297,9 @@ li {
   border-color: var(--landing-ink);
 }
 
+/* The generic form: an underlined citation inline in running text, on privacy.html
+   and termini.html. The header link and the footer's carry the bordered control
+   above instead, which wins on specificity without needing `!important`. */
 .quiet-link {
   color: var(--landing-ink-quiet);
   text-decoration: underline;


### PR DESCRIPTION
## What this changes

The header's "Accedi" and the footer's links painted a bare `--landing-surface`
rectangle with no border, no hover surface and no floor on touch-target size, so they
read as neither link nor button; the brand caught the same borderless patch even
though it isn't a control at all. This changes what `.top .quiet-link`, `footer
.quiet-link` and `.brand` all now share: a 2px ink border on the page's own ground (no
shadow, since that tier is `.box`/`.card`'s signal, not a link's), a `min-height` of
44px so the footer's smaller type still clears the touch-target floor, and a hover
state that inverts to the ink surface. The scope moved from `.top a` to `.top
.quiet-link` so the brand gets its own rule instead of a patch meant for something it
isn't, and stayed on `footer .quiet-link`, which also carries privacy.html and
termini.html's own two-link footers since all three pages share this stylesheet. The
generic `.quiet-link` rule is untouched and keeps its underline, since the same class
doubles as an inline citation in privacy.html and termini.html's running text.

The secondary hero CTA, "Cerchi persone? Raccontaci il progetto", wrapped to two or
three lines at 390px while the primary door stayed on one, so the two CTAs had
different heights. Shortened it to "Cerchi persone?", which fits one line at both
viewports and matches the primary CTA's height without a height rule fighting real
content.

## How I verified it

- `pnpm --filter website test`: 189 passed (188 before, plus one new regression test
  pinning the border, `min-height`, hover surface and no-shadow rule on the new
  header/footer control shell).
- `pnpm --filter website lint`: clean.
- `preflight` (the 7 checks it selected for this diff): `website-lint`,
  `website-types`, `website-unit`, `identity-names`, `website-build`, `website-e2e`,
  `website-image`, all passed in 40.2s.
- `uishot http://localhost:4173/pigrocrm --viewports mobile:390x844 --axe --fail-on
  serious` and the same at `desktop:1440x900`: zero violations at both viewports.
- Drove a real keyboard `Tab` to "Accedi" and hovered the footer's "Privacy" link with
  Puppeteer: the focus ring (`--landing-focus`, offset 3px) is visible on the bordered
  box, and hover inverts the surface to ink with `--landing-cta-ink` text.
- Rendered `/privacy` and `/termini` (they share `landing.css`) and confirmed their
  own two-link footers picked up the same treatment, and that `.quiet-link` used
  inline in their running text (`humancraft.tech`, `joinorbiters.com`) stayed
  underlined prose rather than turning into a boxed control mid-sentence.

## What did not change, on purpose

I did not touch the cookie notice's "Dettagli" link or its "No"/"Va bene" buttons
(`system.css`, `.consent`), even though the issue also measures those under the 44px
floor. That component is deliberately a different, quieter visual tier by its own
comment ("a coloured call to action for a cookie notice would shout louder than the
page it sits on"), growing its touch targets is a design decision of its own, and it
is shared with orbiters.html, which is outside this issue's page. Filed as ORB-87.

`orbiters.css` makes the same borderless-patch move for its own footer (the comment at
`landing.css:101` says so), and this PR does not touch it: `orbiters.html` is a
separate page with its own stylesheet, ORB-64 is scoped to `/pigrocrm`, and nobody
else in this wave owns that file either. Filed as ORB-88 so the same fix lands there
deliberately rather than by accident.

## Anything a reviewer should look at twice

I gave the brand ("Orbiters" / "PigroCRM") the same bordered-box treatment as the
links rather than removing its background patch, since the issue names the brand's
patch as the same defect (a bare rectangle, not that it needs no ground at all): the
header sits on the decorative field and the wordmark needs a sliver of the page's own
ground to stay legible over a dark tile the same as before.

## Screenshots

**1. Header, 1440px**
![Header at 1440, before and after](https://github.com/user-attachments/assets/0f26486d-1a76-4e4d-baf0-b476b0ce8fb4)

**2. Header, 390px**
![Header at 390, before and after](https://github.com/user-attachments/assets/da803974-b04d-4e2d-9a38-e68fceb76940)

**3. Footer, 1440px**
![Footer at 1440, before and after](https://github.com/user-attachments/assets/1923566b-2016-4c8e-a21d-b046de42cb2f)

**4. Footer, 390px**
![Footer at 390, before and after](https://github.com/user-attachments/assets/9bc28eec-2303-4261-86dd-86fefffbfada)

**5. Hero CTAs, 390px: the secondary door no longer wraps to three lines**
![Hero CTAs at 390, before and after](https://github.com/user-attachments/assets/1295dff7-409e-4f95-bf35-4acbb4dbd519)

Linear: ORB-64.
