### PR TITLE
fix(website): the privacy and terms pages sign themselves as Orbiters

### DIFF
--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -20,7 +20,14 @@ describe.each(PAGES)('%s', (name) => {
 
   it('carries its own title, description and Open Graph', () => {
     const title = page.match(/<title>([^<]+)<\/title>/)?.[1] ?? ''
-    expect(title).toContain('PigroCRM')
+    // Until 2026-09-10 every page here titled itself PigroCRM, including the two
+    // legal pages. ORB-36: privacy.html and termini.html are served on
+    // joinorbiters.com, not on pigro.joinorbiters.com, and it is the Orbiters signup
+    // form that links to them, so they title themselves after the site they are on
+    // rather than after the CRM. index.html keeps PigroCRM in its title under
+    // Ivan's 2026-09-09 exception (ORB-24) for search continuity; see the
+    // brand-link assertion below for the same split.
+    expect(title).toContain(name === 'index.html' ? 'PigroCRM' : 'Orbiters')
     const description = meta(page, 'description') ?? ''
     expect(description.length).toBeGreaterThan(40)
     // The trap named in spec 9.2: the previous system's index.html still carries "Studio Rossi is
@@ -68,11 +75,17 @@ describe.each(PAGES)('%s', (name) => {
   })
 
   it('signs itself with the four-tile glyph before the name', () => {
-    // The landing is Orbiters' since 2026-09-09 and signs as Orbiters; the two policy
-    // pages are the product's and keep its name.
-    const brand = name === 'index.html' ? 'Orbiters' : 'PigroCRM'
+    // Until 2026-09-10 the landing signed as Orbiters and the two legal pages kept
+    // PigroCRM, on the reasoning that a legal page belongs to the product it
+    // covers. ORB-36 reopened that: privacy.html and termini.html are served on
+    // joinorbiters.com, not on pigro.joinorbiters.com, the Orbiters signup form is
+    // what links to them, and their own text already covers Orbiters' data (the
+    // signup) alongside PigroCRM's (orbiters.test.ts separately asserts
+    // privacy.html names Orbiters and links /orbiters). All three pages here sign
+    // as Orbiters now; the titolare del trattamento the two legal pages name, and
+    // the substance of what each policy says, did not move with the brand.
     expect(page).toMatch(
-      new RegExp(`<a class="brand" href="/"><span class="glyph" aria-hidden="true"></span>${brand}</a>`),
+      /<a class="brand" href="\/"><span class="glyph" aria-hidden="true"><\/span>Orbiters<\/a>/,
     )
   })
 

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -24,9 +24,11 @@ describe.each(PAGES)('%s', (name) => {
     // legal pages. ORB-36: privacy.html and termini.html are served on
     // joinorbiters.com, not on pigro.joinorbiters.com, and it is the Orbiters signup
     // form that links to them, so they title themselves after the site they are on
-    // rather than after the CRM. index.html keeps PigroCRM in its title under
-    // Ivan's 2026-09-09 exception (ORB-24) for search continuity; see the
-    // brand-link assertion below for the same split.
+    // rather than after the CRM. index.html is PigroCRM's own landing page (served
+    // at /pigrocrm; orbiters.html is the community page at /), so it keeps naming
+    // the CRM in its title regardless of Ivan's separate «freelance» exception
+    // (ORB-24, positioning.md line 85); see the brand-link assertion below for the
+    // same title/brand split.
     expect(title).toContain(name === 'index.html' ? 'PigroCRM' : 'Orbiters')
     const description = meta(page, 'description') ?? ''
     expect(description.length).toBeGreaterThan(40)
@@ -36,7 +38,10 @@ describe.each(PAGES)('%s', (name) => {
     // a product that exists nowhere in that codebase. It is the easiest mistake
     // to repeat, and it is text Google reads during verification.
     expect(description).not.toMatch(/AI optimization platform/i)
-    expect(meta(page, 'og:title')).toBeTruthy()
+    // All three pages' og:title already begins "Orbiters" (index.html's own title
+    // keeps the "Con PigroCRM gratis" suffix, but its og:title does not repeat it),
+    // so this one assertion covers every page in PAGES with no ternary.
+    expect(meta(page, 'og:title')).toContain('Orbiters')
     expect(meta(page, 'og:description')).toBeTruthy()
     expect(meta(page, 'og:type')).toBe('website')
   })

--- a/projects/website/src/privacy.html
+++ b/projects/website/src/privacy.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PigroCRM — Informativa sulla privacy</title>
+    <title>Orbiters — Informativa sulla privacy</title>
     <meta
       name="description"
       content="Chi tratta i tuoi dati su joinorbiters.com e pigro.joinorbiters.com, dove stanno, per quanto, e cosa fa PigroCRM con Gmail e Google Drive se li colleghi."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="PigroCRM — Informativa sulla privacy" />
+    <meta property="og:title" content="Orbiters — Informativa sulla privacy" />
     <meta
       property="og:description"
       content="Titolare Humancraft di Ivan Sala. Server in Unione Europea, un database per spazio, nessun tracciamento. Cosa chiediamo a Google, e cosa no."
@@ -20,7 +20,7 @@
   </head>
   <body>
     <header class="wrap top">
-      <a class="brand" href="/"><span class="glyph" aria-hidden="true"></span>PigroCRM</a>
+      <a class="brand" href="/"><span class="glyph" aria-hidden="true"></span>Orbiters</a>
       <a class="quiet-link" href="/app/">Accedi</a>
     </header>
 

--- a/projects/website/src/termini.html
+++ b/projects/website/src/termini.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PigroCRM — Termini di utilizzo</title>
+    <title>Orbiters — Termini di utilizzo</title>
     <meta
       name="description"
       content="A quali condizioni Humancraft di Ivan Sala offre Orbiters e lo spazio PigroCRM gratuito a chi è in community, e cosa vale per chi installa il software da sé."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="PigroCRM — Termini di utilizzo" />
+    <meta property="og:title" content="Orbiters — Termini di utilizzo" />
     <meta
       property="og:description"
       content="Uno spazio gratuito per chi è in Orbiters, senza garanzie e senza abbonamenti; software open source per chi lo installa sul proprio server."
@@ -20,7 +20,7 @@
   </head>
   <body>
     <header class="wrap top">
-      <a class="brand" href="/"><span class="glyph" aria-hidden="true"></span>PigroCRM</a>
+      <a class="brand" href="/"><span class="glyph" aria-hidden="true"></span>Orbiters</a>
       <a class="quiet-link" href="/app/">Accedi</a>
     </header>
 


### PR DESCRIPTION
## What this changes

`privacy.html` and `termini.html` titled and signed themselves as PigroCRM, but they
are served on joinorbiters.com (not pigro.joinorbiters.com), and it is the Orbiters
signup form under the community page that links to `/privacy`, so a visitor who clicks
Privacy there landed on a tab naming a different product. Their own text already covers
Orbiters' data (the signup section) alongside PigroCRM's hosted spaces, and
`orbiters.test.ts:109` already asserted `privacy.html` names Orbiters and links
`/orbiters`; the title and the brand link were the two spots that had not followed.

Now both pages' `<title>`, `og:title` and header brand link (the four-tile glyph plus
the name) read Orbiters, matching the site they are on and `index.html`'s and
`orbiters.html`'s own signature. Nothing else moved: the titolare del trattamento
(Humancraft di Ivan Sala), the data controller and processor language, the Gmail and
Drive scope text, the cookie and consent paragraphs, the licence and warranty
sections, every body paragraph that legitimately still names PigroCRM as the product
being described, and every link target (owned by ORB-66, running alongside this) are
untouched.

`landing-pages.test.ts`'s title and brand-link assertions are rewritten with a dated
comment, not deleted: `index.html` keeps `PigroCRM` in its title because it is
PigroCRM's own landing page, served at `/pigrocrm`, unrelated to Ivan's separate
2026-09-09 «freelance» exception (ORB-24, `docs/design/positioning.md` line 85); the
two legal pages carried no such exception, so they now assert `Orbiters` instead. The
`og:title` assertion, previously only checked for being non-empty, now pins the same
brand, since a share card is exactly where the old defect would have kept drifting
back unnoticed.

## How I verified it

- `pnpm --filter website lint`: clean.
- `pnpm --filter website test`: 189 tests pass, including the two rewritten
  assertions in `landing-pages.test.ts` and the untouched `orbiters.test.ts:107-112`
  cross-check against `privacy.html`.
- `pnpm --filter website build` and `pnpm --filter website exec tsc --noEmit`: clean.
- `pnpm --filter website test:e2e`: 49 tests pass (run against a temporary local
  port override of `vite.config.ts`/`playwright.config.ts` only, immediately reverted
  before committing, since port 4173 was held by a sibling agent's own e2e run on this
  shared devbox at the time).
- `WEBSITE_WEB_PORT=127.0.0.1:8099 docker compose build` (`projects/website`): image
  builds clean, nginx config unchanged.
- `orbiters-identity-scan .`: clean against 28 names, 3 paths allowed (unchanged).
- `uishot --axe --fail-on serious` against the built pages, before and after, at
  1440x900 and 390x844: zero serious/critical violations in every run.

## Anything a reviewer should look at twice

The naming call itself: I moved the two legal pages to sign as Orbiters rather than
PigroCRM, reasoned from where they are served, who links to them, and what their own
text already covers, per ORB-36. This does not touch the titolare del trattamento or
any substantive claim in either policy; if the naming call should have gone the other
way, that is a brand decision for Lorenzo/Ivan, not something either page's legal
content depends on.

An independent reviewer on this PR flagged the same title-exception comment I had
misattributed and the unpinned `og:title` assertion above; both are fixed in the
second commit.

## Screenshots

Before and after, 1440px and 390px, with an orange box around the changed header
brand link (the browser tab title changed too, not capturable in a page screenshot).

**1. privacy.html, 1440px**
![privacy.html before and after, 1440px](https://github.com/user-attachments/assets/a35b3a66-4fa6-45ca-8b9f-6676dd0611d1)

**2. privacy.html, 390px**
![privacy.html before and after, 390px](https://github.com/user-attachments/assets/f9c4358f-99ed-4301-937e-5f7d1857aa74)

**3. termini.html, 1440px**
![termini.html before and after, 1440px](https://github.com/user-attachments/assets/518fde1d-0ee0-4a16-b724-2aa2b0c570b4)

**4. termini.html, 390px**
![termini.html before and after, 390px](https://github.com/user-attachments/assets/3c67243e-03ad-4591-badc-49d9c0751ebb)

Linear: ORB-36.
