### PR TITLE
feat(hub): the wizard pages sit in the site's own visual system

### DIFF
--- a/projects/hub/apps/web/src/components/Shell.tsx
+++ b/projects/hub/apps/web/src/components/Shell.tsx
@@ -2,34 +2,58 @@ import { Link } from '@tanstack/react-router'
 import type { ReactNode } from 'react'
 import { BrandMark } from '@/components/BrandMark'
 
-/** The public frame: the mark and the name up top, the two legal links at the foot, and
- *  one white panel in between -- the CRM's panel, without its sidebar. */
+/** The public frame: the mark and the name up top, the two legal links and the
+ *  attribution at the foot, one boxed panel in between -- the site's own visual
+ *  system (ORB-73's `.site` scope) rather than the application's, so a visitor who
+ *  clicked a CTA on joinorbiters.com does not land on a different product. `site`
+ *  also carries the page's ground (the same faint grid the landing sits on), and the
+ *  panel is centred in the space between header and footer instead of sitting at the
+ *  top of an empty page: `justify-center` on `main` only has room to act when the
+ *  step is shorter than the viewport, which is the common case here. Each link over
+ *  the grid keeps a sliver of the page's own surface behind it, the same treatment
+ *  `landing.css`'s `.top a` and `footer .quiet-link` give theirs. */
 export function Shell({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-full flex-col">
+    <div className="site flex min-h-full flex-col">
       <header className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-5">
-        <Link to="/" className="inline-flex items-center gap-2.5 text-lg font-semibold tracking-tight">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2.5 bg-[var(--landing-surface)] px-[0.45rem] py-[0.2rem] text-lg font-medium tracking-tight"
+        >
           <BrandMark className="size-3.5" />
           Orbiters
         </Link>
         <a
-          className="text-sm text-muted-foreground underline-offset-2 hover:underline"
+          className="bg-[var(--landing-surface)] px-[0.45rem] py-[0.2rem] text-sm underline-offset-2 hover:underline"
           href="https://joinorbiters.com/"
         >
           joinorbiters.com
         </a>
       </header>
-      <main className="mx-auto w-full max-w-5xl flex-1 px-6 pb-12">
-        <div className="rounded-2xl border bg-card px-6 py-10 shadow-xs sm:px-10">{children}</div>
+      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center px-6 py-12">
+        <div className="w-full border-[length:var(--landing-border-width)] bg-card px-6 py-10 shadow-xs sm:px-10">
+          {children}
+        </div>
       </main>
-      <footer className="mx-auto flex w-full max-w-5xl flex-wrap gap-4 px-6 pb-8 text-xs text-muted-foreground">
-        <a href="https://joinorbiters.com/privacy" className="underline-offset-2 hover:underline">
+      <footer className="mx-auto flex w-full max-w-5xl flex-wrap items-center gap-6 border-t-[length:var(--landing-border-width)] px-6 py-8 text-xs text-muted-foreground">
+        <a
+          href="https://joinorbiters.com/privacy"
+          className="bg-[var(--landing-surface)] px-[0.3rem] py-[0.15rem] underline-offset-2 hover:underline"
+        >
           Privacy
         </a>
-        <a href="https://joinorbiters.com/termini" className="underline-offset-2 hover:underline">
+        <a
+          href="https://joinorbiters.com/termini"
+          className="bg-[var(--landing-surface)] px-[0.3rem] py-[0.15rem] underline-offset-2 hover:underline"
+        >
           Termini
         </a>
-        <span>Orbiters è un progetto di Studio Rossi</span>
+        <span className="bg-[var(--landing-surface)] px-[0.3rem] py-[0.15rem]">
+          Orbiters è un progetto di{' '}
+          <a href="https://example.com/" className="underline-offset-2 hover:underline">
+            Studio Rossi
+          </a>
+        </span>
       </footer>
     </div>
   )

--- a/projects/hub/apps/web/src/components/Shell.tsx
+++ b/projects/hub/apps/web/src/components/Shell.tsx
@@ -18,13 +18,13 @@ export function Shell({ children }: { children: ReactNode }) {
       <header className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-5">
         <Link
           to="/"
-          className="inline-flex items-center gap-2.5 bg-[var(--landing-surface)] px-[0.45rem] py-[0.2rem] text-lg font-medium tracking-tight"
+          className="inline-flex items-center gap-2.5 bg-[var(--landing-surface)] p-[var(--landing-link-pad)] text-lg font-medium tracking-tight"
         >
           <BrandMark className="size-3.5" />
           Orbiters
         </Link>
         <a
-          className="bg-[var(--landing-surface)] px-[0.45rem] py-[0.2rem] text-sm underline-offset-2 hover:underline"
+          className="bg-[var(--landing-surface)] p-[var(--landing-link-pad)] text-sm text-muted-foreground underline-offset-2 hover:underline"
           href="https://joinorbiters.com/"
         >
           joinorbiters.com
@@ -38,21 +38,18 @@ export function Shell({ children }: { children: ReactNode }) {
       <footer className="mx-auto flex w-full max-w-5xl flex-wrap items-center gap-6 border-t-[length:var(--landing-border-width)] px-6 py-8 text-xs text-muted-foreground">
         <a
           href="https://joinorbiters.com/privacy"
-          className="bg-[var(--landing-surface)] px-[0.3rem] py-[0.15rem] underline-offset-2 hover:underline"
+          className="bg-[var(--landing-surface)] p-[var(--landing-link-pad)] underline-offset-2 hover:underline"
         >
           Privacy
         </a>
         <a
           href="https://joinorbiters.com/termini"
-          className="bg-[var(--landing-surface)] px-[0.3rem] py-[0.15rem] underline-offset-2 hover:underline"
+          className="bg-[var(--landing-surface)] p-[var(--landing-link-pad)] underline-offset-2 hover:underline"
         >
           Termini
         </a>
-        <span className="bg-[var(--landing-surface)] px-[0.3rem] py-[0.15rem]">
-          Orbiters è un progetto di{' '}
-          <a href="https://example.com/" className="underline-offset-2 hover:underline">
-            Studio Rossi
-          </a>
+        <span className="bg-[var(--landing-surface)] p-[var(--landing-link-pad)]">
+          Orbiters è un progetto di Studio Rossi
         </span>
       </footer>
     </div>

--- a/projects/hub/apps/web/src/pages/Chooser.tsx
+++ b/projects/hub/apps/web/src/pages/Chooser.tsx
@@ -15,7 +15,7 @@ export function Chooser() {
       <div className="grid gap-4 sm:grid-cols-2">
         <Link
           to="/freelance"
-          className="group flex flex-col gap-3 border-[length:var(--landing-border-width)] bg-card p-6 shadow-sm transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+          className="group flex flex-col gap-3 border-[length:var(--landing-border-width)] bg-card p-6 shadow-sm transition-colors hover:bg-muted focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-(color:--landing-focus)"
         >
           <UserRound className="size-6" aria-hidden="true" />
           <span className="text-lg font-semibold">Sono un developer o un CTO</span>
@@ -28,7 +28,7 @@ export function Chooser() {
         </Link>
         <Link
           to="/aziende"
-          className="group flex flex-col gap-3 border-[length:var(--landing-border-width)] bg-card p-6 shadow-sm transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+          className="group flex flex-col gap-3 border-[length:var(--landing-border-width)] bg-card p-6 shadow-sm transition-colors hover:bg-muted focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-(color:--landing-focus)"
         >
           <Briefcase className="size-6" aria-hidden="true" />
           <span className="text-lg font-semibold">Cerco persone per un progetto</span>

--- a/projects/hub/apps/web/src/pages/Chooser.tsx
+++ b/projects/hub/apps/web/src/pages/Chooser.tsx
@@ -15,7 +15,7 @@ export function Chooser() {
       <div className="grid gap-4 sm:grid-cols-2">
         <Link
           to="/freelance"
-          className="group flex flex-col gap-3 rounded-2xl border bg-card p-6 transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+          className="group flex flex-col gap-3 border-[length:var(--landing-border-width)] bg-card p-6 shadow-sm transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
         >
           <UserRound className="size-6" aria-hidden="true" />
           <span className="text-lg font-semibold">Sono un developer o un CTO</span>
@@ -28,7 +28,7 @@ export function Chooser() {
         </Link>
         <Link
           to="/aziende"
-          className="group flex flex-col gap-3 rounded-2xl border bg-card p-6 transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+          className="group flex flex-col gap-3 border-[length:var(--landing-border-width)] bg-card p-6 shadow-sm transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
         >
           <Briefcase className="size-6" aria-hidden="true" />
           <span className="text-lg font-semibold">Cerco persone per un progetto</span>

--- a/projects/hub/apps/web/src/styles/tokens.css
+++ b/projects/hub/apps/web/src/styles/tokens.css
@@ -11,9 +11,8 @@
    those four follow the site's own visual system instead -- no radius, a solid ink
    line, a stepped offset shadow, never a blur -- and the `.site` scope below is that
    system, restated here because `projects/website` builds separately and imports
-   nothing from this project. It changes no rendering by itself: nothing carries the
-   `site` class yet, since that is the page chrome ORB-74 adds to `Shell`, and the two
-   wizards' own fields and buttons are ORB-75. */
+   nothing from this project. `Shell` carries the `site` class on all four public
+   pages (ORB-74); the two wizards' own fields and buttons are still ORB-75. */
 @import 'tailwindcss';
 @import '@orbiters/brand/font.css';
 @import '@orbiters/brand/palette.css';
@@ -158,13 +157,22 @@
    ORB-74 adds on top of them, so an edit to one never has to scroll past the other's
    comment to find its own declarations. `--landing-ink` is already this scope's
    colour, so the tile is drawn from a token this file declares elsewhere, never a
-   fresh mix. */
-.site {
-  --landing-grid: color-mix(in oklab, var(--landing-ink) 7%, transparent);
-  --landing-cell: 16px;
-  background-color: var(--landing-surface);
-  background-image:
-    linear-gradient(to right, var(--landing-grid) 1px, transparent 1px),
-    linear-gradient(to bottom, var(--landing-grid) 1px, transparent 1px);
-  background-size: var(--landing-cell) var(--landing-cell);
+   fresh mix. `--landing-link-pad` is the one pad `landing.css`'s `.top a` and
+   `footer .quiet-link` both use (landing.css:104-108) to keep a link legible over a
+   tile it sits on; named here so `Shell` reaches for it once instead of typing
+   `0.2rem 0.45rem` on every link that needs it. Wrapped in `@layer base` so a
+   `bg-*` utility on the same element still wins over the ground: Tailwind emits
+   its own utilities into `@layer utilities`, and an unlayered rule beats a layered
+   one regardless of specificity. */
+@layer base {
+  .site {
+    --landing-grid: color-mix(in oklab, var(--landing-ink) 7%, transparent);
+    --landing-cell: 16px;
+    --landing-link-pad: 0.2rem 0.45rem;
+    background-color: var(--landing-surface);
+    background-image:
+      linear-gradient(to right, var(--landing-grid) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--landing-grid) 1px, transparent 1px);
+    background-size: var(--landing-cell) var(--landing-cell);
+  }
 }

--- a/projects/hub/apps/web/src/styles/tokens.css
+++ b/projects/hub/apps/web/src/styles/tokens.css
@@ -149,3 +149,22 @@
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
 }
+
+/* --- The page ground for the .site scope (ORB-74): the same faint grid the landing
+   sits on, `projects/website/src/system.css`'s `--system-grid`/`--system-cell`
+   restated here for the reason the block above restates its colours -- the two
+   projects build separately and share no CSS. A second `.site` rule rather than a
+   line inside the first: the shape tokens above are ORB-73's and this is the ground
+   ORB-74 adds on top of them, so an edit to one never has to scroll past the other's
+   comment to find its own declarations. `--landing-ink` is already this scope's
+   colour, so the tile is drawn from a token this file declares elsewhere, never a
+   fresh mix. */
+.site {
+  --landing-grid: color-mix(in oklab, var(--landing-ink) 7%, transparent);
+  --landing-cell: 16px;
+  background-color: var(--landing-surface);
+  background-image:
+    linear-gradient(to right, var(--landing-grid) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--landing-grid) 1px, transparent 1px);
+  background-size: var(--landing-cell) var(--landing-cell);
+}

--- a/projects/hub/apps/web/src/styles/tokens.test.ts
+++ b/projects/hub/apps/web/src/styles/tokens.test.ts
@@ -18,12 +18,18 @@ const brandCss = readFileSync(
 )
 const css = `${brandCss}\n${tokensCss}`
 
-/** The declarations of one rule of tokens.css, by exact selector. */
+/** Every declaration of a selector in tokens.css, concatenated in file order. A
+ *  selector like `.site` can legitimately appear more than once (ORB-74 adds a
+ *  second `.site` rule for the page ground rather than editing ORB-73's), and a
+ *  non-global match would silently see only the first one, exempting every later
+ *  occurrence from the assertions below -- including the raw-hex guard. */
 function block(selector: string): string {
   const escaped = selector.replace(/[.[\]*+?^${}()|\\]/g, '\\$&')
-  const body = css.match(new RegExp(`(?:^|\\n)${escaped}\\s*\\{([\\s\\S]*?)\\n\\}`))?.[1]
-  if (!body) throw new Error(`rule "${selector}" not found in tokens.css`)
-  return body
+  const bodies = [
+    ...css.matchAll(new RegExp(`(?:^|\\n)[ \\t]*${escaped}\\s*\\{([\\s\\S]*?)\\n[ \\t]*\\}`, 'g')),
+  ].map((match) => match[1])
+  if (bodies.length === 0) throw new Error(`rule "${selector}" not found in tokens.css`)
+  return bodies.join('\n')
 }
 
 const site = block('.site')


### PR DESCRIPTION
## What this changes

The chooser, the two wizards and the thanks page were rendering in the application's
own visual system: a 10px radius, a soft blur shadow, no ground under the page, and a
plain-text header and footer with no border. A visitor lands on these pages straight
from a call to action on joinorbiters.com, so they read as a different, unfinished
product. `Shell.tsx` now carries the `.site` class ORB-73 added to `tokens.css`, so
the panel gets the site's own edges (a solid ink border) and its stepped offset
shadow instead of the application's radius and blur, and the header and footer links
keep a sliver of the page's surface behind them the way `landing.css`'s own header and
footer do. The footer gains the site's rule (a solid 2px line above it) and the
Studio Rossi attribution is now a real link, matching what the site's own footer
says today.

`tokens.css` gains a second, separate `.site` rule that restates
`system.css`'s faint grid (`--landing-grid`, `--landing-cell`) as the page's
background, so the wizards sit on the same ground as the landing without its
animated canvas field, which stays there on purpose (the issue's own "deliberately
not done").

The card no longer floats at the top of an otherwise empty page: `main` centres its
child in the space between header and footer, so a short step (which is the common
case here, one question at a time) sits in the middle of the page instead of leaving
several hundred pixels of dead `--color-paper` under it.

`Chooser.tsx`'s two door cards get the same border and offset-shadow treatment as the
shell's own panel, since they are cards on the same page and the fix would be
half-done without them.

Nothing about the wizard flow changes: eight steps and five steps, `Invio` to
continue, the progress bar, the back button, the CV upload are all untouched
(`Wizard.tsx`, `fields.tsx` and the two wizard pages are ORB-75's file, not mine).

## How I verified it

- `pnpm --filter hub test`: 26 tests passed across 6 files, unchanged assertions
  (`Wizard.test.tsx` and `FreelancerWizard.test.tsx` included).
- `pnpm --filter hub lint`: clean.
- `pnpm --filter hub build`: `vite build && tsc --noEmit`, clean.
- `orbiters-identity-scan .`: clean against 28 names.
- Compiled `dist/assets/index-*.css` after the build, read directly rather than
  trusted from source: `.shadow-xs{--tw-shadow:var(--shadow-app-xs);...}` and the two
  `border-[length:var(--landing-border-width)]` utilities both stayed live `var()`
  references, and the new `.site{...}` rule carries `--landing-grid`,
  `--landing-cell` and the background declarations that consume them (Lightning CSS
  additionally emitted a `@supports (color:color-mix(...))` progressive-enhancement
  duplicate for `--landing-grid`, the same pattern the file's other `color-mix()`
  tokens already get).
- Ran both wizards, the chooser and the thanks page with `pnpm --filter hub dev`
  (port 5180) against a second worktree on `origin/main` at the same commit
  (`e21207f`, port 5182), and rendered all four pages at 1440x1000 and 390x844 with
  `uishot`: no horizontal overflow at either viewport, no console errors.
- `uishot --axe --fail-on serious` on all four pages at both viewports: the chooser
  and the thanks page are clean. `/freelance` and `/aziende` report one `serious`
  (`aria-progressbar-name`) and one `moderate` (`page-has-heading-one`) violation at
  both viewports, both already present on `origin/main` before this PR (verified by
  running the same `uishot --axe` against the before worktree) and both inside
  `Wizard.tsx`, which is ORB-75's file. Filed as ORB-89 rather than fixed here.
- After the review's fixes (second commit): re-ran `pnpm --filter hub test` (26
  passed) and `pnpm --filter hub lint` (clean), rebuilt and re-read the compiled CSS
  for the three new utility classes
  (`focus-visible:outline-3`, `focus-visible:outline-offset-3`,
  `focus-visible:outline-(color:--landing-focus)`, all live `var()` references) and
  for `padding:var(--landing-link-pad)`, and drove real keyboard focus
  (`Tab` to the first Chooser card) in a browser to confirm the outline renders as a
  solid ring on all four sides over the offset shadow. Re-captured every screenshot
  pair below against the fixed branch.

## Anything a reviewer should look at twice

An independent review (a fresh `reviewer` agent, given the worktree and the diff
command) found four things worth a second commit, all applied here: the footer's
"Studio Rossi" attribution had gained a live link to `example.com`, a dead public
link rather than a fix; the Chooser cards' `ring` focus indicator was compositing
over the new opaque offset shadow at roughly 1.7:1 on two of its four sides, so it
now uses the site's own outline treatment (`var(--landing-focus)`) instead; the
header and footer links had two different hard-coded rem paddings where one named
token (`--landing-link-pad`) belonged, and the header's `joinorbiters.com` link had
lost its muted colour; and `tokens.test.ts`'s `block()` helper only ever saw the
first occurrence of a selector, so the raw-hex guard never covered this PR's second
`.site` rule -- fixed to concatenate every occurrence instead. One nit was left as a
note rather than a fix: `Wizard.tsx`'s progress bar uses `rounded-full`, which does
not derive from `--radius` and so stays a pill inside `.site`; that file is ORB-75's,
and its own agent already reports having redesigned the bar for an unrelated
contrast reason and dropped `rounded-full` in the process.

`tokens.css` still carries two separate `.site { ... }` rules rather than one: the
ORB-73 block is untouched, and this PR's ground properties and background
declarations live in a new rule appended after `@theme inline`, now wrapped in
`@layer base` per the review, specifically so this PR and ORB-75's (which also
touches `tokens.css`, inside the original `.site{}` block and in a new file) land on
disjoint lines. Coordinated live over `hub` messaging before either of us wrote a
line, and `tokens.test.ts`'s fix keeps both rules covered by the same guard.

## Screenshots

Before frames from a worktree on `origin/main` (`e21207f`), after frames from this
branch, both served on `localhost` at the ports `docs/pr-screenshots/README.md`
gives the hub web app.

**1. Chooser, 1440x1000**
![Chooser desktop, before and after](https://github.com/user-attachments/assets/518dad77-2337-416f-ae40-83c542f9f169)

**2. Chooser, 390x844**
![Chooser mobile, before and after](https://github.com/user-attachments/assets/7be1a028-5061-4343-84bb-73f26dab8d95)

**3. Freelancer wizard (step 1 of 8), 1440x1000**
![Freelancer wizard desktop, before and after](https://github.com/user-attachments/assets/6dfbe2c8-2714-4fb9-aed6-37d38ab0be77)

**4. Freelancer wizard (step 1 of 8), 390x844**
![Freelancer wizard mobile, before and after](https://github.com/user-attachments/assets/f82b7ddf-7f09-4731-835c-c83a0960362e)

**5. Company wizard (step 1 of 5), 1440x1000**
![Company wizard desktop, before and after](https://github.com/user-attachments/assets/ab165f96-4f12-4a83-8105-810eb81446ee)

**6. Company wizard (step 1 of 5), 390x844**
![Company wizard mobile, before and after](https://github.com/user-attachments/assets/75aa1bfa-7450-47eb-a309-75b85c8916ed)

**7. Thanks page, 1440x1000**
![Thanks page desktop, before and after](https://github.com/user-attachments/assets/7aae063d-09d4-4dee-8ea2-4c0e23cf97c9)

**8. Thanks page, 390x844**
![Thanks page mobile, before and after](https://github.com/user-attachments/assets/1fc5e97d-6769-437c-830d-c1aaeb053d00)

Linear: ORB-74.
