### PR TITLE
fix(website): the community page's own links read as controls, not a bare rectangle

### DIFF
--- a/projects/website/src/orbiters.css
+++ b/projects/website/src/orbiters.css
@@ -224,7 +224,30 @@ h1 {
   color: var(--color-watermelon-strong);
 }
 
+/* The community page's own version of the header/footer control landing.css treats
+   the same way; landing.css's own comment names this file's footer directly. These
+   two links are what is left of it since ORB-19 removed the `<footer>` element itself
+   (the "PigroCRM" and "Accedi" pair, and the ground-sliver rule that only had meaning
+   on the field behind them): the Privacy link and the "Raccontacelo" link, both still
+   inline in the note under the form. A border and a surface turn each into a tappable
+   control instead of a citation mid-sentence, and `min-height` clears the 44px
+   touch-target floor even at the note's smaller type, where the padding alone would
+   not -- this is the page people actually reach on a phone. No shadow at this tier,
+   the same as `.box`'s own step reads at a different tier entirely. orbiters.css has
+   no shared `*` border reset the way landing.css does, so the border is spelled out in
+   full here rather than as `border-width` alone. */
 .note a {
-  color: inherit;
-  text-underline-offset: 0.2em;
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
+  background-color: var(--orb-ground);
+  border: 2px solid var(--orb-ink);
+  padding-inline: 0.75rem;
+  color: var(--orb-ink-quiet);
+  text-decoration: none;
+}
+
+.note a:hover {
+  background-color: var(--orb-ink);
+  color: var(--orb-cta-ink);
 }

--- a/projects/website/src/orbiters.test.ts
+++ b/projects/website/src/orbiters.test.ts
@@ -108,9 +108,12 @@ describe('orbiters.html', () => {
     expect(html).toMatch(/href="\/privacy"/)
     const privacy = readFileSync(join(__dirname, 'privacy.html'), 'utf-8')
     expect(privacy).toContain('Orbiters')
-    // "/orbiters" is a redirect to "/", where the community page actually lives
-    // (path-map-plugin.ts); the canonical href is the one worth asserting on.
-    expect(privacy).toMatch(/href="\/"/)
+    // "/orbiters" is a 301 to "/", where the community page actually lives
+    // (path-map-plugin.ts). Pinned on the link's own text ("joinorbiters.com", the
+    // paragraph explaining where the signup's data goes) rather than a bare `"/"`,
+    // which the header brand and the footer's "Home" link also match and would pass
+    // even if this specific back-link were ever removed.
+    expect(privacy).toMatch(/href="\/(?:orbiters)?">joinorbiters\.com</)
   })
 
   it('no longer signs itself as a PigroCRM project, and offers no login', () => {
@@ -221,6 +224,9 @@ describe('orbiters.css', () => {
     expect(shell).toMatch(/background-color:\s*var\(--orb-ground\)/)
     expect(shell).toMatch(/border:\s*2px solid var\(--orb-ink\)/)
     // 44px, the touch-target floor: this is the page people actually reach on a phone.
+    // `min-height` only takes effect because the anchor is `inline-flex`, taken out of
+    // normal inline flow; pin that too, or the floor can be silently dropped.
+    expect(shell).toMatch(/display:\s*inline-flex/)
     expect(shell).toMatch(/min-height:\s*2\.75rem/)
     // No shadow at this tier: that is `.box`'s own signal, not a link's.
     expect(shell).not.toMatch(/box-shadow/)

--- a/projects/website/src/orbiters.test.ts
+++ b/projects/website/src/orbiters.test.ts
@@ -108,7 +108,9 @@ describe('orbiters.html', () => {
     expect(html).toMatch(/href="\/privacy"/)
     const privacy = readFileSync(join(__dirname, 'privacy.html'), 'utf-8')
     expect(privacy).toContain('Orbiters')
-    expect(privacy).toMatch(/href="\/orbiters"/)
+    // "/orbiters" is a redirect to "/", where the community page actually lives
+    // (path-map-plugin.ts); the canonical href is the one worth asserting on.
+    expect(privacy).toMatch(/href="\/"/)
   })
 
   it('no longer signs itself as a PigroCRM project, and offers no login', () => {
@@ -205,6 +207,28 @@ describe('orbiters.css', () => {
 
   it('does not import the landing sheet', () => {
     expect(css).not.toMatch(/@import/)
+  })
+
+  it('draws the note links as bordered controls, not a bare rectangle (ORB-88)', () => {
+    // Until 2026-09-09 these two links lived in a real `<footer>`, sitting on the
+    // field with a ground-sliver background of its own; ORB-19 removed that footer
+    // (git history: `.foot a`, the "PigroCRM" and "Accedi" pair). What is left of it
+    // is the Privacy link and "Raccontacelo", both inline in the note under the form
+    // now, and this is landing.css's own header/footer treatment (ORB-64) applied to
+    // them, so the two stylesheets stop disagreeing on what a link control looks like.
+    const shell = css.match(/\.note a\s*\{([^}]*)\}/)?.[1]
+    expect(shell, 'the note link control shell rule was not found').toBeTruthy()
+    expect(shell).toMatch(/background-color:\s*var\(--orb-ground\)/)
+    expect(shell).toMatch(/border:\s*2px solid var\(--orb-ink\)/)
+    // 44px, the touch-target floor: this is the page people actually reach on a phone.
+    expect(shell).toMatch(/min-height:\s*2\.75rem/)
+    // No shadow at this tier: that is `.box`'s own signal, not a link's.
+    expect(shell).not.toMatch(/box-shadow/)
+
+    const hover = css.match(/\.note a:hover\s*\{([^}]*)\}/)?.[1]
+    expect(hover, 'the note link hover rule was not found').toBeTruthy()
+    expect(hover).toMatch(/background-color:\s*var\(--orb-ink\)/)
+    expect(hover).toMatch(/color:\s*var\(--orb-cta-ink\)/)
   })
 })
 


### PR DESCRIPTION
## What this changes

Until 2026-09-09 `orbiters.html` carried a real `<footer>` whose two links ("Un progetto PigroCRM", "Accedi") sat on a sliver of the page's own ground so they stayed readable over the field's dark tiles. ORB-19 removed that footer entirely, its `.foot a` rule included, when the community page stopped signing itself as a PigroCRM project. What survived it are the Privacy link and "Raccontacelo", now inline in the note under the form, left as plain underlined prose (`.note a`) with no border, no hover state and no guaranteed touch target.

`landing.css`'s own comment (written the same day, after that footer removal) still names `orbiters.css` as making the same footer-link move, and ORB-64 gave `landing.css`'s header and footer links a bordered-control treatment: a 2px ink border, a 44px `min-height` and a hover invert to the ink surface, no shadow. This applies that same treatment to `.note a`, so the two stylesheets stop disagreeing about what a link control looks like: a 2px `--orb-ink` border, `min-height: 2.75rem`, `background-color: var(--orb-ground)`, and `:hover` inverting to `--orb-ink`/`--orb-cta-ink`. `focus-visible` needed no new rule: `:where(a, button, input):focus-visible` already covers every anchor in the file.

`--orb-ground`, `--orb-ink` and `--orb-cta-ink` already alias the identical shared colours ORB-64's `--landing-surface`, `--landing-ink` and `--landing-cta-ink` resolve to (`--color-paper`, `--color-prussian-blue`, `#ffffff`), so no new token was needed. One thing the two stylesheets could not share verbatim: `orbiters.css` carries no `* { border-style: solid; border-color: var(--orb-ink) }` reset the way `landing.css` does, so the border is spelled out in full (`border: 2px solid var(--orb-ink)`) rather than as `border-width` alone.

Also tightened `orbiters.test.ts`'s assertion on `privacy.html`'s back-link: the original `href="/orbiters"` check kept passing (that path still redirects to `/` and both still exist there), but a first pass at "canonicalising" it to a bare `href="/"` turned out to also match privacy.html's unrelated header brand and footer "Home" links, so it stopped pinning anything specific. Rewritten to match the link's own text ("joinorbiters.com", in the paragraph explaining where the signup's data goes), which holds whether ORB-66 rewrites that href to `/orbiters` or `/`.

Left alone on purpose: no `<footer>` element comes back (`orbiters.test.ts:114` keeps asserting its absence), and the box's layout, the page's copy and the signup form are untouched.

## How I verified it

- `pnpm --filter website test`: 190 passed (10 files), including a new `orbiters.test.ts` case pinning the border, background, `display: inline-flex` (what makes `min-height` apply to an anchor at all), min-height and hover colours, and the untouched "no longer signs itself as a PigroCRM project, and offers no login" assertion.
- `pnpm --filter website lint`: clean.
- `preflight --list` against `origin/main`, then ran everything it selected for this diff: `website-lint`, `website-unit`, `website-build` (`vite build` + `tsc --noEmit`), `website-types`, `website-e2e` (`playwright test`, 49 passed), `website-image` (`docker compose build`, built clean), `identity-names` (`orbiters-identity-scan .`, clean against 28 names).
- `uishot` at 1440 and 390, both before (a second worktree on `origin/main`) and after, plus a real `:hover` (Puppeteer mouse move onto `.note a`: `background-color: rgb(1, 25, 54)`, `color: rgb(255, 255, 255)`, `height: 44px`, `border: 2px`) and a real keyboard focus (visible `outline` ring, screenshot attached below). `uishot --axe --fail-on serious` at both viewports separately (axe only audits the last viewport in a `--viewports` list): clean at both.

## Anything a reviewer should look at twice

The two links sit inline mid-sentence ("Cerchi developer o CTO? Raccontacelo.", and "... persone. Privacy" inside the form's disclosure paragraph), not in a standalone nav row the way `index.html`'s footer links do. `landing.css`'s own `.quiet-link` (the generic, undecorated form) is explicitly commented as staying underlined prose for exactly this case ("an inline citation in running text"), and `landing-style.test.ts` pins that split as an invariant to protect. I deliberately crossed that line here: the issue's own Change #4 asks for the touch-target floor specifically because this is the page people reach on a phone, orbiters.html has no separate citation-only class to carve these two out of (unlike `landing.css`'s pages, both of this page's links are the ones the issue is about), and the issue asks for no layout change, which rules out lifting them into a standalone row instead. `display: inline-flex` keeps them in the text flow while clearing 44px; at 390px the "Privacy" pill visibly outgrows the surrounding line height where it wraps to its own line, which I judged acceptable.

An independent review on this PR also measured that the Privacy link's new 44px footprint widens an existing behaviour: `.box` now shifts about 55% further on the first validation error (65px of height lost, versus 42px on `main`) because the Privacy link lives inside `#note`, the `role="status"` paragraph `orbiters.js`'s `say()` replaces wholesale on every state change, so the link disappears and reappears with everything else. That disappearing act predates this PR; this PR only made what vanishes bigger. Fixing it means moving the Privacy link out of `#note`, a markup change beyond what this issue asks for — filed as ORB-94 rather than folded in here.

## Screenshots

**1. The community page's note links, before and after, at 1440px**
![Note links, before and after, 1440px](https://github.com/user-attachments/assets/f6f1658a-d736-42c1-a78d-d00238f28cf0)

**2. The same, at 390px**
![Note links, before and after, 390px](https://github.com/user-attachments/assets/328a3d97-6486-44e3-82e2-3f3141cba129)
