### PR TITLE
test(core): the free-planner assertion in test_trgm_escape.py holds on any machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,11 +311,13 @@ jobs:
       # `slow` builds a fifty-thousand-row corpus, so a PR does not pay for it and the
       # trunk does. `planner` is a different thing and is deselected on both: it asserts
       # which plan Postgres picks, the winning plan sits within a few percent of the
-      # loser at this row count, and a hosted runner picks the other one. It failed on
-      # the trunk run of the merge commit for exactly that reason, on code that had
-      # passed the same assertion on the devbox minutes earlier. It stays in preflight,
-      # which runs on one known machine, and ORB-9 tracks making the assertion say what
-      # it actually means instead of naming a plan.
+      # loser at this row count, and a hosted runner picks the other one.
+      # `test_trgm_escape.py`'s case (ORB-9) failed on the trunk run of the merge commit
+      # for exactly that reason, on code that had passed the same assertion on the devbox
+      # minutes earlier; its fix stopped costing the plan on whatever bloat the rest of
+      # the suite happened to leave behind, so it no longer carries the marker.
+      # `test_sort_plan.py` still does, for its own sort-plan assertions, and stays in
+      # preflight, which runs on one known machine.
       #
       # `slow` is not skipped on the trunk, it moved: the job below runs it in
       # parallel with this one. Measured 2026-09-09, the two are 10m and 12m of a

--- a/projects/pigrocrm/packages/core/tests/test_trgm_escape.py
+++ b/projects/pigrocrm/packages/core/tests/test_trgm_escape.py
@@ -71,18 +71,21 @@ change no semantics. It would then have had to go from **every** call site in th
 commit, never from one.
 """
 
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
 from corpus import REFERENCE, build_corpus
-from sqlalchemy import ColumnElement, or_, select, text
+from sqlalchemy import ColumnElement, Engine, delete, or_, select, text
 from sqlalchemy.orm import InstrumentedAttribute, Session
 
 from pigrocrm.core.customers.models import Customer
-from pigrocrm.core.db import escape_like
+from pigrocrm.core.db import escape_like, session_factory
 from pigrocrm.core.deals.models import Deal
 from pigrocrm.core.documents.models import Document
+from pigrocrm.core.invoices.models import Invoice
 from pigrocrm.core.people.models import Person
+from pigrocrm.core.pipeline.models import PipelineStage
 
 # The nine indexes this slice declares. Named here rather than derived from the models,
 # so that deleting one from `__table_args__` fails this file instead of quietly agreeing
@@ -358,23 +361,122 @@ def test_a_two_character_pattern_degrades_the_index_to_a_full_scan(db_session: S
     )
 
 
-@pytest.mark.planner
-def test_the_planner_left_alone_still_prefers_a_sequential_scan_at_this_scale(
-    db_session: Session,
-) -> None:
-    """Recorded rather than asserted away: at REFERENCE scale the planner does *not*
-    choose the trigram index when it has a choice, and it is right not to -- 500 narrow
-    rows are cheaper to read whole. This is what makes `enable_seqscan = off` necessary
-    above, and it is pinned here so that a future reader does not take the forced plans
-    for a claim about what production will do on a small table.
+@pytest.fixture(scope="module")
+def customers_at_reference_scale(db_engine: Engine) -> Iterator[Engine]:
+    """REFERENCE-scale corpus, committed, `VACUUM (ANALYZE)`d for real, removed and
+    re-vacuumed afterwards -- ORB-9's fix for the one test below that needs it.
 
-    If this ever starts failing because Postgres chose the index on its own, that is good
-    news and the assertion inverts; it is not a regression.
+    Every other fixture in this file runs `build_corpus` inside `db_session`'s savepoint,
+    which is right for a test that asks whether an index *can* serve a predicate: `ANALYZE`
+    works fine on an uncommitted table. It is wrong for the test below, which asks what the
+    free planner does when nothing forces its hand, because `relpages` reflects the table's
+    real physical size and a savepoint's rollback never shrinks a heap file back down.
+    `test_search_plan.py`'s `inflated` fixture already names the consequence on its own way
+    out: "`test_trgm_escape.py`'s 500-row seq scan is costed on a heap of dead pages" left
+    behind by however many of this file's own earlier tests happened to insert and roll
+    back the same 500 rows into `customers` first. Measured 2026-09-10, running this file's
+    tests in file order left `customers` at 52 pages instead of a fresh build's 11, and
+    priced the free planner's own `Seq Scan` at 58.25 instead of 17.25 -- margin enough that
+    a different runner, holding a different amount of leftover bloat, picks the other plan
+    with no line of code in between (ORB-9).
+
+    Committed and vacuumed for real, on a connection outside any transaction -- `VACUUM`
+    cannot run inside `db_session`'s savepoint at all -- so `customers`'s statistics
+    describe this corpus alone, not however many prior tests' debris the session
+    accumulated. Cleaned up and re-vacuumed on the way out for the reason `inflated` gives
+    for the same step: leaving `customers` bloated here would be exactly the noise this
+    fixture exists to remove, for whichever test runs next.
     """
-    _corpus_with_statistics(db_session)
+    # `customers` is empty of live rows here -- nothing before this fixture in the session
+    # commits into it -- but a plain `VACUUM` before the insert, not only `VACUUM (ANALYZE)`
+    # after it, is what actually discards whatever dead pages earlier tests' rollbacks left
+    # behind: at REFERENCE scale the leftover bloat is not a rounding error next to the
+    # corpus itself the way it is for `inflated`'s fifty thousand rows, so inserting into it
+    # first and only vacuuming afterwards still costs a `Seq Scan` on however many dead
+    # pages happened to precede it. Truncating the trailing empty pages before this corpus
+    # exists is what makes `customers`'s physical size a property of this fixture alone.
+    with db_engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
+        connection.execute(text("VACUUM customers"))
+    factory = session_factory(db_engine)
+    with factory() as session:
+        pre_existing_stages = set(session.scalars(select(PipelineStage.id)).all())
+        build_corpus(session, REFERENCE)
+        session.commit()
+    with db_engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
+        connection.execute(text("VACUUM (ANALYZE) customers"))
+    try:
+        yield db_engine
+    finally:
+        with factory() as session:
+            # Children first, `inflated`'s own order: invoices and documents reference
+            # customers and deals, people and deals reference customers, deals references
+            # a stage.
+            session.execute(delete(Invoice))
+            session.execute(delete(Document))
+            session.execute(delete(Deal))
+            session.execute(delete(Person))
+            session.execute(delete(Customer))
+            session.execute(
+                delete(PipelineStage).where(PipelineStage.id.notin_(pre_existing_stages))
+            )
+            session.commit()
+        with db_engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
+            connection.execute(text("VACUUM (ANALYZE) customers"))
 
-    plan = _free_plan(db_session, rf"ragione_sociale ILIKE '%{_NEEDLE}%' ESCAPE '\'", "customers")
+
+@pytest.fixture
+def customers_session(customers_at_reference_scale: Engine) -> Iterator[Session]:
+    """A plain session on the committed, vacuumed corpus above.
+
+    Not `db_session`: that fixture opens a savepoint this corpus was deliberately built
+    outside of, and a `SET` here should affect the whole session rather than roll back with
+    one."""
+    with session_factory(customers_at_reference_scale)() as session:
+        yield session
+
+
+def test_the_planner_left_alone_still_prefers_a_sequential_scan_at_this_scale(
+    customers_session: Session,
+) -> None:
+    """The free planner's own choice on a genuinely REFERENCE-scale `customers`: no
+    `Seq Scan` above sits with `Filter` doing the excluding here, `Index Cond` doing the
+    excluding above. 500 narrow rows are cheaper to read whole, and it is right not to use
+    the trigram index -- this is what makes `enable_seqscan = off` necessary in
+    `_isolated_plan` above, and it is pinned here so a future reader does not take those
+    forced plans for a claim about what production does on a small table.
+
+    `customers_at_reference_scale` is what makes this a property of the data instead of a
+    property of which tests happened to run first: see its own docstring for the table-bloat
+    mechanism that used to flip this same assertion on a hosted runner while it passed on a
+    devbox minutes earlier (ORB-9). The falsifier right below shows the identical query on
+    the identical corpus losing this `Seq Scan` the moment the choice is taken away from the
+    planner, so this is not an assertion that happens to hold for every plan Postgres could
+    produce.
+
+    If this ever starts failing with the planner genuinely preferring the index on its own,
+    that is good news and the assertion inverts; it is not a regression.
+    """
+    plan = _free_plan(
+        customers_session, rf"ragione_sociale ILIKE '%{_NEEDLE}%' ESCAPE '\'", "customers"
+    )
     assert "Seq Scan on customers" in plan, f"plan was:\n{plan}"
+
+
+def test_the_seq_scan_above_stops_appearing_once_the_planner_loses_the_choice(
+    customers_session: Session,
+) -> None:
+    """The falsifier the test above names: on the identical corpus and the identical query,
+    taking `enable_seqscan` away leaves no `Seq Scan on customers` in the plan at all. The
+    assertion above is measuring a real, losable choice, not one that happens to hold no
+    matter which plan Postgres produces."""
+    customers_session.execute(text("SET enable_seqscan = off"))
+    try:
+        plan = _free_plan(
+            customers_session, rf"ragione_sociale ILIKE '%{_NEEDLE}%' ESCAPE '\'", "customers"
+        )
+    finally:
+        customers_session.execute(text("SET enable_seqscan = on"))
+    assert "Seq Scan on customers" not in plan, f"plan was:\n{plan}"
 
 
 def test_similarity_needs_no_lower_in_the_index_expression(db_session: Session) -> None:

--- a/projects/pigrocrm/packages/core/tests/test_trgm_escape.py
+++ b/projects/pigrocrm/packages/core/tests/test_trgm_escape.py
@@ -387,15 +387,24 @@ def customers_at_reference_scale(db_engine: Engine) -> Iterator[Engine]:
     for the same step: leaving `customers` bloated here would be exactly the noise this
     fixture exists to remove, for whichever test runs next.
     """
-    # `customers` is empty of live rows here -- nothing before this fixture in the session
-    # commits into it -- but a plain `VACUUM` before the insert, not only `VACUUM (ANALYZE)`
-    # after it, is what actually discards whatever dead pages earlier tests' rollbacks left
-    # behind: at REFERENCE scale the leftover bloat is not a rounding error next to the
-    # corpus itself the way it is for `inflated`'s fifty thousand rows, so inserting into it
-    # first and only vacuuming afterwards still costs a `Seq Scan` on however many dead
-    # pages happened to precede it. Truncating the trailing empty pages before this corpus
-    # exists is what makes `customers`'s physical size a property of this fixture alone.
+    # `customers` should be empty of live rows here -- nothing before this fixture in the
+    # session commits into it and survives its own teardown -- but that is a claim about
+    # every other file sharing this container, not something this fixture controls, so it
+    # is checked rather than assumed: the failure this file exists to prevent is exactly a
+    # plan silently costed on a corpus that turned out not to be REFERENCE-scale. A plain
+    # `VACUUM` before the insert, not only `VACUUM (ANALYZE)` after it, is what actually
+    # discards whatever dead pages earlier tests' rollbacks left behind: at REFERENCE scale
+    # the leftover bloat is not a rounding error next to the corpus itself the way it is for
+    # `inflated`'s fifty thousand rows, so inserting into it first and only vacuuming
+    # afterwards still costs a `Seq Scan` on however many dead pages happened to precede it.
+    # Truncating the trailing empty pages before this corpus exists is what makes
+    # `customers`'s physical size a property of this fixture alone.
     with db_engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
+        live = connection.execute(text("SELECT count(*) FROM customers")).scalar_one()
+        assert live == 0, (
+            f"{live} committed customers survived an earlier test; this fixture's plan "
+            "would not be measured at REFERENCE scale"
+        )
         connection.execute(text("VACUUM customers"))
     factory = session_factory(db_engine)
     with factory() as session:
@@ -420,8 +429,13 @@ def customers_at_reference_scale(db_engine: Engine) -> Iterator[Engine]:
                 delete(PipelineStage).where(PipelineStage.id.notin_(pre_existing_stages))
             )
             session.commit()
+        # All five tables this fixture committed into, not only `customers`: `inflated`
+        # re-vacuums every table it dirtied for the same reason, and a plan assertion
+        # added to this file later against `people`, `deals`, `documents` or `invoices`
+        # deserves the same clean slate this test needed.
         with db_engine.connect().execution_options(isolation_level="AUTOCOMMIT") as connection:
-            connection.execute(text("VACUUM (ANALYZE) customers"))
+            for table in ("customers", "people", "deals", "documents", "invoices"):
+                connection.execute(text(f"VACUUM (ANALYZE) {table}"))
 
 
 @pytest.fixture
@@ -438,12 +452,16 @@ def customers_session(customers_at_reference_scale: Engine) -> Iterator[Session]
 def test_the_planner_left_alone_still_prefers_a_sequential_scan_at_this_scale(
     customers_session: Session,
 ) -> None:
-    """The free planner's own choice on a genuinely REFERENCE-scale `customers`: no
-    `Seq Scan` above sits with `Filter` doing the excluding here, `Index Cond` doing the
-    excluding above. 500 narrow rows are cheaper to read whole, and it is right not to use
-    the trigram index -- this is what makes `enable_seqscan = off` necessary in
-    `_isolated_plan` above, and it is pinned here so a future reader does not take those
-    forced plans for a claim about what production does on a small table.
+    """The free planner's own choice on a genuinely REFERENCE-scale `customers`: the
+    `Seq Scan` the forced plans above never show, with `Filter` doing the excluding here
+    and `Index Cond` doing it above. 500 narrow rows are cheaper to read whole, and it is
+    right not to use the trigram index -- this is what makes `enable_seqscan = off`
+    necessary in `_isolated_plan` above, and it is pinned here so a future reader does not
+    take those forced plans for a claim about what production does on a small table.
+
+    No longer `@pytest.mark.planner`: that marker meant the plan depended on which machine
+    ran it, and `customers_at_reference_scale` is what removes the dependency, so this now
+    runs in the ordinary gate instead of preflight's single-machine lane.
 
     `customers_at_reference_scale` is what makes this a property of the data instead of a
     property of which tests happened to run first: see its own docstring for the table-bloat


### PR DESCRIPTION
## What this changes

`test_the_planner_left_alone_still_prefers_a_sequential_scan_at_this_scale` in
`test_trgm_escape.py` asserted a specific plan string (`Seq Scan on customers`) on a
table whose statistics came from `db_session`'s per-test savepoint. `ANALYZE` runs fine
inside that savepoint, but `relpages` reflects the table's real physical size, and a
savepoint's rollback never shrinks a heap file back down. Every earlier test in the same
file (and, at package scale, every earlier test in the whole suite) inserts and rolls
back the same 500 rows into `customers`, and the pages that leaves behind are still
there to be counted. Measured locally: running the file in file order left `customers`
at 52 pages instead of a fresh build's 11, and priced the free planner's own `Seq Scan`
at 58.25 instead of 17.25 -- margin enough that a hosted runner, holding a different
amount of leftover bloat, priced the trigram index cheaper instead (56.25..60.26, per
ORB-9) with no line of code in between.

The fix gives the planner a corpus whose physical state is a property of this test
alone. `customers_at_reference_scale` commits its own REFERENCE-scale corpus outside
`db_session`'s savepoint (`VACUUM` cannot run inside one at all), runs a plain `VACUUM`
on `customers` *before* inserting -- not only `ANALYZE`/`VACUUM (ANALYZE)` after, which
is what `test_search_plan.py`'s `inflated` fixture does and which is not enough at this
row count, see below -- and `VACUUM (ANALYZE)`s again after, so the estimate describes
this corpus and nothing that ran before it. It cleans up and re-vacuums on the way out,
the same way `inflated` already does, so it doesn't leave `customers` bloated for
whichever test runs after it.

I also added a falsifier,
`test_the_seq_scan_above_stops_appearing_once_the_planner_loses_the_choice`: on the
identical corpus and the identical query, taking `enable_seqscan` away leaves no
`Seq Scan on customers` in the plan at all, so the assertion above is provably not one
that would hold for any plan Postgres could produce.

`test_the_planner_left_alone_still_prefers_a_sequential_scan_at_this_scale` no longer
carries `@pytest.mark.planner`: it is deterministic now, so it runs in the normal gate
instead of the preflight-only lane the marker used to route it into (the CI/preflight
`-m "not slow and not planner"` and `-m "planner"` filters need no changes, since they
already select per-marker; `test_sort_plan.py` still carries the marker for its own,
separate, out-of-scope sort-plan assertions).

## How I verified it

- **Reproduced the exact failure first.** Before the fix, running the whole package's
  suite ahead of this file (`uv run pytest -q projects/pigrocrm/packages/core/tests
  -m "not slow"`, 3077 tests) failed this one test with
  `cost=56.25..60.26 rows=1 width=16` for `Bitmap Heap Scan on customers` -- the exact
  numbers ORB-9 measured on the hosted runner, reproduced locally by table-bloat alone.
  A first version of the fix (commit-and-`VACUUM (ANALYZE)`-after only, mirroring
  `inflated` verbatim) still failed the same way in the same scenario, because
  `VACUUM (ANALYZE)` after an insert doesn't truncate pages that were already dead
  before the insert landed on top of them. Adding the pre-insert `VACUUM` fixed it.
- **Same adversarial run, after the fix:** `uv run pytest -q
  projects/pigrocrm/packages/core/tests -m "not slow"` -- 3077 passed, 0 failed
  (357s).
- **Break/restore, the acceptance criterion.** With `SET enable_seqscan = off` added
  temporarily inside the main test (mimicking what the falsifier does permanently), the
  identical test failed as expected:
  ```
  AssertionError: plan was:
  Bitmap Heap Scan on customers  (cost=30.69..34.70 rows=1 width=16)
    Recheck Cond: (...)
    ->  Bitmap Index Scan on ix_customers_ragione_sociale_trgm  (cost=0.00..30.69 rows=1 width=0)
          Index Cond: ((ragione_sociale)::text ~~* '%zzqqxxww%'::text)
  ```
  Reverted the temporary line, reran both tests: 2 passed.
- **The file alone, standalone and after the file's own bloat:**
  `test_trgm_escape.py` alone, 11 passed (70.6s); the two new tests alone (fresh
  container), 2 passed (20.9s).
- **`preflight --list`** selected `pigrocrm-py-lint`, `pigrocrm-py-test`,
  `pigrocrm-py-corpus`, `pigrocrm-py-planner` and `identity-names` for this diff.
  `preflight` (all five, unconditional lint/format included): all PASS --
  `pigrocrm-py-lint` 0.4s, `identity-names` 0.9s, `pigrocrm-py-test` 254.7s (the main
  `-n auto --dist loadfile -m "not slow and not planner"` gate, confirming the fix holds
  under xdist too), `pigrocrm-py-corpus` 702.2s, `pigrocrm-py-planner` 57.3s (now only
  `test_sort_plan.py`, unaffected by this change).
- `uv run mypy`: no issues (the change is test-only; mypy's configured source roots
  don't cover test files, so this is a repo-wide sanity check, not new coverage).

## Anything a reviewer should look at twice

`customers_at_reference_scale` VACUUMs `customers` before inserting into it, which is
one step more than `test_search_plan.py`'s `inflated` fixture does (that one only
`VACUUM (ANALYZE)`s after building). I found this the hard way: a first version of the
fix that only vacuumed after committing reproduced the exact CI failure under the same
adversarial full-suite run. `inflated`'s 50 000 rows dwarf whatever bloat preceded it,
so the after-only vacuum is enough there; at REFERENCE scale (500 rows) leftover bloat
from a shared session-scoped container is not a rounding error next to the corpus
itself, so the pre-insert `VACUUM` is load-bearing here specifically. Worth a second
look in case there's a cleaner way to express that asymmetry.

## Deliberately not done

`test_sort_plan.py` (`pytestmark = [pytest.mark.slow, pytest.mark.planner]`) carries the
same class of machine-dependent plan assertions and its own file comment says
"ORB-9 covers the family." The actual ORB-9 ticket text names only
`test_the_planner_left_alone_still_prefers_a_sequential_scan_at_this_scale`, and my
assignment scoped me to `test_trgm_escape.py` under `packages/core`, so I left it alone
and filed ORB-90 as a follow-up rather than widening this PR's diff into a second file.

## Screenshots

Not applicable: this is a backend test-only change with no visible surface.

Linear: ORB-9.
