### PR TITLE
fix(website): the cookie notice's controls clear the 44px touch-target floor

### DIFF
--- a/projects/website/src/consent.test.ts
+++ b/projects/website/src/consent.test.ts
@@ -294,13 +294,31 @@ describe('the notice clears the 44px touch-target floor without shouting (ORB-87
     expect(before).toMatch(/inset:\s*-14px -4px/)
   })
 
+  it('paints the buttons after the link\'s hit-slop, so a corner click cannot land on the wrong control', () => {
+    // `.consent a::before` is positioned, so without this it paints in tree order
+    // after the row of buttons and can win a hit test in the sliver where the slop
+    // reaches over this row (measured: a real overlap and click-theft toward
+    // "Dettagli" at some notice widths before this rule, none after). z-index stays
+    // auto -- this only changes paint order among same-level positioned boxes, not
+    // anything a reader sees.
+    expect(rule('.consent-actions')).toMatch(/position:\s*relative/)
+  })
+
   it('keeps every consent control a real `a`/`button`, so the shared focus-visible rule already covers it', () => {
     // landing.css and orbiters.css each carry one `::where(a, button…):focus-visible`
     // rule with no scope narrower than the whole page (landing-style.test.ts and
     // orbiters.test.ts hold those). This notice earns a visible focus ring for free
     // as long as consent.js keeps building real anchors and buttons rather than a
-    // `div` with a click handler -- which is what this test actually pins.
-    expect(js).toMatch(/document\.createElement\('a'\)/)
-    expect(js).toMatch(/document\.createElement\('button'\)/)
+    // `div` with a click handler -- checked here on the DOM the same file already
+    // builds, not by grepping the source for the word `createElement`.
+    run().start()
+    const box = notice()
+    expect(box?.querySelector('a')).toBeInstanceOf(window.HTMLAnchorElement)
+    for (const label of ['No', 'Va bene']) {
+      const control = [...(box?.querySelectorAll('button') ?? [])].find(
+        (candidate) => candidate.textContent === label,
+      )
+      expect(control, `nessun bottone "${label}"`).toBeInstanceOf(window.HTMLButtonElement)
+    }
   })
 })

--- a/projects/website/src/consent.test.ts
+++ b/projects/website/src/consent.test.ts
@@ -247,3 +247,60 @@ describe('when the browser refuses to remember anything', () => {
     }
   })
 })
+
+describe('the notice clears the 44px touch-target floor without shouting (ORB-87)', () => {
+  // The behavioural tests above build the notice in jsdom, which lays out no CSS at
+  // all: a real render is what actually proves a pixel size, and the PR this test
+  // ships with carries one (uishot at 390 and 1440, before and after). What a unit
+  // test can hold is the rule shape, so a later edit that quietly drops the floor or
+  // swaps it for a heavier control fails here before it fails on a phone.
+  const css = readFileSync(join(__dirname, 'system.css'), 'utf-8')
+
+  function rule(selector: string): string {
+    const escaped = selector.replace(/[.[\]*+?^${}()|\\]/g, '\\$&')
+    const body = css.match(new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`))?.[1]
+    expect(body, `rule "${selector}" not found`).toBeTruthy()
+    return body ?? ''
+  }
+
+  it('gives "No" and "Va bene" a floor on both axes, not just a taller box', () => {
+    // Height alone would still leave the two-letter "No" narrower than 44px: the
+    // floor is on `min-width` too.
+    const button = rule('.consent button')
+    expect(button).toMatch(/min-width:\s*2\.75rem/)
+    expect(button).toMatch(/min-height:\s*2\.75rem/)
+    // Padding and a floor, the ORB-64 shape, not the louder one: the border stays
+    // the notice's existing 1px and the resting background stays transparent, no
+    // saturated fill added to make the bigger box easier to see.
+    expect(button).toMatch(/border:\s*1px solid/)
+    expect(button).toMatch(/background-color:\s*transparent/)
+  })
+
+  it('grows the "Dettagli" link\'s hit area without growing its line (ORB-87)', () => {
+    // The link sits mid-sentence, so a real `min-height` would force the paragraph's
+    // lines apart. `position: relative` is what lets the phantom pseudo-element
+    // below anchor to the glyph instead of the page.
+    expect(rule('.consent a')).toMatch(/position:\s*relative/)
+    expect(rule('.consent a')).not.toMatch(/min-height|padding|border/)
+
+    const before = rule('.consent a::before')
+    expect(before).toMatch(/content:\s*['"]['"]/)
+    expect(before).toMatch(/position:\s*absolute/)
+    // No colour and no size property at all: the phantom box paints nothing, so it
+    // cannot make the notice louder by construction, only wider to a thumb.
+    expect(before).not.toMatch(/background|border|width:|height:/)
+    // -14px top/bottom against the glyph's ~16-20px line box clears 44px; the
+    // exact number is measured on a render, this only pins the shape surviving.
+    expect(before).toMatch(/inset:\s*-14px -4px/)
+  })
+
+  it('keeps every consent control a real `a`/`button`, so the shared focus-visible rule already covers it', () => {
+    // landing.css and orbiters.css each carry one `::where(a, button…):focus-visible`
+    // rule with no scope narrower than the whole page (landing-style.test.ts and
+    // orbiters.test.ts hold those). This notice earns a visible focus ring for free
+    // as long as consent.js keeps building real anchors and buttons rather than a
+    // `div` with a click handler -- which is what this test actually pins.
+    expect(js).toMatch(/document\.createElement\('a'\)/)
+    expect(js).toMatch(/document\.createElement\('button'\)/)
+  })
+})

--- a/projects/website/src/system.css
+++ b/projects/website/src/system.css
@@ -77,21 +77,27 @@
   inset: -14px -4px;
 }
 
+/* Positioned so this row paints after the link's `::before` hit-slop rather than
+   under it: the slop crosses this row's gap when the notice wraps its paragraph
+   onto its own line, and without this a corner of "No" would report a click on
+   "Dettagli" instead. No visual change -- z-index stays auto. */
 .consent-actions {
+  position: relative;
   display: flex;
   gap: 0.5rem;
   margin-left: auto;
 }
 
-/* Padding and a floor, not a heavier border or a fill: the 44px touch-target
-   floor this milestone names, reached the same way ORB-64's header controls
-   reached it, on both axes so "No" clears it on width as well as height. */
+/* A floor, not heavier padding: `min-width` alone takes "No" from 37px to 44px,
+   and `min-height` already governs over the old vertical padding, so the original
+   padding stays -- widening it would grow `.consent-actions` enough to wrap the
+   notice a line earlier at some widths, the layout change this issue rules out. */
 .consent button {
   cursor: pointer;
   font: inherit;
   min-width: 2.75rem;
   min-height: 2.75rem;
-  padding: 0.5rem 0.9rem;
+  padding: 0.25rem 0.6rem;
   border: 1px solid color-mix(in oklab, var(--color-prussian-blue) 20%, transparent);
   background-color: transparent;
   color: var(--color-prussian-blue);

--- a/projects/website/src/system.css
+++ b/projects/website/src/system.css
@@ -59,9 +59,22 @@
   flex: 1 1 12rem;
 }
 
+/* "Dettagli" sits mid-sentence, so growing its own box would force the line
+   apart and read as loud where the notice means to stay quiet. `::before`
+   grows the hit area instead of the glyph: nothing paints, nothing shifts,
+   and a thumb still finds the 44px floor this milestone names. It sits over
+   the line above, which carries no other control, so nothing is stolen from
+   it. */
 .consent a {
+  position: relative;
   color: inherit;
   text-underline-offset: 0.2em;
+}
+
+.consent a::before {
+  content: '';
+  position: absolute;
+  inset: -14px -4px;
 }
 
 .consent-actions {
@@ -70,10 +83,15 @@
   margin-left: auto;
 }
 
+/* Padding and a floor, not a heavier border or a fill: the 44px touch-target
+   floor this milestone names, reached the same way ORB-64's header controls
+   reached it, on both axes so "No" clears it on width as well as height. */
 .consent button {
   cursor: pointer;
   font: inherit;
-  padding: 0.25rem 0.6rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  padding: 0.5rem 0.9rem;
   border: 1px solid color-mix(in oklab, var(--color-prussian-blue) 20%, transparent);
   background-color: transparent;
   color: var(--color-prussian-blue);


### PR DESCRIPTION
## What this changes

The cookie notice's three controls were under the 44px touch-target floor this
milestone names: "Dettagli" measured 20px tall, "No" was 38×29 and "Va bene" 68×29.
Now every one of them is at least 44px in its smaller dimension on a phone, and the
notice stays the same quiet tier it was: no border-width bump, no fill, no shadow.

"No" and "Va bene" get `min-width`/`min-height: 2.75rem`, the same shape ORB-64 used
for the header and footer controls; the existing padding is untouched, since the
`min-width`/`min-height` floor alone already carries both axes. "Dettagli" sits
mid-sentence in the notice's paragraph, so a real `min-height` on it would force the
line apart and read as loud; it gets an invisible `::before` hit-slop instead
(`inset: -14px -4px`), which grows the clickable area without painting anything or
shifting a pixel.

The focus-visible state needed nothing: landing.css and orbiters.css each already carry
one page-wide `::where(a, button):focus-visible` rule, and the notice's controls are
real `<a>`/`<button>` elements, so they were already covered. I checked this with real
keyboard Tab presses rather than assuming it from the CSS.

Both `index.html` and `orbiters.html` carry the notice (it lives in `system.css`,
shared by both sheets), so I rendered both.

**A review round found and fixed one real bug.** The link's `::before` hit-slop is a
positioned box, so it paints after the non-positioned buttons in the CSS stacking
order; whenever the notice wraps its paragraph onto its own line, the slop's edge
crosses into the buttons' row and a click in that sliver landed on "Dettagli" instead
of "No". `.consent-actions` now gets `position: relative` so the row paints after the
slop in tree order (no visual change, z-index stays `auto`), which I verified resolves
every overlap in a sweep of widths 280-390px on both pages. The review also caught that
my first pass had widened the buttons' padding unnecessarily (the `min-width`/
`min-height` floor alone was enough), which was moving the notice's wrap threshold and
is exactly what created the overlap band in the first place -- reverting it removes
both the unwanted layout change and the bug's precondition.

## How I verified it

- `pnpm --filter website test` -- 193 passed, including a describe block in
  `consent.test.ts` that pins the rule shapes (the 2.75rem floor on both axes for the
  buttons, the hit-slop shape and stacking-order fix on the link, no border/fill
  added, no source-regex standing in for a DOM check).
- `pnpm --filter website lint` -- clean.
- `preflight --list` selected `website-lint`, `website-unit`, `website-build`,
  `website-types`, `website-e2e`, `website-image`, `identity-names` for the two
  changed files; all seven passed (`website-e2e`: 49 passed, re-run after the fix too).
- Real-render measurement at 390px, both pages, via a headless Chrome tab
  (`getBoundingClientRect`): "No" 44×44, "Va bene" 47.3×44 (`/pigrocrm`: 69.2×44), the
  "Dettagli" hit area at or above 44px on its smaller dimension in every case.
- A geometric overlap-and-`elementFromPoint` sweep from 280px to 390px on both pages,
  before and after the stacking fix: every width where the link's phantom hit-slop
  geometrically overlaps a button now resolves the click to the button, not the link.
- `uishot --axe --fail-on serious` at 390 and 1440 on both `/` and `/pigrocrm`: zero
  violations on all four runs, both before and after the review fix.
- Real keyboard navigation (Puppeteer's `page.keyboard.press('Tab')`, not a synthetic
  `.focus()` call) through both pages: reached "Dettagli", "No" and "Va bene" in that
  order, each showing `outline: 3px solid` in the page's own focus colour.
- `pixel.test.ts` unchanged and passing: the pixel still only loads after "Va bene".

## Anything a reviewer should look at twice

The `::before` hit-slop on "Dettagli" still overlaps the line of text above it (there
is no text below, since the link is always the paragraph's last line on both pages at
both viewports I rendered). That line carries no other control, so nothing is stolen
from it, but a pointer over that band shows the link's cursor and hover state over
plain prose, which is inherent to the technique. I could not find a case where
"Dettagli" wraps to a line with content after it or before it that has its own control;
if a future copy change adds one, worth re-checking with a render.

## Screenshots

**1. The notice at 390px, `/` (orbiters.html)**
![Consent notice at 390px on the community page, before and after](https://github.com/user-attachments/assets/a9045de4-99ea-41a1-b060-a3d472d962a3)

**2. The notice at 1440px, `/` (orbiters.html)**
![Consent notice at 1440px on the community page, before and after](https://github.com/user-attachments/assets/3e7828b2-c1d4-4517-8a6b-e8223a32d947)

**3. The notice at 390px, `/pigrocrm` (index.html)**
![Consent notice at 390px on the PigroCRM page, before and after](https://github.com/user-attachments/assets/6f81dde2-c551-4384-ab00-6c95a0e7e224)

**4. The notice at 1440px, `/pigrocrm` (index.html)**
![Consent notice at 1440px on the PigroCRM page, before and after](https://github.com/user-attachments/assets/0cb798d1-eb78-42cb-a4e1-7afec9afcf18)

The "before" frames are `origin/main` (`1a23646`), built in a second worktree; the
"after" frames are this branch's final state, same data, same viewport.

Linear: ORB-87.
