### PR TITLE
test(web): custom-fields.spec.ts waits for its own requests, not a fixed timeout

### DIFF
--- a/projects/pigrocrm/apps/web/e2e/custom-fields.spec.ts
+++ b/projects/pigrocrm/apps/web/e2e/custom-fields.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Page, type Response } from '@playwright/test'
 import { loginAsAdmin, rowAction, typeLikeAHuman } from './helpers'
 
 test.beforeEach(async ({ page }) => {
@@ -57,19 +57,15 @@ test("a custom field's whole life: appears everywhere with no restart, and a cle
   // passed on retry, in the same suite run; reproduced live under load with zero
   // columnheaders, not just this one, still on screen when the timeout hit). Waiting for
   // both responses to actually land is the fix: a test bug, not the application's --
-  // `describe_entity`/`FieldDefinitionService.create` already commit before the POST
-  // that creates the field even returns, and every request here reads live.
-  const [, schemaResponse, customersResponse] = await Promise.all([
+  // `FieldDefinitionService.create` commits before the POST that creates the field even
+  // returns, and `describe_entity` reads live, so the reload cannot miss the field.
+  const isGet = (response: Response, path: string): boolean =>
+    new URL(response.url()).pathname.endsWith(path) && response.request().method() === 'GET'
+  await Promise.all([
     page.goto('/app/clienti'),
-    page.waitForResponse(
-      (response) => response.url().includes('/api/schema/customer') && response.request().method() === 'GET',
-    ),
-    page.waitForResponse(
-      (response) => response.url().includes('/api/customers') && response.request().method() === 'GET',
-    ),
+    page.waitForResponse((response) => isGet(response, '/api/schema/customer')),
+    page.waitForResponse((response) => isGet(response, '/api/customers')),
   ])
-  expect(schemaResponse.ok()).toBe(true)
-  expect(customersResponse.ok()).toBe(true)
   await expect(page.getByRole('columnheader', { name: 'Referente' })).toBeVisible()
 
   // The create-form input, native (Telefono) and custom (Referente) side by side.

--- a/projects/pigrocrm/apps/web/e2e/custom-fields.spec.ts
+++ b/projects/pigrocrm/apps/web/e2e/custom-fields.spec.ts
@@ -48,8 +48,28 @@ test("a custom field's whole life: appears everywhere with no restart, and a cle
   await createTextField(page, 'Referente')
 
   // The column, with no rebuild: buildCustomerColumns (features/customers/columns.tsx)
-  // reads it straight off GET /api/schema/customer.
-  await page.goto('/app/clienti')
+  // reads it straight off GET /api/schema/customer, and `DataTable`'s own loading gate
+  // (components/DataTable.tsx) is `customers.isLoading` -- so the columnheader depends on
+  // both requests, not just one. `page.goto` here is a genuine hard reload: the whole SPA
+  // bundle, the auth check, and both of those requests, all from scratch. Asserting
+  // `toBeVisible()` right after `goto` bets the suite's fixed `expect.timeout` always
+  // outruns a cold reload plus two round trips -- it does not (ORB-39: failed once,
+  // passed on retry, in the same suite run; reproduced live under load with zero
+  // columnheaders, not just this one, still on screen when the timeout hit). Waiting for
+  // both responses to actually land is the fix: a test bug, not the application's --
+  // `describe_entity`/`FieldDefinitionService.create` already commit before the POST
+  // that creates the field even returns, and every request here reads live.
+  const [, schemaResponse, customersResponse] = await Promise.all([
+    page.goto('/app/clienti'),
+    page.waitForResponse(
+      (response) => response.url().includes('/api/schema/customer') && response.request().method() === 'GET',
+    ),
+    page.waitForResponse(
+      (response) => response.url().includes('/api/customers') && response.request().method() === 'GET',
+    ),
+  ])
+  expect(schemaResponse.ok()).toBe(true)
+  expect(customersResponse.ok()).toBe(true)
   await expect(page.getByRole('columnheader', { name: 'Referente' })).toBeVisible()
 
   // The create-form input, native (Telefono) and custom (Referente) side by side.


### PR DESCRIPTION
## What this changes

`custom-fields.spec.ts:45` failed and passed on retry in the same suite run
(ORB-39): a column that a freshly-defined custom field adds to the customer
list was not there yet when the test looked for it, right after a full
`page.goto('/app/clienti')`. That `goto` is a genuine hard reload -- the
whole SPA bundle, the auth check, and both `GET /api/schema/customer` and
`GET /api/customers`, all from scratch -- and the test asserted
`toBeVisible()` on the columnheader immediately after, betting that the
suite's fixed `expect.timeout` (8s) always outruns that cold reload plus
two round trips. It does not, reliably, under load.

I reproduced it first (`--repeat-each=25 --retries=0`, same parallelism the
gate uses: `workers: 1`): it failed once, at the same line, with the same
"element not found" shape the issue reported. Instrumenting the failure
showed the whole table, not just the custom column, still had zero
columnheaders when the 8-second timeout hit -- the fingerprint of an
assertion racing its own request, not of the application showing the wrong
columns after both requests had actually landed. `describe_entity` and
`FieldDefinitionService.create` already read live and already commit before
the POST that creates the field even returns, so this was the test, not the
application.

The fix: wait for both responses to actually land (`page.waitForResponse`
alongside the `goto`) before asserting the columnheader is visible, instead
of hoping the fixed window covers a cold reload it was never sized for.
Nothing about the assertion itself changed -- it still requires the exact
column to be visible, with the same default timeout, now measured from the
point both of its own dependencies have actually resolved.

Retries stay on (`playwright.config.ts`'s `retries: process.env.CI ? 1 : 0`
is unchanged): the spec now passes reliably with `--retries=0` on its own,
so there was no case to make for turning retries off for the whole suite,
and doing that silently for one flake would hide a real regression in every
other spec's margin instead of fixing this one's.

## How I verified it

- Reproduced on `main` before touching anything: `pnpm exec playwright test
  e2e/custom-fields.spec.ts:45 --retries=0 --repeat-each=25 --workers=1
  --reporter=line` failed once (repeat 16 of 25) with `element(s) not
  found` on `getByRole('columnheader', { name: 'Referente' })`, at
  `custom-fields.spec.ts:53` -- the same line and shape ORB-39 reported.
- After the fix: `pnpm exec playwright test e2e/custom-fields.spec.ts:45
  --retries=0 --repeat-each=20 --workers=1 --reporter=line` -> `20 passed
  (4.1m)`, no retries, same parallelism the gate uses.
- The full file once more: `pnpm exec playwright test
  e2e/custom-fields.spec.ts --retries=0 --workers=1 --reporter=line` -> `3
  passed (48.0s)`.
- `preflight --list` on this diff selects `pigrocrm-web-lint`,
  `pigrocrm-web-unit`, `pigrocrm-web-build`, `pigrocrm-e2e` and
  `identity-names`. `preflight` (all five): lint, unit, build and
  identity-names passed; `pigrocrm-e2e` (the full 39-test suite) failed on
  two *unrelated* tests in `resilience.spec.ts` (`kill ESRCH`, the API
  process already gone by the time the test tries to signal it) -- every
  test in `custom-fields.spec.ts` passed in that same run (37 of 39
  passed). That spec is not part of the required GitHub `ci` check (e2e
  only runs through `preflight`, never in `pull_request`/`push`), and I did
  not chase it: a different file, a different failure shape, and it did not
  run under normal, single-checkout load (several other agents were on the
  same box at the time). Filed as ORB-91 rather than fixed here.
- `pnpm --filter web exec tsc --noEmit` and `pnpm exec eslint
  e2e/custom-fields.spec.ts` on the touched file: no errors.

## Anything a reviewer should look at twice

I checked `apps/web/src` for the same shape of bug -- a table's `isLoading`
gated on the entity-list query alone, not on the `schema` query that
supplies its dynamic custom-field columns (`clienti/index.tsx`,
`persone/index.tsx`, `deal/lista.tsx` all do this) -- since it would produce
the identical symptom (the table renders before its columns are complete).
I did not find it in this reproduction: every captured failure showed *zero*
columnheaders, including the native ones, meaning the whole table was still
loading rather than rendered with an incomplete column set. That is a
`customers`/`page` reload timing question, not a `schema`-vs-`customers`
ordering one, so I left those three files alone -- fixing a defect I did
not actually observe here would be guessing. If that gap turns out to
matter on its own it is a separate issue, not this one.

## What did not change, on purpose

`playwright.config.ts`'s `retries` and `expect.timeout` are untouched. The
fix targets the one assertion that follows a hard reload, not the suite's
defaults.

## Screenshots

Nothing visible changed: this is a Playwright spec, not application code.
No before/after pair to capture.

Linear: ORB-39.
