### PR TITLE
fix(website): the site's own links stop bouncing through /orbiters

### DIFF
--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -234,7 +234,7 @@
 
       <footer class="wrap rule" style="padding-block: 2rem">
         <p class="fine" style="display: flex; gap: 1.5rem; flex-wrap: wrap">
-          <a class="quiet-link" href="/orbiters">Orbiters</a>
+          <a class="quiet-link" href="/">Orbiters</a>
           <a class="quiet-link" href="/privacy">Privacy</a>
           <a class="quiet-link" href="/termini">Termini</a>
           <a class="quiet-link" href="https://example.com/">Studio Rossi</a>

--- a/projects/website/src/links.test.ts
+++ b/projects/website/src/links.test.ts
@@ -35,8 +35,12 @@ import { REDIRECTS, route } from './path-map-plugin'
  *   site does not control (`/orbiters`, from before the community page took `/`);
  *   markup this build produces itself should say what it means directly. That rule is
  *   what the three links this issue names actually trip: none of them 404, all three
- *   still 301 to a page that exists, and all three are "wrong" only in that sense --
+ *   still 301 to a page that exists, and all three are "wrong" only in that sense,
  *   which is exactly why nothing before this test noticed them.
+ * - A path under `ELSEWHERE` (`/app/`, `/hub/...`) resolves to another tenant of the
+ *   origin, named in `deploy/joinorbiters.conf` and served by a container this suite
+ *   never runs, so the check stops at "the path map hands it away" and does not, and
+ *   cannot, follow it further.
  */
 
 const PAGE_FILES = ['index.html', 'orbiters.html', 'privacy.html', 'termini.html'] as const
@@ -55,11 +59,11 @@ function idsOn(page: string): Set<string> {
 }
 
 /** The site's own trusted external destinations. Mirrors the allowlist
- *  `landing-pages.test.ts:42` already enforces for `href`/`src` subresources, kept as
- *  its own list here because that file does not cover `orbiters.html`, and because an
- *  `<a>` a visitor clicks is a different concern from a subresource the page fetches
- *  for itself: this list is free to diverge from that one without either test lying
- *  about what it guarantees. */
+ *  `landing-pages.test.ts`'s "requests nothing from another origin" test already
+ *  enforces for `href`/`src` subresources, kept as its own list here because that
+ *  file does not cover `orbiters.html`, and because an `<a>` a visitor clicks is a
+ *  different concern from a subresource the page fetches for itself: this list is
+ *  free to diverge from that one without either test lying about what it guarantees. */
 const EXTERNAL_HOSTS = ['github.com', 'pigro.joinorbiters.com', 'example.com', 'openai.com', 'humancraft.tech']
 
 function checkExternal(href: string): string | undefined {
@@ -74,13 +78,19 @@ function checkExternal(href: string): string | undefined {
   return undefined
 }
 
-/** Resolves one internal path (no fragment) against the path map, applying the
- *  redirect-is-wrong rule from the file comment above. */
+/** Resolves one internal path (no fragment, no query string) against the path map,
+ *  applying the redirect-is-wrong rule from the file comment above. */
 function checkInternalPath(pathname: string): string | undefined {
   const result = route(pathname)
   if (result.kind === 'not-found') return `${pathname} is not served: the path map 404s it`
   if (result.kind === 'redirect') {
     return `${pathname} is a redirect to ${result.to}; link to ${result.to} directly instead of through the redirect`
+  }
+  // route() calls anything with a dot a "file" without checking it exists (that is
+  // what lets a hashed build asset through in preview); a source-tree check is not
+  // proof of a built one, but it does catch a plain typo in a link to a static asset.
+  if (result.kind === 'file' && !existsSync(join(SRC_DIR, pathname))) {
+    return `${pathname} is not served: no file under src/ answers it`
   }
   return undefined
 }
@@ -94,7 +104,11 @@ function checkHref(pageFile: PageFile, href: string): string | undefined {
   }
   if (/^https?:\/\//.test(href)) return checkExternal(href)
   if (href.startsWith('/')) {
-    const [pathname, fragment] = href.split('#') as [string, string | undefined]
+    // route() -- and the middleware built on it -- both drop the query string before
+    // matching a path; the same has to happen here, or a page's own campaign link to
+    // itself (e.g. "?utm_source=...") 404s in this check while nginx serves it fine.
+    const [pathWithoutQuery] = href.split('?') as [string]
+    const [pathname, fragment] = pathWithoutQuery.split('#') as [string, string | undefined]
     const pathFailure = checkInternalPath(pathname)
     if (pathFailure) return pathFailure
     if (fragment === undefined) return undefined
@@ -105,6 +119,10 @@ function checkHref(pageFile: PageFile, href: string): string | undefined {
     const targetFile = result.file.replace(/^\//, '') as PageFile
     return idsOn(html[targetFile] ?? '').has(fragment) ? undefined : `${href}: no id="${fragment}" on ${targetFile}`
   }
+  // A scheme this file does not otherwise recognise (tel:, sms:, data:, javascript:,
+  // ...) is not a page this site serves either, for the same reason mailto: above is
+  // skipped rather than resolved.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return undefined
   // A relative reference (e.g. "./file.pdf"), resolved against this project's src/ the
   // way a browser resolves it against the page: it has to exist on disk. None of the
   // four pages' <a> tags use one today; this is the fallback for the day one does.
@@ -135,5 +153,23 @@ describe('idsOn, the id-extraction helper behind the fragment check', () => {
     const page = '<h2 id="come-funziona">Come funziona</h2>'
     expect(idsOn(page).has('come-funziona')).toBe(true)
     expect(idsOn(page).has('altro')).toBe(false)
+  })
+})
+
+describe('checkHref, edge cases none of the four pages exercise today', () => {
+  it('catches a mistyped absolute asset path, and passes the real one', () => {
+    expect(checkHref('index.html', '/orbiters-logo.svg')).toBeUndefined()
+    expect(checkHref('index.html', '/orbiter-logo.svg')).toMatch(/no file under src\/ answers it/)
+  })
+
+  it('drops the query string before routing, like the dev server does', () => {
+    expect(checkHref('index.html', '/privacy?utm_source=newsletter')).toBeUndefined()
+    // The redirect-is-wrong rule still applies once the query string is gone.
+    expect(checkHref('index.html', '/orbiters?utm_source=newsletter')).toMatch(/is a redirect to \//)
+  })
+
+  it('skips a scheme it does not otherwise resolve, the same way it skips mailto:', () => {
+    expect(checkHref('index.html', 'tel:+390000000')).toBeUndefined()
+    expect(checkHref('index.html', 'javascript:void(0)')).toBeUndefined()
   })
 })

--- a/projects/website/src/links.test.ts
+++ b/projects/website/src/links.test.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { REDIRECTS, route } from './path-map-plugin'
+
+/**
+ * ORB-66: nothing else in the suite resolves an `<a href>` against what the site
+ * actually serves. `path-map-plugin.ts`'s `route()` is the one function that already
+ * knows the answer for an internal path -- it is what the dev and preview servers run
+ * on every request, and `path-map-plugin.test.ts` keeps it equal to `deploy/nginx.conf`
+ * -- so this file reuses it rather than growing a second opinion about which paths
+ * exist.
+ *
+ * What this deliberately does not check, and why:
+ *
+ * - External links (`https://...`) are checked for shape (a parseable absolute URL)
+ *   and for host (an explicit allowlist), never fetched: a test that curls another
+ *   site's server fails on a machine with no network and on a day that site is down,
+ *   for a reason this repository did nothing to cause. The GitHub link in index.html
+ *   is the case worth naming: `.../blob/main/projects/pigrocrm/README.md#deploy`
+ *   happens to point at a file this very checkout carries, but the `#deploy` fragment
+ *   is a heading slug GitHub's own renderer computes when it displays the file, not
+ *   anything this repository's build produces or serves. Verifying it would mean
+ *   reimplementing GitHub's markdown-to-anchor algorithm to check a target nothing
+ *   here emits, for a link that is still, mechanically, external. That is exactly the
+ *   class of bug behind ORB-65's dead `#installazione` anchor (a GitHub link, on a
+ *   repository that no longer existed under that name, fixed by hand): a fragment into
+ *   another repository or another product's README cannot be verified locally, so the
+ *   host allowlist plus a human glance (recorded in the PR) is the whole check, on
+ *   purpose, both before and after that fix.
+ * - `mailto:` links point at an address, not a page this site serves, so they carry no
+ *   route to resolve.
+ * - A link that resolves through `REDIRECTS` is treated as wrong, not merely checked
+ *   for a working target. `REDIRECTS` exists for a bookmark or an inbound link this
+ *   site does not control (`/orbiters`, from before the community page took `/`);
+ *   markup this build produces itself should say what it means directly. That rule is
+ *   what the three links this issue names actually trip: none of them 404, all three
+ *   still 301 to a page that exists, and all three are "wrong" only in that sense --
+ *   which is exactly why nothing before this test noticed them.
+ */
+
+const PAGE_FILES = ['index.html', 'orbiters.html', 'privacy.html', 'termini.html'] as const
+type PageFile = (typeof PAGE_FILES)[number]
+
+const SRC_DIR = join(__dirname)
+const html: Record<PageFile, string> = Object.fromEntries(
+  PAGE_FILES.map((name) => [name, readFileSync(join(SRC_DIR, name), 'utf-8')]),
+) as Record<PageFile, string>
+
+/** Every `id="..."` in a page, as the set of fragments it can be linked to. Exercised
+ *  directly below, since no page currently links to an in-page anchor to exercise it
+ *  through the check itself. */
+function idsOn(page: string): Set<string> {
+  return new Set([...page.matchAll(/\bid="([^"]+)"/g)].map((m) => m[1]!))
+}
+
+/** The site's own trusted external destinations. Mirrors the allowlist
+ *  `landing-pages.test.ts:42` already enforces for `href`/`src` subresources, kept as
+ *  its own list here because that file does not cover `orbiters.html`, and because an
+ *  `<a>` a visitor clicks is a different concern from a subresource the page fetches
+ *  for itself: this list is free to diverge from that one without either test lying
+ *  about what it guarantees. */
+const EXTERNAL_HOSTS = ['github.com', 'pigro.joinorbiters.com', 'example.com', 'openai.com', 'humancraft.tech']
+
+function checkExternal(href: string): string | undefined {
+  let url: URL
+  try {
+    url = new URL(href)
+  } catch {
+    return `${href} is not a parseable absolute URL`
+  }
+  if (url.protocol !== 'https:') return `${href} is not https`
+  if (!EXTERNAL_HOSTS.includes(url.hostname)) return `${href} is not on an allowed host`
+  return undefined
+}
+
+/** Resolves one internal path (no fragment) against the path map, applying the
+ *  redirect-is-wrong rule from the file comment above. */
+function checkInternalPath(pathname: string): string | undefined {
+  const result = route(pathname)
+  if (result.kind === 'not-found') return `${pathname} is not served: the path map 404s it`
+  if (result.kind === 'redirect') {
+    return `${pathname} is a redirect to ${result.to}; link to ${result.to} directly instead of through the redirect`
+  }
+  return undefined
+}
+
+/** Resolves one `<a href>` from `pageFile`, returning a failure reason or undefined. */
+function checkHref(pageFile: PageFile, href: string): string | undefined {
+  if (href.startsWith('mailto:')) return undefined
+  if (href.startsWith('#')) {
+    const id = href.slice(1)
+    return idsOn(html[pageFile]).has(id) ? undefined : `${href}: no id="${id}" on ${pageFile}`
+  }
+  if (/^https?:\/\//.test(href)) return checkExternal(href)
+  if (href.startsWith('/')) {
+    const [pathname, fragment] = href.split('#') as [string, string | undefined]
+    const pathFailure = checkInternalPath(pathname)
+    if (pathFailure) return pathFailure
+    if (fragment === undefined) return undefined
+    const result = route(pathname)
+    if (result.kind !== 'page') {
+      return `${href}: ${pathname} is not one of this site's own pages, so its fragment cannot be checked here`
+    }
+    const targetFile = result.file.replace(/^\//, '') as PageFile
+    return idsOn(html[targetFile] ?? '').has(fragment) ? undefined : `${href}: no id="${fragment}" on ${targetFile}`
+  }
+  // A relative reference (e.g. "./file.pdf"), resolved against this project's src/ the
+  // way a browser resolves it against the page: it has to exist on disk. None of the
+  // four pages' <a> tags use one today; this is the fallback for the day one does.
+  return existsSync(join(SRC_DIR, href)) ? undefined : `${href} does not exist relative to ${pageFile}`
+}
+
+describe('REDIRECTS resolve to something real', () => {
+  it('sends every redirect target somewhere the path map does not 404', () => {
+    for (const [from, to] of Object.entries(REDIRECTS)) {
+      expect(route(to).kind, `${from} -> ${to}`).not.toBe('not-found')
+    }
+  })
+})
+
+describe.each(PAGE_FILES)('%s', (name) => {
+  it('links only to what the site actually serves', () => {
+    const hrefs = [...html[name].matchAll(/<a\s[^>]*\bhref="([^"]+)"/g)].map((m) => m[1]!)
+    const failures = hrefs.map((href) => checkHref(name, href)).filter((reason): reason is string => reason !== undefined)
+    expect(failures).toEqual([])
+  })
+})
+
+describe('idsOn, the id-extraction helper behind the fragment check', () => {
+  // No page currently links to an in-page anchor, so this is proven directly on the
+  // helper `checkHref` calls for a "#fragment" href, rather than through a page fixture
+  // that does not exist yet.
+  it('finds an id declared anywhere in the markup, and only that id', () => {
+    const page = '<h2 id="come-funziona">Come funziona</h2>'
+    expect(idsOn(page).has('come-funziona')).toBe(true)
+    expect(idsOn(page).has('altro')).toBe(false)
+  })
+})

--- a/projects/website/src/privacy.html
+++ b/projects/website/src/privacy.html
@@ -41,7 +41,7 @@
 
         <h2>L'iscrizione a Orbiters</h2>
         <p>
-          Su <a class="quiet-link" href="/orbiters">joinorbiters.com</a> ti chiediamo nome, cognome
+          Su <a class="quiet-link" href="/">joinorbiters.com</a> ti chiediamo nome, cognome
           e l'indirizzo email, e il tuo profilo LinkedIn solo se vuoi darcelo. Compilando il form
           non ti metti in una lista d'attesa: entri in Orbiters, e quei dati sono la tua
           iscrizione. Li usiamo per tenerla in piedi e per scriverti, chiamandoti per nome, di
@@ -84,7 +84,7 @@
           nel CRM né nella pagina dei termini o in questa.
         </p>
         <p>
-          Sulla home e sulla pagina di <a class="quiet-link" href="/orbiters">Orbiters</a>, che sono
+          Sulla home e sulla pagina di <a class="quiet-link" href="/pigrocrm">PigroCRM</a>, che sono
           le due pagine su cui possono arrivare i nostri annunci, c'è un'eccezione e la diciamo:
           il pixel di misurazione di ChatGPT Ads (OpenAI). Serve a sapere se un annuncio ha portato
           un'iscrizione, e per farlo scrive un cookie di prima parte sul nostro dominio


### PR DESCRIPTION
## What this changes

Nothing in the suite resolved an `<a href>` against what the site actually serves, and three internal links pointed at `/orbiters`, which nginx 301s to `/` since the community page took the front door on 2026-09-09: the landing's footer ("Orbiters", `index.html:237`), and two sentences in `privacy.html` ("joinorbiters.com" at `:44`, and the pixel-disclosure paragraph naming the page at `:87`). None of them 404, so nothing noticed; they still worked, just through a hop the site's own markup has no reason to take.

The footer link and the privacy.html domain mention now point straight at `/`. The pixel-disclosure paragraph named the wrong page for the second half of "the two pages an ad can land on": `/orbiters` is a redirect with no page left behind it, so the sentence now names and links `/pigrocrm`, the actual second page `pixel.test.ts`'s `MEASURED` list carries (`index.html`, served at `/pigrocrm`, and `orbiters.html`, served at `/`).

Adds `src/links.test.ts`, which walks every `<a href>` on the four built pages and resolves it against `path-map-plugin.ts`'s `route()`, the same function the dev and preview servers run on every request. A path the map 404s is a failure, and so is a link that only works by resolving through `REDIRECTS`, which is exactly what these three did: `REDIRECTS` exists for a bookmark or an inbound link this site does not control, never for markup this build produces itself. External links are checked for shape and host, never fetched; the file's header comment says why, including how it treats the GitHub link in `index.html` that happens to point back into this repository (the class of bug behind ORB-65's now-fixed dead `#installazione` anchor).

## How I verified it

`pnpm --filter website test`, before the fix, on the unmodified pages: exactly the three failures the issue names, all tripping the same rule:

```
FAIL  links.test.ts > index.html > links only to what the site actually serves
  - []
  + ["/orbiters is a redirect to /; link to / directly instead of through the redirect"]

FAIL  links.test.ts > privacy.html > links only to what the site actually serves
  - []
  + ["/orbiters is a redirect to /; link to / directly instead of through the redirect",
  +  "/orbiters is a redirect to /; link to / directly instead of through the redirect"]

Test Files  1 failed (1)
     Tests  2 failed | 4 passed (6)
```

After the fix, same command, same file: `Test Files 1 passed (1)`, `Tests 9 passed (9)` (the extra three cover the file-kind, query-string and non-mailto-scheme cases the independent review below caught).

Then the full suite, rebased onto `main` after both ORB-36 (#11) and ORB-88 (#13) merged: `pnpm --filter website test` (11 files, 199 tests, all green), `lint` (eslint, clean), `build` (vite), `exec tsc --noEmit` (clean), `test:e2e` (Playwright against `vite preview`, 49 passed), the `website-image` docker build (clean), and `orbiters-identity-scan .` (clean against 28 names, 4 paths allowed - added `links.test.ts` to the local allowlist, the same way `landing-pages.test.ts` already is, since both legitimately reference `humancraft.tech`). Everything `preflight --list` selected for this diff.

**External links, checked by hand** (curl from outside, 2026-09-09, recorded here as the baseline the issue asked for):

| Link | From | Answer |
| --- | --- | --- |
| `/orbiters` | `index.html:237`, `privacy.html:44` and `:87` | 301 to `/` (fixed above: all three now link to `/` or `/pigrocrm` directly) |
| `https://github.com/joinorbiters/orbiters/blob/main/projects/pigrocrm/README.md#deploy` | `index.html:213` | 200 (ORB-65's fix; the fragment itself is GitHub's own heading slug, not something this build can verify) |
| `/`, `/pigrocrm`, `/privacy`, `/termini`, `/hub/freelance`, `/hub/aziende`, `https://humancraft.tech/`, `https://pigro.joinorbiters.com/app/registrati` | various | 200 |
| `/app/` | both headers | 302 to `pigro.joinorbiters.com/app/` (intentional, ORB-64) |

## Anything a reviewer should look at twice

`links.test.ts` treats any internal `<a>` that resolves through `REDIRECTS` as wrong, not merely as "working through an extra hop". That is a stricter reading than "resolves in `PAGES` or `REDIRECTS`" taken literally, and it is the rule that actually catches the three links this issue names (none of them 404; all three still 301 to a page that exists). The file's header comment explains the reasoning; a `REDIRECTS`-target-resolves check also runs on its own, independent of any page linking there, so a future legitimate redirect entry is still validated even though nothing should ever link to it directly.

An independent review (second commit) found and fixed three gaps in the check's own coverage before this went further: an absolute path `route()` calls a "file" was never checked against disk (a mistyped asset link would have passed), a query string was not dropped before routing the way the dev server's own middleware drops it, and a non-`mailto:` scheme (`tel:`, `javascript:`, ...) fell through to the relative-file branch with a misleading message. It also flagged that `orbiters.test.ts:111` (owned by ORB-88, not touched here) asserted `privacy.html` still contained `href="/orbiters"`; I had already flagged that to the agent working ORB-88 before making this change, and their PR #13 fixed the assertion. Both #11 and #13 are merged and this branch is rebased onto the result.

## Screenshots

One visible copy change: `privacy.html`'s pixel-disclosure paragraph names the second page as "PigroCRM" (linking `/pigrocrm`) instead of "Orbiters" (linking the now-removed `/orbiters`). Before/after at 1440px, cropped to the paragraph:

**1. privacy.html, the pixel-disclosure paragraph**
![privacy.html paragraph naming the two pages an ad can land on, before and after](https://github.com/user-attachments/assets/56f666fa-a652-444f-b512-4bf3d024f03a)

Nothing else in this diff is visible: the footer link and the domain mention keep their text (`Orbiters`, `joinorbiters.com`), only their `href` changes.

Linear: ORB-66.
