### PR TITLE
feat(hub): the wizards' fields and buttons draw the site's controls

### DIFF
--- a/projects/hub/apps/web/src/styles/tokens.css
+++ b/projects/hub/apps/web/src/styles/tokens.css
@@ -98,6 +98,17 @@
   --shadow-app-sm: calc(var(--landing-step) * 0.75) calc(var(--landing-step) * 0.75) 0 var(--landing-ink);
   --shadow-app-md: var(--landing-step) var(--landing-step) 0 var(--landing-ink);
   --shadow-app-lg: var(--landing-step) var(--landing-step) 0 var(--landing-ink);
+
+  /* ORB-75: the two magnitudes landing.css and orbiters.css spend on a control's own
+     padding, neither of which lands on Tailwind's 0.25rem spacing grid, so a
+     component reaches for these instead of retyping the site's numbers. The CTA
+     scale is landing.css's `.cta` (`landing.css:263`); the control scale is
+     orbiters.css's `.signup input`/`.signup button` (`orbiters.css:174`), which the
+     site's own forms use for every text input it has. */
+  --landing-cta-padding-block: 0.9rem;
+  --landing-cta-padding-inline: 1.5rem;
+  --landing-control-padding-block: 0.85rem;
+  --landing-control-padding-inline: 1rem;
 }
 
 @layer base {

--- a/projects/hub/apps/web/src/wizard/Wizard.tsx
+++ b/projects/hub/apps/web/src/wizard/Wizard.tsx
@@ -1,7 +1,7 @@
-import { ArrowLeft, ArrowRight, Check } from 'lucide-react'
 import { useState, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import './site-controls.css'
 
 /**
  * One question per screen, the shape Typeform and Tally made familiar: a progress bar,
@@ -117,10 +117,11 @@ export function Wizard<T>({
           aria-valuenow={progress}
           aria-valuemin={0}
           aria-valuemax={100}
-          className="h-1.5 w-full overflow-hidden rounded-full bg-border"
+          aria-label="Avanzamento"
+          className="h-2 w-full overflow-hidden border-(length:--landing-border-width)"
         >
           <div
-            className="h-full rounded-full bg-primary transition-[width] duration-300"
+            className="h-full bg-(--landing-ink) transition-[width] duration-300"
             style={{ width: `${review ? 100 : progress}%` }}
           />
         </div>
@@ -160,12 +161,10 @@ export function Wizard<T>({
             </p>
           )}
           <div className="flex items-center justify-between">
-            <Button type="button" variant="ghost" onClick={back} disabled={submitting}>
-              <ArrowLeft className="mr-2 size-4" />
+            <Button type="button" variant="outline" onClick={back} disabled={submitting}>
               Indietro
             </Button>
             <Button type="button" onClick={onSubmit} disabled={submitting}>
-              <Check className="mr-2 size-4" />
               {submitting ? 'Invio…' : submitLabel}
             </Button>
           </div>
@@ -192,11 +191,10 @@ export function Wizard<T>({
           <div className="flex items-center justify-between">
             <Button
               type="button"
-              variant="ghost"
+              variant="outline"
               onClick={back}
               className={cn(index === 0 && 'invisible')}
             >
-              <ArrowLeft className="mr-2 size-4" />
               Indietro
             </Button>
             <div className="flex items-center gap-3">
@@ -205,7 +203,6 @@ export function Wizard<T>({
               </span>
               <Button type="button" onClick={next}>
                 {index === steps.length - 1 ? 'Rivedi' : 'Avanti'}
-                <ArrowRight className="ml-2 size-4" />
               </Button>
             </div>
           </div>

--- a/projects/hub/apps/web/src/wizard/fields.tsx
+++ b/projects/hub/apps/web/src/wizard/fields.tsx
@@ -29,7 +29,7 @@ export function TextField({
       ref={ref}
       value={value}
       onChange={(event) => onChange(event.target.value)}
-      className="h-12 text-lg md:text-lg"
+      className="text-lg md:text-lg"
       {...rest}
     />
   )
@@ -75,23 +75,32 @@ export function ChoiceField<V extends string>({
 }) {
   return (
     <div role="radiogroup" className="grid gap-3 sm:grid-cols-3">
-      {options.map((option, index) => (
-        <button
-          key={option.value}
-          type="button"
-          role="radio"
-          aria-checked={value === option.value}
-          onClick={() => onChange(option.value)}
-          className={cn(
-            'flex flex-col items-start gap-1 rounded-2xl border bg-card p-4 text-left transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none',
-            value === option.value && 'border-foreground ring-2 ring-foreground/20',
-          )}
-        >
-          <span className="text-xs text-muted-foreground">{index + 1}</span>
-          <span className="font-medium">{option.label}</span>
-          {option.hint && <span className="text-sm text-muted-foreground">{option.hint}</span>}
-        </button>
-      ))}
+      {options.map((option, index) => {
+        const selected = value === option.value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'flex flex-col items-start gap-1 rounded-2xl border-(length:--landing-border-width) bg-card p-4 text-left transition-colors hover:bg-muted focus-visible:outline-3 focus-visible:outline-(--landing-focus) focus-visible:outline-offset-3',
+              selected && 'bg-(--landing-ink) text-(--landing-cta-ink) hover:bg-(--landing-ink)',
+            )}
+          >
+            <span className={cn('text-xs', selected ? 'text-(--landing-cta-ink)/70' : 'text-muted-foreground')}>
+              {index + 1}
+            </span>
+            <span className="font-medium">{option.label}</span>
+            {option.hint && (
+              <span className={cn('text-sm', selected ? 'text-(--landing-cta-ink)/85' : 'text-muted-foreground')}>
+                {option.hint}
+              </span>
+            )}
+          </button>
+        )
+      })}
     </div>
   )
 }
@@ -155,7 +164,7 @@ export function FileField({
       ) : (
         <p className="text-sm text-muted-foreground">Trascina qui il file, oppure</p>
       )}
-      <label className="cursor-pointer text-sm font-medium underline underline-offset-2">
+      <label className="cursor-pointer text-sm font-medium underline underline-offset-2 has-[:focus-visible]:outline-3 has-[:focus-visible]:outline-(--landing-focus) has-[:focus-visible]:outline-offset-3">
         {value ? 'Scegli un altro file' : 'Scegli il file'}
         <input
           ref={inputRef}

--- a/projects/hub/apps/web/src/wizard/site-controls.css
+++ b/projects/hub/apps/web/src/wizard/site-controls.css
@@ -1,0 +1,67 @@
+/* ORB-75: a descendant of `.site` (the chooser, the two wizards and the thanks page,
+   ORB-73's decision) draws the shared `ui/*` primitives -- Button, Input, Textarea --
+   in the landing's own vocabulary instead of the application's. tokens.css's `.site`
+   scope already repoints `--radius`, `--border`, `--input` and the shadow scale for
+   any descendant, which is enough for every utility class that already reads one of
+   those custom properties (`rounded-lg`, `border-input`, `shadow-xs`...). What that
+   cascade does not reach, because the shadcn primitives spend it as their own
+   utilities rather than as a token: the fixed heights, Tailwind's default 1px border
+   width, the application's tighter padding, and the blurred `ring-*` focus treatment
+   `landing.css`'s own header comment (`landing.css:9`) rules out ("no radius, blur or
+   soft shadow anywhere"). Every rule below sits outside any `@layer`, so it wins over
+   Tailwind's own utilities (emitted inside `@layer utilities`) regardless of source
+   order or selector specificity -- confirmed against the compiled CSS in `dist`,
+   never against this source alone (`ui-design-tokens`, the Tailwind v4 shadow trap
+   ORB-73 already paid for). */
+
+.site [data-slot='button'] {
+  border-width: var(--landing-border-width);
+}
+
+/* The two navigation buttons in `Wizard.tsx` are always `data-size="default"`; the
+   site's CTA is not a fixed-height pill, it is padding around the label
+   (`landing.css:263`), so the box grows with its own text instead of clipping it. */
+.site [data-slot='button'][data-size='default'] {
+  height: auto;
+  padding-block: var(--landing-cta-padding-block);
+  padding-inline: var(--landing-cta-padding-inline);
+}
+
+/* `.cta:hover` turns solid ink, never a faded tint of itself (landing.css:268-271);
+   `.cta.secondary:hover` swaps to the same ink fill with the CTA's own ink text
+   (landing.css:303-306) -- the "outline" variant is what `Wizard.tsx` uses for
+   Indietro, so it is what carries the secondary door's shape here. */
+.site [data-slot='button'][data-variant='default']:hover {
+  background-color: var(--landing-ink);
+  border-color: var(--landing-ink);
+}
+.site [data-slot='button'][data-variant='outline']:hover {
+  background-color: var(--landing-ink);
+  border-color: var(--landing-ink);
+  color: var(--landing-cta-ink);
+}
+
+.site [data-slot='input'],
+.site [data-slot='textarea'] {
+  padding-block: var(--landing-control-padding-block);
+  padding-inline: var(--landing-control-padding-inline);
+}
+
+/* aria-invalid keeps the destructive border orbiters.css's own `.signup
+   input[aria-invalid='true']` already draws (orbiters.css:185-187); the soft
+   translucent ring the application adds on top of it is the one thing that has to
+   go, since it is exactly the blurred halo the site's stylesheet never draws. */
+.site [data-slot='input'][aria-invalid='true'],
+.site [data-slot='textarea'][aria-invalid='true'] {
+  box-shadow: none;
+}
+
+/* The application's focus state is a blurred, semi-transparent ring; the site's is a
+   solid offset outline in the same Watermelon (landing.css:283-286). A control this
+   rule reaches keeps whatever border it already has -- the outline is drawn outside
+   it, never replacing it. */
+.site :where([data-slot='button'], [data-slot='input'], [data-slot='textarea']):focus-visible {
+  outline: 3px solid var(--landing-focus);
+  outline-offset: 3px;
+  box-shadow: none;
+}


### PR DESCRIPTION
## What this changes

The two wizards' controls draw the application's shapes today: a rounded, watermelon
pill for Avanti with an arrow glyph after the label, a transparent Indietro carrying no
visual weight beside it, rounded inputs with a translucent focus ring, and a
`rounded-full` progress bar. They now draw the site's own vocabulary that ORB-73 landed
in `tokens.css`'s `.site` scope: square, a 2px ink border, the site's own padding scale,
and a solid offset focus outline instead of the application's blurred ring. The CTA
stays the one saturated thing on screen; Indietro becomes the site's secondary door
shape (the same rectangle, drawn in the ink); the progress bar is an ink-outlined track
with a solid fill, since `rounded-full` is a fixed Tailwind radius that never derives
from `--radius` and stayed a pill even under `.site`, and the translucent grey I first
tried for its track measured 1.29:1 against the panel, short of the 3:1 control floor.
The wizard's behaviour, validation and Italian copy are unchanged.

## How I verified it

- `pnpm --filter hub test`: 26/26 green, unmodified (the existing flow assertions
  query by role and label, not by class, so nothing needed rewriting).
- `pnpm --filter hub lint` and `pnpm --filter hub build` (`vite build && tsc --noEmit`):
  clean.
- `preflight --list` / `preflight` in my worktree: selects `hub-web-lint`,
  `hub-web-unit`, `hub-web-build`, `identity-names`; all four pass.
- Compiled `dist` CSS, not just the source, per the ORB-73 shadow trap: every
  `.site [data-slot=...]` rule and every `border-(length:--landing-border-width)` /
  `bg-(--landing-ink)` / `outline-(--landing-focus)` utility resolved to a live `var()`,
  none baked to a literal.
- Drove both wizards end to end with the `.site` class applied (ORB-74 is what adds it
  to `Shell` in production; I added it via script for this branch, since it isn't
  merged yet) through the `browser` tool: every step of both wizards, tabbing through a
  step, a manual `aria-invalid` toggle on an input and a textarea to render the error
  state, `.focus()` on a hidden file input, a radio-card selection and its focus state,
  and the review screen's Indietro/Invia pair.
- `uishot --axe --fail-on serious` at 390 and at 1440, run separately per viewport
  (axe only audits the last one in a `--viewports` list): clean now. The same run on
  the unmodified `main` worktree caught `aria-progressbar-name` (serious, the
  progressbar had no accessible name) already on `main`; this branch fixes it as a
  side effect of touching that element. `page-has-heading-one` (moderate, no `h1` on
  the page) is also pre-existing on `main` and is not something this diff's files can
  fix; filed separately (ORB-92).
- Contrast, computed from the actual resolved colours in the running page (canvas
  compositing, not a guess), floor 4.5:1 for text and 3:1 for controls:

  | Pair | Ratio |
  | --- | --- |
  | CTA text (white) on CTA fill (Watermelon Strong) | 4.67:1 |
  | Secondary/Indietro text (ink) on white | 17.59:1 |
  | Ink border (button, input, choice card) on white panel | 17.59:1 |
  | Ink border on the paper ground | 15.70:1 |
  | Focus outline (Watermelon) on white panel | 4.22:1 |
  | Focus outline (Watermelon) on the paper ground | 3.77:1 |
  | Destructive/error border on white input | 4.67:1 |
  | Progress fill (ink) on white panel | 17.59:1 |
  | Progress track's ink border on white panel | 17.59:1 |
  | Choice-card selected fill (ink) vs white unselected | 17.59:1 |
  | Choice-card selected label (white) on ink fill | 17.59:1 |
  | Choice-card selected index number (white/70%) on ink fill | 8.99:1 |
  | Choice-card selected hint (white/85%) on ink fill | 12.89:1 |

  The one pair I abandoned for failing the floor: a translucent `--shadow-ink-strong`
  (12% ink) track/fill for the progress bar and the choice-card selection both measured
  1.29:1 against white. Both are now solid ink instead (see What this changes).

## Anything a reviewer should look at twice

- The choice-card ("Come preferisci lavorare?") selection state is a bigger visual
  change than the rest of this diff: it went from a translucent `ring-2` outline to a
  solid ink fill with white text, because the translucent version is the 1.29:1 pair
  above. The issue didn't name this control specifically (only Avanti, Indietro, the
  inputs and the progress bar), but it's the same shared soft-shadow/low-contrast
  problem, so I fixed it under the same "no radius, blur or soft shadow anywhere" rule
  landing.css states for itself.
- `aria-invalid` is never actually set on any field by `FreelancerWizard.tsx` or
  `CompanyWizard.tsx` today (out of my ownership per the batch contract, `wizard/*` and
  `ui/*` only) — the error state screenshots below were produced by toggling the
  attribute directly via script to render what the CSS now does with it, not by
  triggering real validation on a field-by-field basis. The step-level validation
  (`role="alert"` under the question) is unchanged and is what the wizard actually uses
  today.
- Two pre-existing defects found while capturing these screenshots, confirmed against
  an unmodified `main` worktree, deliberately left alone and filed instead:
  `ORB-92` (page has no `h1`) and `ORB-93` (the review screen's answer column wraps
  every long value one character per line at 390px, `w-40` label column leaving no
  room).

## Screenshots

Nine before/after pairs, `.site` applied via script since ORB-74 (which adds the class
to `Shell` in production) has not merged yet.

**1. Freelancer, step 1 (TextField) — 1440**
**2. Freelancer, step 1 (TextField) — 390**
**3. Freelancer, email step — Indietro/Avanti weight and the input's error state — 1440**
**4. Freelancer, CV step (FileField) — 1440**
**5. Freelancer, "Come preferisci lavorare?" (ChoiceField), selected + focus — 1440**
**6. Freelancer, review screen (Indietro/Invia la candidatura) — 1440**
**7. Freelancer, review screen — 390**
**8. Company, "Raccontaci il progetto" (LongTextField/Textarea), focused — 1440**
**9. Company, "Raccontaci il progetto" (LongTextField/Textarea), focused — 390**
Linear: ORB-75.

![pair-step1-1440](https://github.com/user-attachments/assets/b106d1e7-bd95-4dfb-9910-a8165d02e4fc)

![pair-step1-390](https://github.com/user-attachments/assets/cd640920-6000-4f61-955c-f4455aadf4cf)

![pair-email-error-1440](https://github.com/user-attachments/assets/ecd48560-23a6-49da-9913-ca1b1269e6ca)

![pair-cv-1440](https://github.com/user-attachments/assets/5ba7ebf5-3e8d-41b5-87c9-162743e4c143)

![pair-choice-1440](https://github.com/user-attachments/assets/27718627-e491-4678-a08c-e3b2b4aee0fc)

![pair-review-1440](https://github.com/user-attachments/assets/3c02b1e6-9cba-4314-b9cf-61df0dc63684)

![pair-review-390](https://github.com/user-attachments/assets/8b835230-fab4-4bb3-bf6d-ba817ab2ed56)

![pair-longtext-1440](https://github.com/user-attachments/assets/57b295f4-722c-4701-9f5a-801b9fcce004)

![pair-longtext-390](https://github.com/user-attachments/assets/032b4d63-c720-4b0b-8000-82a31341d7c2)
