### PR TITLE
fix(hub): the site's text inputs pick up the 2px border and lose the fixed height

### DIFF
--- a/projects/hub/apps/web/src/wizard/site-controls.css
+++ b/projects/hub/apps/web/src/wizard/site-controls.css
@@ -41,10 +41,22 @@
   color: var(--landing-cta-ink);
 }
 
+/* ORB-94: the border-width rule above only ever named `[data-slot='button']`, so
+   Input and Textarea kept Tailwind's default 1px (`border border-input`, input.tsx
+   and textarea.tsx). Input's own base class also carries a fixed `h-9` (36px), which
+   the padding below only shrank into rather than grew past, since `height` -- unlike
+   `padding` -- was never given an unlayered override here: a 390px phone measured a
+   36px box next to a 53px CTA. `height: auto` releases it, the same way the CTA's
+   own `height: auto` already does; Textarea already floors on `min-h-16` rather than
+   a fixed height, which the padding below only ever grows past, so it is untouched. */
 .site [data-slot='input'],
 .site [data-slot='textarea'] {
+  border-width: var(--landing-border-width);
   padding-block: var(--landing-control-padding-block);
   padding-inline: var(--landing-control-padding-inline);
+}
+.site [data-slot='input'] {
+  height: auto;
 }
 
 /* aria-invalid keeps the destructive border orbiters.css's own `.signup


### PR DESCRIPTION
## What this changes

Follow-up to ORB-75 (#18, merged). Main measured, on merged `main` against a real
`vite preview` build rather than a dev server or a `.site`-injection script: every
`input[data-slot="input"]` on both wizards computed a 1px border and a fixed 36px
height, next to the 2px-bordered, 53-59px CTA beside it. `site-controls.css`'s
border-width rule only ever named the button; the padding-only rule for inputs and
textareas never touched `height`, so `input.tsx`'s own fixed `h-9` stayed in force and
the added padding shrank into it instead of growing past it, one property short of
reaching a rendered element, the same class of miss `--shadow-xs` was for ORB-73.

`.site [data-slot='input'], .site [data-slot='textarea']` now also carry
`border-width: var(--landing-border-width)`; `.site [data-slot='input']` releases its
fixed height (`height: auto`), the same way the CTA button already does. Textarea
already floors on `min-h-16` rather than a fixed height, so it needed neither change
and is untouched.

## How I verified it

- `pnpm --filter hub test`: 26/26 green, unmodified.
- `pnpm --filter hub lint`: clean.
- `pnpm --filter hub build` (`vite build && tsc --noEmit`): clean; compiled `dist` CSS
  read directly: `.site [data-slot=input],.site [data-slot=textarea]{border-width:var(--landing-border-width);...}.site [data-slot=input]{height:auto}` — a live `var()`, not baked.
- `vite preview` of that build (not a dev server), driven with the `browser` tool, `.site`
  live on the real `Shell` (ORB-74 is merged, no script injection needed this time).
  Computed `border-top-width` and bounding-box `height` of every text input, both
  wizards, both viewports:

  | Field | Viewport | Border | Height |
  | --- | --- | --- | --- |
  | Freelancer "Nome" | 1440 | 2px | 59.19px |
  | Freelancer "Cognome" | 1440 | 2px | 59.19px |
  | Freelancer "Nome" | 390 | 2px | 59.19px |
  | Freelancer "Cognome" | 390 | 2px | 59.19px |
  | Company "Azienda" | 1440 | 2px | 59.19px |

  Before this fix (measured the same way on `main`, `c3ad9b4`): 1px border, 36px
  height on every one of the rows above.

## Anything a reviewer should look at twice

Nothing beyond what's above; this is a one-property-short fix on a file ORB-75 already
introduced, not a new surface.

## Screenshots

No visible layout change beyond what ORB-75's own screenshots already claimed (taller,
2px-bordered inputs) — this PR is what actually makes that render true in the built
app rather than only in a dev-server session with `.site` injected by script. Not
recapturing the ORB-75 pairs since the intended appearance is unchanged, only the
mechanism that was supposed to produce it.

Linear: ORB-95.
