### PR TITLE
docs: record fixed-port collisions across concurrent checkouts

### DIFF
--- a/projects/pigrocrm/AGENTS.md
+++ b/projects/pigrocrm/AGENTS.md
@@ -94,6 +94,17 @@ it starts. On this shared box that is a real collision with other projects, and 
 why `pigrocrm-e2e` is `serial: true` in `.github/preflight.json`. Editing those three
 values into `${VAR:-default}` form is a genuine improvement and has not been done.
 
+**Two concurrent `pigrocrm-e2e` runs corrupt each other through the pidfile, not just
+the ports.** `e2e/resilience.spec.ts` kills the API mid-suite and relaunches it,
+tracking the pid through the fixed path `PIGROCRM_E2E_API_PIDFILE`
+(`/tmp/pigrocrm-e2e-api.pid` by default) rather than through a per-checkout handle.
+With a second run alive on the same box, `helpers.ts`'s `killApi()` can read a pid
+that run already replaced or reaped and die on `kill ESRCH` at `helpers.ts:209`
+instead of the test it was meant to run — observed live on 2026-09-10 with several
+other agents' containers and dev servers on the same devbox, filed as ORB-91. Run
+`pigrocrm-e2e` one checkout at a time; the pidfile trap does not show up any other
+way.
+
 **Migrations live in `packages/core/migrations` with `alembic.ini` beside them**, and
 `tenants/service.py` finds that file from `pigrocrm.core.__file__` rather than from
 the checkout, so it works identically in the image. The API container runs

--- a/projects/website/AGENTS.md
+++ b/projects/website/AGENTS.md
@@ -61,3 +61,22 @@ the CRM or the hub and a redirect into production would make the suite depend on
 Playwright against `vite preview` on the fixed port 4173, which is why its preflight
 check is `serial: true`. A change to the rendered pages is not done until you have run
 it, and a visual claim needs a render, not a description.
+
+**Two checkouts cannot run that preview at the same time, and it fails loud rather
+than quiet.** `preview.strictPort` is `true` in `vite.config.ts`, so a second `pnpm
+preview` (or a second `pnpm test:e2e`, which chains `build && preview` itself) on a
+box already running one exits immediately: `error when starting preview server:
+Error: Port 4173 is already in use`, confirmed live by running `pnpm exec vite
+preview` against this project while another checkout's preview already held 4173.
+Three agents hit this on 2026-09-10 running the same day's issues in parallel
+checkouts. Wait for the other preview to exit, or run one checkout's e2e suite at a
+time; do not edit `vite.config.ts` or `playwright.config.ts` to move the port
+instead, and if you do to unblock yourself locally, revert it before committing —
+an uncommitted port override is easy to leave in.
+
+The hub's own `vite preview` (`projects/hub/apps/web`) has no `strictPort`, so it
+does not collide the same way: it finds the next free port instead and logs it,
+confirmed live as `4174` while 4173 was held. What it does not do is serve at `/`:
+the hub is built with `base: '/hub/'`, so its preview's root path 404s and the
+wizard pages are at `/hub/`, `/hub/freelance` and `/hub/aziende` — worth knowing
+before assuming a blank page means a broken build.


### PR DESCRIPTION
## What this changes

Today's two waves ran eleven parallel agents against this repo and three of them
separately lost time to the same undocumented fact, none of it written down
anywhere: the local verification commands bind fixed ports, so two checkouts
cannot run them at the same time. This adds that fact to `projects/website/AGENTS.md`
(website's e2e/preview both bind 4173 with `strictPort`, so a second checkout's
preview dies loud instead of queueing, and the trap of editing the config to move
the port and forgetting to revert it) and to `projects/pigrocrm/AGENTS.md`
(`resilience.spec.ts` tracks the API through a fixed pidfile path that a concurrent
run can overwrite, filed as ORB-91). It also notes that the hub's own preview has
no `strictPort`, so it silently moves to the next free port instead of colliding,
and that it serves under `/hub/` rather than `/`. No source file changes.

No Linear card for this: it is a documentation change recording what today's waves
cost, filed as a standalone PR by design.

## How I verified it

Built and ran both previews from a fresh checkout while another live agent held
4173:

```
$ pnpm exec vite preview   # projects/website, strictPort: true
error when starting preview server:
Error: Port 4173 is already in use

$ pnpm exec vite preview   # projects/hub/apps/web, no strictPort
Port 4173 is in use, trying another one...
  ➜  Local:   http://localhost:4174/hub/
```

That is the strictPort/no-strictPort contrast and the `/hub/` base path, both
observed live rather than guessed. For ORB-91, read `helpers.ts`'s `killApi()`
(reads the pid from `PIGROCRM_E2E_API_PIDFILE`, calls `process.kill`, no ESRCH
guard) against the issue's own stack trace, which matches line for line.

`preflight --list` on this docs-only diff selected `website-lint`, `website-unit`,
`website-build`, `website-types`, `website-e2e`, `website-image` and
`identity-names` (it path-matches the touched `projects/website/AGENTS.md`, which
pulls in the whole website project; nothing pigrocrm-specific was selected beyond
`identity-names`, matched on `projects/pigrocrm/AGENTS.md` too). I ran
`pnpm --filter website lint`, `pnpm --filter website test` (203 passed),
`pnpm --filter website build && pnpm --filter website exec tsc --noEmit`, and
`orbiters-identity-scan .` (clean against 28 names, 4 paths allowed), all green.
I did not run `website-e2e` or the `website-image` docker build: port 4173 was
genuinely held by another live agent on this shared box at the time, which is the
exact collision this PR documents, and running them serially against a live
neighbour would not have proven anything the commands above did not already.

## Anything a reviewer should look at twice

I put the hub's `/hub/` base-path note inside `projects/website/AGENTS.md` rather
than `projects/hub/AGENTS.md`, since my assignment scoped me to the website and
pigrocrm files only and the fact surfaced from the website's own preview
collision. If it reads better living in the hub's own file instead, that is a
one-paragraph move.

## Screenshots

Nothing visible changed; this is a documentation-only PR.
