### PR TITLE
docs(hub): the preview's base path belongs in the hub's own guide

### DIFF
--- a/projects/hub/AGENTS.md
+++ b/projects/hub/AGENTS.md
@@ -45,6 +45,14 @@ The tests bring a `testcontainers` Postgres to `head` with this package's migrat
 never with `create_all`: a table the model declares and the migration forgets fails
 here rather than on the server.
 
+**Its `vite preview` serves under `/hub/`, not `/`.** The web app is built with
+`base: '/hub/'`, so the preview's root path 404s and the wizard pages are at `/hub/`,
+`/hub/freelance` and `/hub/aziende`. A blank page at `/` is that, not a broken build.
+Unlike the website's, this preview has no `strictPort`, so a second checkout does not
+collide with the first: it takes the next free port and logs it, confirmed live as `4174`
+while another agent held 4173 on 2026-09-10. Read the port off its own output rather than
+assuming 4173.
+
 ## The database was inherited
 
 `signups` was created by PigroCRM's sidecar in production and holds real rows.

--- a/projects/website/AGENTS.md
+++ b/projects/website/AGENTS.md
@@ -73,10 +73,3 @@ checkouts. Wait for the other preview to exit, or run one checkout's e2e suite a
 time; do not edit `vite.config.ts` or `playwright.config.ts` to move the port
 instead, and if you do to unblock yourself locally, revert it before committing —
 an uncommitted port override is easy to leave in.
-
-The hub's own `vite preview` (`projects/hub/apps/web`) has no `strictPort`, so it
-does not collide the same way: it finds the next free port instead and logs it,
-confirmed live as `4174` while 4173 was held. What it does not do is serve at `/`:
-the hub is built with `base: '/hub/'`, so its preview's root path 404s and the
-wizard pages are at `/hub/`, `/hub/freelance` and `/hub/aziende` — worth knowing
-before assuming a blank page means a broken build.


### PR DESCRIPTION
## What this changes

PR #20 recorded that the hub's `vite preview` serves under `/hub/` and does not collide on a fixed port, but wrote it into `projects/website/AGENTS.md`, since the agent that measured it was scoped to the website and PigroCRM files. It is a fact about the hub, and the next person confused by a 404 at `/` will be reading the hub's guide, so I moved it there, under "Running it", and made it lead with the base path rather than with the comparison.

Nothing else changed: the website's own paragraph about `strictPort` and port 4173 stays where it is, because that one really is about the website.

## How I verified it

Documentation only, no code path touched. I read both files after the move and ran nothing else, since a docs diff has nothing to exercise.

## Anything a reviewer should look at twice

The hub paragraph now ends with "read the port off its own output rather than assuming 4173", which is the actionable half. If you would rather the whole port story lived in one place instead of one paragraph per project, say so and I will consolidate it into the root guide.

## Screenshots

Nothing visible changed: two documentation files.
