### PR TITLE
fix(hub): each wizard page carries one visually hidden h1 naming it

### DIFF
--- a/projects/hub/apps/web/src/wizard/Wizard.test.tsx
+++ b/projects/hub/apps/web/src/wizard/Wizard.test.tsx
@@ -81,6 +81,20 @@ describe('Wizard', () => {
     expect(onSubmit).toHaveBeenCalledTimes(1)
   })
 
+  it('carries exactly one level-one heading naming the wizard, on the step screen and on the review', async () => {
+    const user = userEvent.setup()
+    render(<Harness onSubmit={() => {}} />)
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
+    expect(screen.getByRole('heading', { level: 1, name: 'Test' })).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('Nome'), 'Ada{Enter}')
+    await user.type(screen.getByLabelText('Email'), 'ada@studio.it{Enter}')
+    expect(screen.getByRole('heading', { name: 'Tutto giusto?' })).toBeInTheDocument()
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
+    expect(screen.getByRole('heading', { level: 1, name: 'Test' })).toBeInTheDocument()
+  })
+
   it('goes back to the step a server error names', async () => {
     const user = userEvent.setup()
     const { rerender } = render(<Harness onSubmit={() => {}} />)

--- a/projects/hub/apps/web/src/wizard/Wizard.tsx
+++ b/projects/hub/apps/web/src/wizard/Wizard.tsx
@@ -105,6 +105,11 @@ export function Wizard<T>({
         next()
       }}
     >
+      {/* The page's single accessible heading (ORB-89): the design keeps the step
+          question as an `<h2>` and the review screen's «Tutto giusto?» as another,
+          so this names the wizard itself rather than promoting either -- visually
+          hidden because the breadcrumb below already says the same title out loud. */}
+      <h1 className="sr-only">{title}</h1>
       <div className="space-y-2">
         <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>{title}</span>

--- a/projects/hub/apps/web/src/wizard/Wizard.tsx
+++ b/projects/hub/apps/web/src/wizard/Wizard.tsx
@@ -108,11 +108,13 @@ export function Wizard<T>({
       {/* The page's single accessible heading (ORB-89): the design keeps the step
           question as an `<h2>` and the review screen's «Tutto giusto?» as another,
           so this names the wizard itself rather than promoting either -- visually
-          hidden because the breadcrumb below already says the same title out loud. */}
+          hidden because the breadcrumb below already shows the same title on
+          screen. That breadcrumb span carries `aria-hidden` so a screen reader
+          hears the title once, from this heading, rather than twice. */}
       <h1 className="sr-only">{title}</h1>
       <div className="space-y-2">
         <div className="flex items-center justify-between text-xs text-muted-foreground">
-          <span>{title}</span>
+          <span aria-hidden="true">{title}</span>
           <span aria-live="polite">
             {review ? 'Riepilogo' : `${index + 1} di ${steps.length}`}
           </span>


### PR DESCRIPTION
## What this changes

`/hub/freelance` and `/hub/aziende` had no `<h1>` at all: the step title rendered as an `<h2>`, so `document.querySelector('h1')` returned `null` on a real build, which axe reports as `page-has-heading-one`. `Wizard.tsx` now renders a page-level `<h1>` from the `title` prop, visually hidden (`sr-only`) so the design stays exactly as it is: the step question stays an `<h2>` and so does the review screen's «Tutto giusto?». It renders outside the step/review conditional, so both states carry the same single `<h1>`, reading «Entra in Orbiters» on `/hub/freelance` and «Cerchi persone» on `/hub/aziende`, which is already what each page's `title` prop said. The chooser and the thanks page already had their own visible `<h1>` and are untouched.

## How I verified it

- `pnpm --filter hub test`: 27 passed (6 files), including the new `Wizard.test.tsx` assertion.
- Proved the new test is the regression guard: reverted the `Wizard.tsx` change with the test in place, `vitest run src/wizard/Wizard.test.tsx` failed (1 failed, 2 passed, `getAllByRole('heading', { level: 1 })` found none); restored the fix, same command passed 3/3.
- `pnpm --filter hub lint` and `pnpm --filter hub build` both clean; `preflight` selected `identity-names`, `hub-web-unit`, `hub-web-lint`, `hub-web-build`, all four passed.
- Real build, not a dev server: `pnpm --filter hub build` then `vite preview --port 34211 --strictPort`, driven with a headless browser.
  - `document.querySelectorAll('h1')` has length 1 on every public page, with the accessible name each should carry: `/hub/freelance` → «Entra in Orbiters» (`sr-only`), `/hub/aziende` → «Cerchi persone» (`sr-only`), `/hub/` → «Chi sei?», `/hub/grazie?chi=freelance` → «Grazie, sei dentro.», `/hub/grazie?chi=azienda` → «Grazie, ci siamo.».
  - Filled the `/hub/aziende` wizard through to the review screen: still exactly one `<h1>` («Cerchi persone», `sr-only`) alongside the review's own `<h2>` («Tutto giusto?»).
  - `uishot --axe --fail-on serious` at `390x844` and `1440x900`: clean (`"violations": []`, exit 0) on `/hub/freelance`, `/hub/aziende`, `/hub/`, and the thanks page in their initial state.

## Anything a reviewer should look at twice

Running the same axe check against `/hub/aziende` once the review screen is reached (not required by this card, but it is the same file) surfaces a pre-existing `serious` `definition-list` violation unrelated to this fix: the review `<dl>`'s row `<div>` holds a `<button>` alongside its `<dt>`/`<dd>`, which axe does not allow as a direct child. It predates this change, is not part of ORB-89's scope («the single missing `<h1>`, not an accessibility pass»), and I filed it separately as ORB-96 rather than fold it in here.

## Screenshots

Nothing visible changed: the new `<h1>` is `sr-only` by design, so the two wizard pages render pixel-identical to `main`. Verified by the visual axe/DOM pass above rather than a screenshot pair.

Linear: ORB-89.

