### PR TITLE
fix(hub): the review screen's answers wrap on words at 390px

### DIFF
--- a/projects/hub/apps/web/src/wizard/Wizard.tsx
+++ b/projects/hub/apps/web/src/wizard/Wizard.tsx
@@ -144,14 +144,17 @@ export function Wizard<T>({
           </div>
           <dl className="divide-y rounded-2xl border bg-card">
             {steps.map((candidate, at) => (
-              <div key={candidate.id} className="flex items-start gap-4 px-4 py-3 text-sm">
-                <dt className="w-40 shrink-0 text-muted-foreground">{candidate.title}</dt>
-                <dd className="min-w-0 flex-1 break-words font-medium">
+              <div
+                key={candidate.id}
+                className="flex flex-col gap-1 px-4 py-3 text-sm sm:flex-row sm:items-start sm:gap-4"
+              >
+                <dt className="text-muted-foreground sm:w-40 sm:shrink-0">{candidate.title}</dt>
+                <dd className="break-words font-medium sm:min-w-0 sm:flex-1">
                   {candidate.summary(value) || '—'}
                 </dd>
                 <button
                   type="button"
-                  className="shrink-0 text-xs text-muted-foreground underline-offset-2 hover:underline"
+                  className="self-start text-xs text-muted-foreground underline-offset-2 hover:underline sm:shrink-0"
                   onClick={() => {
                     setError(null)
                     setIndex(at)

--- a/projects/hub/apps/web/src/wizard/Wizard.tsx
+++ b/projects/hub/apps/web/src/wizard/Wizard.tsx
@@ -154,7 +154,7 @@ export function Wizard<T>({
                 </dd>
                 <button
                   type="button"
-                  className="self-start text-xs text-muted-foreground underline-offset-2 hover:underline sm:shrink-0"
+                  className="mt-1 self-start text-xs text-muted-foreground underline-offset-2 hover:underline sm:mt-0 sm:shrink-0"
                   onClick={() => {
                     setError(null)
                     setIndex(at)


### PR DESCRIPTION
## What this changes

On the review step ("Tutto giusto?") of both wizards, at 390px, every answer longer than a couple of characters wrapped one character per line: the review `<dl>`'s row was a fixed-width flex row (a 160px `dt` column plus a 16px gap), which at 390px left almost no room for the `dd` value, so `break-words` gave up on word boundaries and broke mid-character. "Ada Lovelace" rendered as six stacked lines.

The row now stacks below `sm:` (640px, the breakpoint this file already uses elsewhere: `sm:grid-cols-2` on other steps): label above value, full width, so a value wraps on word boundaries, with its own top margin ahead of the "Modifica" control so the two read as separate lines rather than a third line of the answer. At `sm:` and up the row goes back to being the original fixed-width flex row, since there was always enough room there. Nothing about the CV, LinkedIn or links fields changed, and no raw pixel or colour value was introduced: the fix is entirely Tailwind's own breakpoint and spacing-scale utilities.

## How I verified it

- `pnpm --filter hub test`: 27 passed (6 files, unchanged). No new unit test: jsdom has no real layout engine, so `getClientRects()` on a wrapped value there is always a single zero-size box regardless of the fix — an assertion on it would not exercise anything real. Verified instead against two live dev servers on the same commit range, one on `main` and one on this branch, both on `/hub/aziende`'s review screen with the same data.
- **Word-boundary wrap, measured, not eyeballed.** Filled the company wizard through to review (`Referente`: "Ada Lovelace") and used a DOM `Range` around just that substring inside its `<dd>` to count wrapped lines via `getClientRects()`, at 390px: **6 lines before, 1 line after.**
- **Nothing moves at 1440.** Same review screen, same data, at 1440x900: `dt`/`dd`/`button` `getBoundingClientRect()` for every one of the five rows is pixel-identical before and after (same `x`, `y`, `width`, `height` down to the sub-pixel).
- `pnpm --filter hub lint` and `pnpm --filter hub build` clean; `preflight` selected `identity-names`, `hub-web-unit`, `hub-web-lint`, `hub-web-build`, all four passed.

## Anything a reviewer should look at twice

The row's "Modifica" button now sits below the value on a stacked row rather than to its right, since it is a sibling of `dt`/`dd` inside the same flex container and there was no room to keep it beside a value that now wants the full width. This is a byproduct of the minimal fix, not something the card asked for; ORB-96 (filed from ORB-89's review) is a different, pre-existing defect about the same button's placement inside the `<dl>` for axe's `definition-list` rule, unrelated to this layout change and not addressed here.

## Screenshots

**1. Review screen at 390px: "Ada Lovelace" and every other answer, before and after**
![Review screen wrap, mobile, before and after](https://github.com/user-attachments/assets/6944be89-c1b9-48ea-845f-ff6b8bc54847)

**2. Review screen at 1440px: unchanged**
![Review screen, desktop, before and after](https://github.com/user-attachments/assets/ae2014bd-3928-4ec9-ac1c-a2c3b89a466c)

Linear: ORB-93.
