### PR TITLE
feat(web): the invoice list says which customer each row belongs to

### DIFF
--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoicesTab.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoicesTab.test.tsx
@@ -33,6 +33,15 @@ describe('InvoicesTab', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 
+  /** Every row on this tab belongs to the customer (or the deal's customer) named in
+   *  the page title above it, so the «Cliente» column the list page shows (ORB-98) would
+   *  only repeat that title on each line. */
+  it('does not repeat the customer on every row', async () => {
+    renderWithClient(<InvoicesTab owner={{ customerId: 'c1' }} />)
+    expect(await screen.findByRole('columnheader', { name: 'Numero' })).toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Cliente' })).not.toBeInTheDocument()
+  })
+
   /**
    * The slot exists so the button that creates an invoice sits on the tab that lists
    * them, rather than in the page header where it would be offered from every other tab

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { describe, expect, it } from 'vitest'
-import { buildInvoiceColumns } from './columns'
+import { buildInvoiceColumns, type InvoiceColumnOptions } from './columns'
 import type { Invoice } from './queries'
 
 const ISSUED = {
@@ -26,8 +26,10 @@ const PROFORMA = {
   totale: '500.00',
 } as unknown as Invoice
 
-function accessor(id: string, row: Invoice): unknown {
-  const column = buildInvoiceColumns().find((candidate) => candidate.id === id)
+const WITH_CUSTOMER = { ...ISSUED, customer_ragione_sociale: 'ACME S.r.l.' } as Invoice
+
+function accessor(id: string, row: Invoice, options?: InvoiceColumnOptions): unknown {
+  const column = buildInvoiceColumns(options).find((candidate) => candidate.id === id)
   if (column === undefined || !('accessorFn' in column) || column.accessorFn === undefined) {
     throw new Error(`nessuna colonna con id ${id}`)
   }
@@ -65,16 +67,16 @@ describe('buildInvoiceColumns', () => {
  * date, a right-aligned figure, a state as a dotted pill (design spec §4). Only
  * `row.original` is consulted by these cells, so the cast supplies exactly that.
  */
-function renderCell(id: string, row: Invoice) {
-  const column = buildInvoiceColumns().find((candidate) => candidate.id === id)
+function renderCell(id: string, row: Invoice, options?: InvoiceColumnOptions) {
+  const column = buildInvoiceColumns(options).find((candidate) => candidate.id === id)
   if (column === undefined || typeof column.cell !== 'function') {
     throw new Error(`la colonna ${id} non ha un cell renderer`)
   }
   return render(column.cell({ row: { original: row } } as never) as ReactElement)
 }
 
-function column(id: string) {
-  const found = buildInvoiceColumns().find((candidate) => candidate.id === id)
+function column(id: string, options?: InvoiceColumnOptions) {
+  const found = buildInvoiceColumns(options).find((candidate) => candidate.id === id)
   if (found === undefined) throw new Error(`nessuna colonna con id ${id}`)
   return found
 }
@@ -139,5 +141,54 @@ describe('how an invoice row reads', () => {
     const { container } = renderCell('stato_pagamento', PROFORMA)
     expect(screen.getByText('—')).toBeInTheDocument()
     expect(container.querySelector('[data-slot="badge"]')).toBeNull()
+  })
+})
+
+/**
+ * The «Cliente» column (ORB-98). Opt-in, because the same columns draw the Fatture tab
+ * inside a customer's page, where every row belongs to the customer named in the title:
+ * a column repeating it on each line would be noise there and information only on the
+ * list page, which is the one screen that mixes customers.
+ */
+describe('the customer column', () => {
+  const CLIENTE = { cliente: true }
+
+  function ids(options?: InvoiceColumnOptions): string[] {
+    return buildInvoiceColumns(options).map((candidate) => candidate.id ?? '')
+  }
+
+  it('is not part of the default columns', () => {
+    expect(ids()).not.toContain('cliente')
+  })
+
+  it('sits right after the number when asked for', () => {
+    const columns = ids(CLIENTE)
+    expect(columns.indexOf('cliente')).toBe(columns.indexOf('numero') + 1)
+  })
+
+  it('reads the ragione sociale the API resolved for the row', () => {
+    expect(column('cliente', CLIENTE).header).toBe('Cliente')
+    expect(accessor('cliente', WITH_CUSTOMER, CLIENTE)).toBe('ACME S.r.l.')
+  })
+
+  /** `customer_ragione_sociale` is `str | None` on the server: the association always
+   *  exists, the name may fail to resolve. That reads as the same dash every other
+   *  empty cell shows, never as an empty string a reader could mistake for a customer
+   *  with no name -- and `''`, which `ragione_sociale` can legitimately hold, reads the
+   *  same way. */
+  it('shows the em dash when the name did not resolve or is empty', () => {
+    const unresolved = { ...ISSUED, customer_ragione_sociale: null } as Invoice
+    const blank = { ...ISSUED, customer_ragione_sociale: '' } as Invoice
+    expect(accessor('cliente', unresolved, CLIENTE)).toBe('—')
+    expect(accessor('cliente', blank, CLIENTE)).toBe('—')
+    expect(accessor('cliente', ISSUED, CLIENTE)).toBe('—')
+  })
+
+  it('renders the name as plain text and the missing name as a quiet dash', () => {
+    renderCell('cliente', WITH_CUSTOMER, CLIENTE)
+    expect(screen.getByText('ACME S.r.l.')).toBeInTheDocument()
+
+    renderCell('cliente', ISSUED, CLIENTE)
+    expect(screen.getByText('—').className).toContain('text-muted-foreground')
   })
 })

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
@@ -14,7 +14,53 @@ import {
 
 const EMPTY = '—'
 
-export function buildInvoiceColumns(): ColumnDef<DataTableFeatures, Invoice>[] {
+/**
+ * `cliente` adds the «Cliente» column (ORB-98). Opt-in rather than always there because
+ * the same columns draw two screens: the list page, which mixes every customer's
+ * invoices and is where a row has to say whose it is, and the Fatture tab inside a
+ * customer's or a deal's page, where every row belongs to the customer already named in
+ * the title and the column would only repeat it on each line.
+ */
+export interface InvoiceColumnOptions {
+  cliente?: boolean
+}
+
+/**
+ * The name the API resolved for the row, or the dash. `customer_ragione_sociale` is
+ * `str | None` on the server: the association always exists (`customer_id` is NOT NULL),
+ * the name may fail to resolve, and that reads as the same em dash every other empty
+ * cell shows rather than as an empty string a reader could take for a nameless customer.
+ * `''` gets the same dash: `ragione_sociale` is a `SafeStr` with no minimum length, so an
+ * empty name is a value the column can legitimately hold, and a blank cell would read as
+ * a rendering fault rather than as what it is.
+ */
+function customerName(row: Invoice): string {
+  const name = row.customer_ragione_sociale
+  return name === null || name === undefined || name === '' ? EMPTY : name
+}
+
+export function buildInvoiceColumns(
+  options: InvoiceColumnOptions = {},
+): ColumnDef<DataTableFeatures, Invoice>[] {
+  const cliente: ColumnDef<DataTableFeatures, Invoice>[] = options.cliente
+    ? [
+        {
+          header: 'Cliente',
+          id: 'cliente',
+          accessorFn: (row) => customerName(row),
+          // Plain text, like «Tipo»: the table is auto-layout and `TableCell` already
+          // says `whitespace-nowrap`, so a long name widens its column and the table
+          // scrolls inside its frame, the way every other text column here behaves. A
+          // `truncate` on an inline span in a `<td>` with no width would promise an
+          // ellipsis the DOM cannot deliver.
+          cell: ({ row }) => {
+            const name = customerName(row.original)
+            return name === EMPTY ? <span className="text-muted-foreground">{EMPTY}</span> : name
+          },
+        },
+      ]
+    : []
+
   return [
     {
       header: 'Numero',
@@ -24,6 +70,7 @@ export function buildInvoiceColumns(): ColumnDef<DataTableFeatures, Invoice>[] {
       // `formatInvoiceNumber` cannot derive a reference from a number.
       accessorFn: (row) => formatInvoiceNumber(row),
     },
+    ...cliente,
     {
       header: 'Tipo',
       id: 'tipo',

--- a/projects/pigrocrm/apps/web/src/lib/api-types.ts
+++ b/projects/pigrocrm/apps/web/src/lib/api-types.ts
@@ -1783,7 +1783,8 @@ export interface paths {
          * Period Pnl
          * @description Two columns, closed deals and deals in progress. There is deliberately no combined
          *     total: adding a finished job's margin to a half-done one produces a figure that is
-         *     neither.
+         *     neither. `base` picks which of the two readings of revenue the report gives
+         *     (ORB-61); everything else about it is the same.
          */
         get: operations["period_pnl_api_analytics_pnl_get"];
         put?: never;
@@ -2365,36 +2366,6 @@ export interface paths {
         get: operations["runs_api_automation_runs_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/orbiters/signups": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Subscribe
-         * @description 201 and `{"ok": true}`, whether the address was new or already on the list.
-         *
-         *     The person is on the list either way, which is the only thing the page says and the
-         *     only thing this answers: telling a caller *which* of the two happened is telling
-         *     them whether an address they do not own is a subscriber.
-         *
-         *     The ad conversion is measured after the answer, never before it: see
-         *     `_measure_the_conversion`. It is scheduled even for an address already on the list,
-         *     because the browser fires its own event on the same submit and the two carry one id
-         *     -- suppressing the server half would not remove that event, it would only remove the
-         *     half that survives an ad blocker.
-         */
-        post: operations["subscribe_api_orbiters_signups_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4682,18 +4653,14 @@ export interface components {
             tipo: "fattura" | "proforma";
             /** Causale */
             causale?: string | null;
+            /** Note Interne */
+            note_interne?: string | null;
+            /** Data Emissione */
+            data_emissione?: string | null;
             /** Competenza Da */
             competenza_da?: string | null;
             /** Competenza A */
             competenza_a?: string | null;
-            /**
-             * Data Emissione
-             * @description The proforma's own document date; refused on a fattura, whose date is
-             *     assigned at emission. Defaults to today.
-             */
-            data_emissione?: string | null;
-            /** Note Interne */
-            note_interne?: string | null;
             /** Righe */
             righe?: components["schemas"]["InvoiceLineIn"][];
             /**
@@ -4716,8 +4683,8 @@ export interface components {
          *     of it: the stamp duty is declared alongside, validated non-negative, and never added
          *     to the total. `DatiBollo/BolloVirtuale` says the issuer settled it virtually (slice 3
          *     §6.1 rule 4 and §7.2), which is why `sum_totals` stores the same identity for a
-         *     natively issued invoice -- and the previous system's own register agrees: its «Totale» column always
-         *     equals «Imp. Reddito».
+         *     natively issued invoice -- and the previous system's own register agrees: its «Totale» column
+         *     always equals «Imp. Reddito».
          *
          *     No `riferimento`: `invoices.riferimento` is constrained by
          *     `ck_invoices_riferimento_only_on_proforma` to `NULL` on every `tipo = 'fattura'`
@@ -4745,6 +4712,10 @@ export interface components {
             deal_id?: string | null;
             /** Causale */
             causale?: string | null;
+            /** Competenza Da */
+            competenza_da?: string | null;
+            /** Competenza A */
+            competenza_a?: string | null;
             /** Righe */
             righe: components["schemas"]["InvoiceLineImport"][];
             /** Imponibile */
@@ -4977,6 +4948,8 @@ export interface components {
             note_interne: string | null;
             /** Snapshot Versione */
             snapshot_versione: number | null;
+            /** Customer Ragione Sociale */
+            customer_ragione_sociale?: string | null;
             /** Custom Fields */
             custom_fields: {
                 [key: string]: unknown;
@@ -5002,30 +4975,32 @@ export interface components {
         };
         /**
          * InvoiceUpdate
-         * @description Only what stays mutable after emission (spec 4).
+         * @description What a draft may still change, and what stays mutable after emission (spec 4).
          *
-         *     Everything typed and clearable is absent, which removes the A14 shape from this
-         *     surface instead of reproducing it: lines are replaced in bulk, `stato_pagamento`
-         *     and `data_incasso` go through `set_payment_state`, and `stato` goes through
-         *     `issue`/`annul`. Both native fields here are text-shaped, so `""` is a real
-         *     "clear it" spelling for each.
+         *     Lines are replaced in bulk, `stato_pagamento` and `data_incasso` go through
+         *     `set_payment_state`, and `stato` goes through `issue`/`annul`. `supplied_changes`
+         *     reads this with `exclude_unset`, so an explicit `null` clears a column and an omitted
+         *     key leaves it alone -- which is what lets the three `date` columns sit here without
+         *     reproducing A14.
          *
-         *     `causale` is on this schema because a draft has to be correctable before it is
-         *     issued, and it is frozen afterwards by `InvoiceService.update`, which raises
-         *     `ImmutableField` -- not by leaving it off the schema, which would have made a
-         *     draft's own subject line unfixable.
+         *     `causale`, the accrual period and a proforma's `data_emissione` are on this schema
+         *     because a draft has to be correctable before it is issued, and they are frozen
+         *     afterwards by `InvoiceService.update`, which raises `ImmutableField` -- not by
+         *     leaving them off the schema, which would have made a draft's own subject line
+         *     unfixable. The period is cleared as a pair and a proforma's date is never cleared;
+         *     a fattura's `data_emissione` is refused here outright, since `issue` owns it.
          */
         InvoiceUpdate: {
             /** Causale */
             causale?: string | null;
+            /** Note Interne */
+            note_interne?: string | null;
+            /** Data Emissione */
+            data_emissione?: string | null;
             /** Competenza Da */
             competenza_da?: string | null;
             /** Competenza A */
             competenza_a?: string | null;
-            /** Data Emissione */
-            data_emissione?: string | null;
-            /** Note Interne */
-            note_interne?: string | null;
             /** Custom Fields */
             custom_fields?: {
                 [key: string]: unknown;
@@ -5248,6 +5223,11 @@ export interface components {
             a: string;
             /** Customer Id */
             customer_id: string | null;
+            /**
+             * Base
+             * @enum {string}
+             */
+            base: "emissione" | "competenza";
             chiusi: components["schemas"]["PnlTotals"];
             in_corso: components["schemas"]["PnlTotals"];
             /** Spese Generali */
@@ -5661,61 +5641,6 @@ export interface components {
             /** Collegamento */
             collegamento: string | null;
         };
-        /**
-         * SignupAck
-         * @description What the public POST answers, and all it answers: the request was accepted.
-         *
-         *     The same body and the same 201 for a first signup and for the hundredth, so the
-         *     reply does not say whether the address was already on the list either. The landing
-         *     needs nothing more -- it branches on the status alone -- and anything more would be
-         *     readable by anyone who can guess an email address.
-         */
-        SignupAck: {
-            /**
-             * Ok
-             * @default true
-             */
-            ok: boolean;
-        };
-        /** SignupCreate */
-        SignupCreate: {
-            /**
-             * Email
-             * Format: email
-             */
-            email: string;
-            /** Nome */
-            nome: string;
-            /** Cognome */
-            cognome: string;
-            /** Linkedin Url */
-            linkedin_url?: string | null;
-            utm?: components["schemas"]["SignupUtm"] | null;
-            /** Pixel Event Id */
-            pixel_event_id?: string | null;
-            /** Oppref */
-            oppref?: string | null;
-        };
-        /**
-         * SignupUtm
-         * @description The attribution the landing read from its own URL, if any. Every key optional and
-         *     bounded: an ad platform's macro left unexpanded (`{{AD_SET_ID}}`) is stored as the
-         *     literal it arrived as, because that is what happened.
-         */
-        SignupUtm: {
-            /** Utm Source */
-            utm_source?: string | null;
-            /** Utm Medium */
-            utm_medium?: string | null;
-            /** Utm Campaign */
-            utm_campaign?: string | null;
-            /** Utm Content */
-            utm_content?: string | null;
-            /** Utm Term */
-            utm_term?: string | null;
-            /** Utm Id */
-            utm_id?: string | null;
-        };
         /** SollecitiPage */
         SollecitiPage: {
             /** Items */
@@ -5736,8 +5661,8 @@ export interface components {
          *     sum recomputed at reminder time: a demand for payment that names a figure the
          *     client's copy of the invoice does not carry is a demand they are right to ignore.
          *
-         *     `ultima_risposta_il` is the signal the previous system could not have had, and it is `None` on an
-         *     installation with no mailbox connected -- the honest degradation, not a claim that
+         *     `ultima_risposta_il` is the signal the previous system could not have had, and it is `None` on
+         *     an installation with no mailbox connected -- the honest degradation, not a claim that
          *     nobody replied.
          */
         SollecitoCandidate: {
@@ -21914,10 +21839,7 @@ export interface operations {
                 /** @description Fine del periodo, YYYY-MM-DD */
                 to: string;
                 customer_id?: string | null;
-                /**
-                 * @description Data a cui attribuire i ricavi: `emissione` (la data della fattura) o `competenza` (il periodo di competenza, quando c'è)
-                 * @default emissione
-                 */
+                /** @description Quale data colloca il ricavo di una fattura nel periodo: 'emissione' (la data del documento, predefinita) oppure 'competenza' (il periodo di competenza dichiarato sulla fattura, con la data di emissione per chi non lo dichiara). Costi e ore restano attribuiti alla propria data. */
                 base?: "emissione" | "competenza";
             };
             header?: never;
@@ -25865,127 +25787,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AutomationRun"][];
-                };
-            };
-            /** @description Permesso negato: l'actor non ha il ruolo richiesto. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** Type */
-                        type: string;
-                        /** Title */
-                        title: string;
-                        /** Status */
-                        status: number;
-                        /** Detail */
-                        detail: string;
-                        /** Code */
-                        code: string;
-                        /** Instance */
-                        instance: string;
-                    } & {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description La risorsa richiesta non esiste o è stata rimossa. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** Type */
-                        type: string;
-                        /** Title */
-                        title: string;
-                        /** Status */
-                        status: number;
-                        /** Detail */
-                        detail: string;
-                        /** Code */
-                        code: string;
-                        /** Instance */
-                        instance: string;
-                    } & {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description La richiesta è in conflitto con lo stato attuale della risorsa. */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** Type */
-                        type: string;
-                        /** Title */
-                        title: string;
-                        /** Status */
-                        status: number;
-                        /** Detail */
-                        detail: string;
-                        /** Code */
-                        code: string;
-                        /** Instance */
-                        instance: string;
-                    } & {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Una regola di dominio non è stata rispettata (application/problem+json), oppure il corpo, i parametri o il path della richiesta non hanno la forma attesa e non hanno mai raggiunto l'endpoint (application/json). */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** Type */
-                        type: string;
-                        /** Title */
-                        title: string;
-                        /** Status */
-                        status: number;
-                        /** Detail */
-                        detail: string;
-                        /** Code */
-                        code: string;
-                        /** Instance */
-                        instance: string;
-                    } & {
-                        [key: string]: unknown;
-                    };
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    subscribe_api_orbiters_signups_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SignupCreate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SignupAck"];
                 };
             };
             /** @description Permesso negato: l'actor non ha il ruolo richiesto. */

--- a/projects/pigrocrm/apps/web/src/routes/app/fatture/index.test.tsx
+++ b/projects/pigrocrm/apps/web/src/routes/app/fatture/index.test.tsx
@@ -119,6 +119,35 @@ describe('the invoice list', () => {
     expect(within(filters).getByLabelText('Filtra per tipo')).toBeInTheDocument()
   })
 
+  /** The list is the one screen that mixes customers, so it is the one that says whose
+   *  invoice each row is (ORB-98). The tab inside a customer's page does not: see
+   *  `InvoicesTab.test.tsx`. */
+  it('says which customer each invoice belongs to', async () => {
+    mockGet.mockImplementation(((path: string) =>
+      path === '/api/invoices'
+        ? ok({
+            items: [
+              {
+                id: 'f1',
+                anno: 2026,
+                numero: 7,
+                riferimento: null,
+                tipo: 'fattura',
+                stato: 'emessa',
+                stato_pagamento: 'da_incassare',
+                data_emissione: '2026-08-20',
+                totale: '1500.00',
+                customer_ragione_sociale: 'ACME S.r.l.',
+              },
+            ],
+            next_cursor: null,
+          })
+        : ok({ items: [], next_cursor: null })) as never)
+    renderList()
+    expect(await screen.findByRole('columnheader', { name: 'Cliente' })).toBeInTheDocument()
+    expect(screen.getByRole('cell', { name: 'ACME S.r.l.' })).toBeInTheDocument()
+  })
+
   it('still explains the «scadute» drill-through it arrives with', async () => {
     renderList(true)
     expect(await screen.findByRole('status')).toHaveTextContent(/scadute e non incassate/i)

--- a/projects/pigrocrm/apps/web/src/routes/app/fatture/index.tsx
+++ b/projects/pigrocrm/apps/web/src/routes/app/fatture/index.tsx
@@ -70,7 +70,10 @@ export function InvoicesList({ scadute }: { scadute?: boolean }) {
     scadute,
   })
 
-  const columns = buildInvoiceColumns()
+  // With the customer: this is the one screen that mixes every customer's invoices, so
+  // a row has to say whose it is (ORB-98). The Fatture tab on a customer's or a deal's
+  // page draws the same columns without it -- see `InvoicesTab`.
+  const columns = buildInvoiceColumns({ cliente: true })
 
   return (
     <>

--- a/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/repository.py
+++ b/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/repository.py
@@ -9,6 +9,7 @@ MCP exclusion list at exactly four names, so a new public method on `InvoiceServ
 force either a new tool or an edit to another slice's declared list.
 """
 
+from collections.abc import Collection
 from datetime import date
 from decimal import Decimal
 from typing import cast
@@ -17,6 +18,7 @@ from uuid import UUID
 from sqlalchemy import ColumnElement, delete, distinct, func, select, text
 from sqlalchemy.orm import Session
 
+from pigrocrm.core.customers.models import Customer
 from pigrocrm.core.db import today_local
 from pigrocrm.core.deals.models import Deal
 from pigrocrm.core.invoices.models import (
@@ -384,6 +386,29 @@ class InvoiceRepository:
                 .limit(limit)
             ).scalars()
         )
+
+    def customer_names(self, customer_ids: Collection[UUID]) -> dict[UUID, str]:
+        """The `ragione_sociale` of each given customer, in one query.
+
+        The same method, for the same reason, as `DealRepository.customer_names`: one
+        statement for a whole page rather than one per row, so a 50-row invoice list costs
+        two queries and never fifty-one. A label lookup for rows already chosen, run after
+        the limit.
+
+        No `deleted_at` filter, deliberately, and here it matters more than for deals: an
+        issued invoice outlives the customer relationship, and `CustomerService.soft_delete`
+        may archive a customer whose invoices stay in the register. An archived customer's
+        name is still the name on those invoices; filtering it out would print a dash on
+        rows that have a perfectly good one.
+
+        An empty input short-circuits: `IN ()` is a query with no possible rows.
+        """
+        if not customer_ids:
+            return {}
+        rows = self.session.execute(
+            select(Customer.id, Customer.ragione_sociale).where(Customer.id.in_(customer_ids))
+        ).all()
+        return {row[0]: row[1] for row in rows}
 
     # `list` must stay the last method defined in this class -- an unconditional
     # project rule (`test_module_imports.py`). Defining a method named `list` rebinds

--- a/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/schemas.py
+++ b/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/schemas.py
@@ -455,6 +455,20 @@ class InvoiceRead(BaseModel):
     motivo_annullamento: str | None
     note_interne: str | None
     snapshot_versione: int | None
+    # The customer's `ragione_sociale`, denormalised onto the read shape exactly as
+    # `DealRead.customer_ragione_sociale` is (ORB-98): the name lives on `customers` and
+    # renaming a customer must not need a second write here. `InvoiceService._read`
+    # fills it from one batched lookup per page (`InvoiceRepository.customer_names`),
+    # which is why the default is `None` -- a bare `model_validate(invoice)` reads an
+    # `Invoice` that has no such attribute at all.
+    #
+    # Typed `str | None` although `invoices.customer_id` is NOT NULL: the association
+    # always exists, but this schema validates whatever the lookup found, and a name that
+    # could not be resolved must read as absent rather than crash the whole page.
+    #
+    # Read-only: on no Create, Update or Import schema, so `native_fields`
+    # (schema_registry.py derives it from the Create schema) never lists it either.
+    customer_ragione_sociale: str | None = None
     custom_fields: dict[str, Any]
     created_at: datetime
     updated_at: datetime

--- a/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/service.py
+++ b/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/service.py
@@ -444,7 +444,7 @@ class InvoiceService:
             {"tipo": invoice.tipo, "righe": len(computed), "totale": str(invoice.totale)},
         )
         self.session.commit()
-        return InvoiceRead.model_validate(invoice)
+        return self._read(invoice)
 
     def update(self, invoice_id: UUID, data: InvoiceUpdate, actor: Actor) -> InvoiceRead:
         actor.require_write("update_invoice")
@@ -487,7 +487,7 @@ class InvoiceService:
             setattr(invoice, key, value)
         self.activities.record(ENTITY, invoice.id, "updated", actor, {"changed": sorted(changes)})
         self.session.commit()
-        return InvoiceRead.model_validate(invoice)
+        return self._read(invoice)
 
     def replace_lines(
         self, invoice_id: UUID, righe: list[InvoiceLineIn], actor: Actor
@@ -518,7 +518,7 @@ class InvoiceService:
             {"righe": len(computed), "totale": str(invoice.totale)},
         )
         self.session.commit()
-        return InvoiceRead.model_validate(invoice)
+        return self._read(invoice)
 
     def confirm_proforma(self, invoice_id: UUID, actor: Actor) -> InvoiceRead:
         """`bozza` -> `confermata` on a proforma: the amount is agreed and the document
@@ -545,7 +545,7 @@ class InvoiceService:
         invoice.stato = "confermata"
         self.activities.record(ENTITY, invoice.id, "confirmed", actor)
         self.session.commit()
-        return InvoiceRead.model_validate(invoice)
+        return self._read(invoice)
 
     def soft_delete(self, invoice_id: UUID, actor: Actor) -> None:
         """Only what never consumed a number, and never a `consumata` proforma.
@@ -639,7 +639,7 @@ class InvoiceService:
             {"stato_pagamento": invoice.stato_pagamento},
         )
         self.session.commit()
-        return InvoiceRead.model_validate(invoice)
+        return self._read(invoice)
 
     def _party_from_customer(self, customer: Customer) -> PartySnapshot:
         return PartySnapshot(
@@ -1030,7 +1030,7 @@ class InvoiceService:
         # `produce_artifacts` next -- which is idempotent and regenerates from the
         # snapshot, so a crash between the two leaves an invoice that is fiscally
         # complete and merely unprinted.
-        return InvoiceRead.model_validate(target)
+        return self._read(target)
 
     def import_issued(self, data: InvoiceImport, actor: Actor) -> InvoiceRead:
         """Register a fattura that another system issued (slice 9 §3).
@@ -1708,7 +1708,7 @@ class InvoiceService:
             {"numero": invoice.numero, "anno": invoice.anno, "motivo": data.motivo},
         )
         self.session.commit()
-        return InvoiceRead.model_validate(invoice)
+        return self._read(invoice)
 
     def _check_transmission_date(self, quando: date, data_emissione: date | None) -> None:
         """The two facts a delivery date has to satisfy: not in the future, not before the
@@ -1770,7 +1770,7 @@ class InvoiceService:
             ENTITY, invoice.id, "transmitted_externally", actor, {"data": data.data.isoformat()}
         )
         self.session.commit()
-        return InvoiceRead.model_validate(invoice)
+        return self._read(invoice)
 
     def _for_export(self, invoice: Invoice) -> InvoiceForExport:
         """The frozen view the exporter and the PDF read. Never the live profiles.
@@ -2147,7 +2147,32 @@ class InvoiceService:
     # ---- reads ---------------------------------------------------------------
 
     def get(self, invoice_id: UUID, actor: Actor) -> InvoiceRead:
-        return InvoiceRead.model_validate(self._require(invoice_id))
+        return self._read(self._require(invoice_id))
+
+    def _read(self, invoice: Invoice) -> InvoiceRead:
+        """The one place an `Invoice` becomes an `InvoiceRead`, so every path -- a
+        mutation's answer, `get`, `list` -- hands back the same shape, the customer's name
+        included. Mirrors `DealService._read`."""
+        return self._reads([invoice])[0]
+
+    def _reads(self, invoices: Sequence[Invoice]) -> list[InvoiceRead]:
+        """The batched form, and the reason `customer_ragione_sociale` is resolved here
+        and not inside `InvoiceRead` itself: one lookup for the whole page
+        (`InvoiceRepository.customer_names`), so a page of invoices costs two queries
+        rather than one per row. A schema-level validator or a lazy ORM relationship would
+        both put the lookup on the row, which is exactly the N+1 this avoids.
+
+        `model_copy` and not a second `model_validate`: the name is not an attribute of
+        `Invoice` at all, so there is nothing on the ORM object for `from_attributes` to
+        read -- and the value comes from a `String` column, already the right type.
+        """
+        names = self.repo.customer_names({invoice.customer_id for invoice in invoices})
+        return [
+            InvoiceRead.model_validate(invoice).model_copy(
+                update={"customer_ragione_sociale": names.get(invoice.customer_id)}
+            )
+            for invoice in invoices
+        ]
 
     def lines(self, invoice_id: UUID, actor: Actor) -> list[InvoiceLineRead]:
         self._require(invoice_id)
@@ -2168,7 +2193,7 @@ class InvoiceService:
         has_more = len(rows) > query.limit
         items = rows[: query.limit]
         return InvoicePage(
-            items=[InvoiceRead.model_validate(i) for i in items],
+            items=self._reads(items),
             next_cursor=items[-1].id if has_more and items else None,
         )
 

--- a/projects/pigrocrm/packages/core/tests/test_invoice_service.py
+++ b/projects/pigrocrm/packages/core/tests/test_invoice_service.py
@@ -7,9 +7,11 @@ a scenario in this file -- it is impossible by construction. The number appears 
 
 from datetime import date
 from decimal import Decimal
+from typing import Any
 from uuid import UUID, uuid4
 
 import pytest
+from sqlalchemy import event
 from sqlalchemy.orm import Session
 
 from pigrocrm.core.activities.service import ActivityService
@@ -800,3 +802,56 @@ def test_a_proforma_date_is_editable_while_a_draft_and_never_cleared(
     with pytest.raises(ValidationFailed) as caught:
         service.update(proforma.id, InvoiceUpdate(data_emissione=None), ADMIN)
     assert caught.value.details["field"] == "data_emissione"
+
+
+# --- the customer's name on the read shape -------------------------------------------
+
+
+def test_every_read_carries_the_customer_s_name(service: InvoiceService, customer_id: UUID) -> None:
+    """`InvoiceRead.customer_ragione_sociale` is denormalised from `customers` at read
+    time, exactly as `DealRead` does it (ORB-98): the list page has to say whose invoice
+    a row is without a request per row. Every path that hands back an `InvoiceRead`
+    carries it, so a mutation's answer and the next `get` agree on the same shape."""
+    created = service.create(InvoiceCreate(customer_id=customer_id), ADMIN)
+    assert created.customer_ragione_sociale == "Acme S.r.l."
+
+    assert service.get(created.id, ADMIN).customer_ragione_sociale == "Acme S.r.l."
+
+    updated = service.update(created.id, InvoiceUpdate(causale="Consulenza"), ADMIN)
+    assert updated.customer_ragione_sociale == "Acme S.r.l."
+
+    page = service.list(InvoiceListQuery(), ADMIN)
+    assert [item.customer_ragione_sociale for item in page.items] == ["Acme S.r.l."]
+
+
+def test_the_customer_name_costs_one_query_for_the_whole_page(
+    service: InvoiceService, db_session: Session
+) -> None:
+    """Counted, not reasoned about, for the same reason `test_deals.py` counts it: an N+1
+    reintroduced by a later refactor is invisible to every other assertion here."""
+    for index in range(3):
+        customer = Customer(ragione_sociale=f"ACME {index}", nazione="IT")
+        db_session.add(customer)
+        db_session.flush()
+        service.create(InvoiceCreate(customer_id=customer.id), ADMIN)
+
+    statements: list[str] = []
+
+    def record(conn: Any, cursor: Any, statement: str, *args: Any) -> None:
+        statements.append(statement)
+
+    connection = db_session.connection()
+    event.listen(connection, "after_cursor_execute", record)
+    try:
+        page = service.list(InvoiceListQuery(), ADMIN)
+    finally:
+        event.remove(connection, "after_cursor_execute", record)
+
+    assert len(page.items) == 3
+    # The list itself, plus exactly one lookup for the three customer names.
+    assert len(statements) == 2, statements
+    assert sorted(item.customer_ragione_sociale or "" for item in page.items) == [
+        "ACME 0",
+        "ACME 1",
+        "ACME 2",
+    ]


### PR DESCRIPTION
## What this changes

The Fatture list showed Numero, Tipo, Stato, Data, Totale and Pagamento, and nothing about whose invoice a row was: to learn the customer a person had to open each row. Ivan asked for it on 2026-09-10 («nella schermata delle fatture voglio vedere a quale cliente è associata»). The frontend could not fix that alone, because `InvoiceRead` carried only `customer_id`.

Now every `InvoiceRead` carries `customer_ragione_sociale`, the customer's name denormalised at read time the way `DealRead` already does it: `InvoiceRepository.customer_names` resolves every name of a page in one query, and `InvoiceService._read`/`_reads` apply it to every `InvoiceRead` the service hands back, so `get`, `list` and the mutation answers share one shape and the MCP tools (`list_invoices`, `get_invoice`) get the name with no change of their own. The list page shows a «Cliente» column right after Numero, with the same em dash every other empty cell shows when the name did not resolve.

The regeneration of `api-types.ts` is its own first commit: the committed file had fallen behind the API on `main` (it still typed `/api/orbiters/signups`, which the API no longer serves, and lacked the ORB-61 fields on `InvoiceRead`). ORB-101 tracks a gate for that drift.

## How I verified it

- Core, the two new tests first, red then green: `test_every_read_carries_the_customer_s_name` and `test_the_customer_name_costs_one_query_for_the_whole_page` (the latter counts the statements: the list plus exactly one lookup for three customers).
- `uv run pytest -q -n 3 --dist loadfile -m "not slow and not planner" projects/pigrocrm`: 4167 passed. (`-n auto` on this Mac trips the testcontainers reaper port race, 1084 setup errors and 0 failures; with three workers it is clean.)
- `uv run ruff check projects/pigrocrm`, `uv run ruff format --check projects/pigrocrm`, `uv run mypy`: clean, 279 source files.
- Web, red then green: `columns.test.ts` (opt-in column, position, accessor, dash for `null` and `''`, plain-text cell), `fatture/index.test.tsx` (the list renders the «Cliente» header and the name the API sent), `InvoicesTab.test.tsx` (the tab does not).
- `pnpm --filter web test`: 1057 passed, 101 files. `pnpm --filter web lint`, `pnpm --filter web build`, `tsc --noEmit`: clean.
- `pnpm --filter web generate:api` against the API on this branch: the only schema change on top of the regeneration commit is `customer_ragione_sociale?: string | null` on `InvoiceRead`.
- Opened http://localhost:5173/app/fatture against a local stack with three customers, two issued invoices and one proforma: the column reads «Bianchi Consulting S.r.l.», «Officina Verdi S.n.c.», «Studio Neri & Partner» on the right rows. `GET /api/invoices` returns the same names.
- `bash projects/pigrocrm/apps/web/scripts/e2e.sh` (the Playwright suite, serial, its own Postgres): 39 passed in 1.3m.

## Anything a reviewer should look at twice

- `InvoiceRepository.customer_names` does not filter `deleted_at`, on purpose and more so than for deals: `CustomerService.soft_delete` blocks only on active deals, so an archived customer with issued invoices is a real state, and its name is still the name on those invoices. The docstring says so.
- Every mutation answer now costs one extra primary-key `SELECT` on `customers`, the same price `DealService` pays. `create` already holds the `Customer` row for the party snapshot, so a future micro-optimisation could pass the name through; not worth a signature change today.
- The cell is plain text, not `truncate`: the table is auto-layout and `TableCell` already says `whitespace-nowrap`, so a long name widens its column and the table scrolls inside its frame like every other text column. An earlier draft had `truncate` on an inline span, which does nothing there; the independent review caught it.

## What did not change, on purpose

- The Fatture tab inside a customer's or a deal's page keeps its columns: every row there belongs to the customer named in the title. Recorded on ORB-98.
- No customer filter on the list page: the `customer_id` API filter exists and the ask was to see the name, not to filter by it.

## API changes

- `GET /api/invoices`, `GET /api/invoices/{id}` and every mutation that answers an `InvoiceRead`: the response gains `customer_ragione_sociale` (`string | null`, read-only, never accepted on write). No status code changes. `pnpm --filter web generate:api` was run with the API up on `localhost:8000`; `projects/pigrocrm/apps/web/src/lib/api-types.ts` matches.

## Screenshots

**1. Fatture list, the «Cliente» column after Numero**
![Fatture list, before and after](https://github.com/user-attachments/assets/b600242b-9236-417e-86f1-16a26ce49ba9)

Same data on both frames: the before is the `origin/main` web on 5175, the after this branch on 5173, both against this branch's API, so the before shows a state `main` never had only in the sense that its API already knew the name; the page did not.

Linear: ORB-98.
