### PR TITLE
feat(deploy): the two preview environments get public names behind basic auth

### DIFF
--- a/.github/workflows/deploy-hub.yml
+++ b/.github/workflows/deploy-hub.yml
@@ -85,10 +85,12 @@ jobs:
       compose-project: orbiters-preview
       ref: ${{ github.event.workflow_run.head_sha }}
       # The API's probe touches the database (SELECT 1), so a green deploy means
-      # Postgres is up and migrated, not only that uvicorn answered. No `url`: the
-      # host vhost proxies `/hub/` to production, and nothing serves the preview
-      # publicly. Its ports are in docs/adding-a-project.md §7.
+      # Postgres is up and migrated, not only that uvicorn answered. The `url` is the
+      # preview name, behind basic auth, which since 2026-09-10 serves this stack's
+      # `/hub/` the way joinorbiters.com serves production's. Ports: §7 of
+      # docs/adding-a-project.md.
       health-url: http://127.0.0.1:8086/health
+      url: https://preview.joinorbiters.com/hub/
     secrets: inherit
 
   production:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -83,7 +83,7 @@ jobs:
       # request that proves the container started, nginx parsed its config and the
       # build produced the page map the config expects.
       health-url: http://127.0.0.1:8083/
-      url: https://joinorbiters.com
+      url: https://preview.joinorbiters.com
     secrets: inherit
 
   production:

--- a/docs/adding-a-project.md
+++ b/docs/adding-a-project.md
@@ -258,8 +258,14 @@ rows.
 | website | web 8082 | web 8083 |
 | hub (`orbiters`, `orbiters-preview`) | api 8084, web 8085, Postgres 55435 | api 8086, web 8087, Postgres 55436 |
 
-The vhost proxies production only. A preview with no public name is reached on the
-host, by its loopback port, which is also why its deploy job passes no `url`.
+Since 2026-09-10 preview has public names too: `preview.joinorbiters.com` mirrors the
+website plus hub map, `preview.pigro.joinorbiters.com` mirrors the CRM's, and both are
+behind HTTP basic auth against `/etc/nginx/.htpasswd-preview` with
+`X-Robots-Tag: noindex` on every answer. So a new project's preview gets a vhost as
+well as a production one, the two files stay the same shape, and only the ports differ.
+Two rules that are the reason it is safe: the password file lives on the server and
+never in the repository, and a preview name only ever proxies preview containers, so a
+click inside preview cannot walk out into production data.
 
 The copy in the repository is plain HTTP and is the source of truth for what the rules
 are. The copy in `/etc/nginx/sites-available/` has certbot's port-443 block on top of

--- a/projects/pigrocrm/deploy/nginx/preview.pigro.joinorbiters.conf
+++ b/projects/pigrocrm/deploy/nginx/preview.pigro.joinorbiters.conf
@@ -1,0 +1,100 @@
+# preview.pigro.joinorbiters.com -- the CRM preview stack under its own name.
+#
+# The same shape as `pigro.joinorbiters.conf`, one environment behind it: everything
+# the `pigrocrm-preview` stack on 127.0.0.1:8081 serves passes through, and the four
+# public paths point at the *preview* website rather than the live one, so a click
+# inside preview never walks out into production.
+#
+# The CRM keeps its own name here for the same reason it has one in production: the
+# session cookie is scoped to the root space's prefix, and sharing a host with the
+# website's path map would put two products' cookies and two path maps on one origin.
+#
+# **The root slug is not in this file.** `__ROOT_SLUG__` below is a placeholder for the
+# value of `PIGROCRM_ROOT_SLUG` in that environment's `.env`, which is a real company's
+# name and therefore never committed (see `test_no_real_identity_in_the_repository.py`
+# and `orbiters-identity-scan`). Substitute it when installing:
+#
+#   slug=$(grep -oP '(?<=^PIGROCRM_ROOT_SLUG=).*' /opt/pigrocrm-preview/.env)
+#   sed "s/__ROOT_SLUG__/$slug/g" preview.pigro.joinorbiters.conf \
+#     | sudo tee /etc/nginx/sites-available/preview.pigro.joinorbiters.conf
+#
+# A copy installed with the placeholder still resolves: every `/app/` deep link
+# redirects to a space that does not exist and the SPA answers its own 404. That is the
+# failure to look for if login works and nothing else does.
+#
+# Behind HTTP basic auth (`/etc/nginx/.htpasswd-preview`) like the other preview name,
+# and `X-Robots-Tag: noindex` on top of it. See `projects/website/deploy/preview.joinorbiters.conf`
+# for why.
+#
+# TLS is added by `certbot --nginx`, which rewrites this file in place.
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name preview.pigro.joinorbiters.com;
+
+    absolute_redirect off;
+
+    auth_basic "Orbiters preview";
+    auth_basic_user_file /etc/nginx/.htpasswd-preview;
+
+    add_header X-Robots-Tag "noindex, nofollow, noarchive" always;
+
+    location ^~ /.well-known/acme-challenge/ {
+        auth_basic off;
+        root /var/www/html;
+    }
+    location = /robots.txt {
+        auth_basic off;
+        default_type text/plain;
+        return 200 "User-agent: *\nDisallow: /\n";
+    }
+    location = /health {
+        auth_basic off;
+        proxy_pass http://127.0.0.1:8081/health;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+
+    # The root installation's own space name: the bare host and the unprefixed login
+    # land there. Deep links and assets under /app/ keep working unprefixed.
+    location = /          { return 302 /__ROOT_SLUG__/app/; }
+    location = /app       { return 302 /__ROOT_SLUG__/app/; }
+    location = /app/login {
+        proxy_pass http://127.0.0.1:8081;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+    location = /app/registrati {
+        proxy_pass http://127.0.0.1:8081;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+    location ^~ /app/assets/ {
+        proxy_pass http://127.0.0.1:8081;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+    location = /app/mark.svg {
+        proxy_pass http://127.0.0.1:8081;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+    location ^~ /app/ { return 302 /__ROOT_SLUG__$request_uri; }
+
+    # The public pages belong to the website, and in this environment that is the
+    # website *preview* container, not production.
+    location = /pigrocrm { return 301 https://preview.joinorbiters.com/pigrocrm; }
+    location = /privacy  { return 301 https://preview.joinorbiters.com/privacy; }
+    location = /termini  { return 301 https://preview.joinorbiters.com/termini; }
+    location = /orbiters { return 301 https://preview.joinorbiters.com/; }
+
+    # Both Google OAuth flows need the session cookie, which is scoped to the root
+    # space's prefix. A space's own callback is registered with its prefix and never
+    # lands here. Note that Google only ever redirects back to a registered URI, so
+    # these work in preview only once this host is added to the OAuth client.
+    location = /api/gmail/oauth/start    { return 302 /__ROOT_SLUG__$request_uri; }
+    location = /api/gmail/oauth/callback { return 302 /__ROOT_SLUG__$request_uri; }
+    location = /api/drive/oauth/start    { return 302 /__ROOT_SLUG__$request_uri; }
+    location = /api/drive/oauth/callback { return 302 /__ROOT_SLUG__$request_uri; }
+
+    location / {
+        proxy_pass http://127.0.0.1:8081;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+}

--- a/projects/website/deploy/preview.joinorbiters.conf
+++ b/projects/website/deploy/preview.joinorbiters.conf
@@ -1,0 +1,88 @@
+# preview.joinorbiters.com -- the same path map as joinorbiters.com, one environment
+# behind it.
+#
+# This name exists so a change can be looked at on the server that will serve it,
+# under the layout it will be served under, before a release tag exists. It mirrors
+# `joinorbiters.conf` line for line and differs only in the ports: every `-preview`
+# container instead of every production one.
+#
+#   website-preview-web    127.0.0.1:8083   (production: 8082)
+#   orbiters-preview-api   127.0.0.1:8086   (production: 8084)
+#   orbiters-preview-web   127.0.0.1:8087   (production: 8085)
+#
+# Keeping the two files the same shape is the point: a path that works here and not
+# in production is a deploy difference, not a routing one. When `joinorbiters.conf`
+# gains a location, this file gains it too.
+#
+# **It is behind HTTP basic auth, and that is not decoration.** These pages collect a
+# CV, an email address and a company request, they are a second copy of a public site
+# (which search engines would read as duplicate content), and they are a build nobody
+# has approved yet. The password file is `/etc/nginx/.htpasswd-preview` on the server,
+# outside the repository and never in it. `X-Robots-Tag` is set as well, so the answer
+# stays "do not index" if the auth is ever lifted for a demo.
+#
+# TLS is added by `certbot --nginx`, which rewrites this file in place on the server.
+# The copy here is the plain-HTTP source of truth; the copy in
+# /etc/nginx/sites-available/ has certbot's 443 block on top of it and is edited in
+# place rather than overwritten, or TLS disappears on the next change.
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name preview.joinorbiters.com;
+
+    absolute_redirect off;
+    client_max_body_size 1M;
+
+    auth_basic "Orbiters preview";
+    auth_basic_user_file /etc/nginx/.htpasswd-preview;
+
+    add_header X-Robots-Tag "noindex, nofollow, noarchive" always;
+
+    # Renewal has to reach the challenge without a password, and a crawler must not
+    # be told to index it either. Both certbot authenticators (`--nginx` and
+    # `--webroot -w /var/www/html`) go through this path.
+    location ^~ /.well-known/acme-challenge/ {
+        auth_basic off;
+        root /var/www/html;
+    }
+
+    # Anything that gets past the password still says it is not a public copy.
+    location = /robots.txt {
+        auth_basic off;
+        default_type text/plain;
+        return 200 "User-agent: *\nDisallow: /\n";
+    }
+
+    # The Orbiters hub (projects/hub): its API on 8086, its SPA on 8087.
+    location = /api/orbiters/signups {
+        proxy_pass http://127.0.0.1:8086/api/orbiters/signups;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+    location ^~ /api/hub/ {
+        client_max_body_size 6M;
+        proxy_pass http://127.0.0.1:8086;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+    location = /hub { return 302 /hub/; }
+    location ^~ /hub/ {
+        proxy_pass http://127.0.0.1:8087;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+    location = /health {
+        auth_basic off;
+        proxy_pass http://127.0.0.1:8081/health;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+
+    # "Accedi" on both pages: the CRM preview answers on its own name, exactly as
+    # production sends it to pigro.joinorbiters.com.
+    location = /app  { return 302 https://preview.pigro.joinorbiters.com/app/; }
+    location /app/   { return 302 https://preview.pigro.joinorbiters.com$request_uri; }
+
+    # Everything else is the website preview container, which decides what exists.
+    location / {
+        proxy_pass http://127.0.0.1:8083;
+        include /etc/nginx/snippets/orbiters-proxy.conf;
+    }
+}


### PR DESCRIPTION
## What this changes

Preview environments have existed since the deploy pipeline was armed, but only on the
server's loopback: `127.0.0.1:8083` for the website, `8087` for the hub, `8081` for the
CRM. Looking at a merged change before a release tag meant opening an SSH tunnel, which
is fine for me and useless for anybody else. This gives them two names that mirror the
production pair, one environment behind, sharing the path map so a URL that works in
preview works in production.

| Name | Serves | Ports |
|---|---|---|
| `preview.joinorbiters.com` | website preview, hub preview under `/hub/`, hub API under `/api/hub/` | 8083, 8087, 8086 |
| `preview.pigro.joinorbiters.com` | CRM preview | 8081 |

The second name is not invented here: `deploy-pigrocrm.yml` has been passing it as the
preview environment's URL since the pipeline was written, against a record that never
existed.

## How I verified

`nginx -t` on the deploy host against both files, with the placeholder substituted,
included in a throwaway `http {}` context so the real config was never touched:
`syntax is ok`, `test is successful`. The port map was read off the running containers
and each environment's `.env` rather than assumed: `docker ps` on the host, plus
`ORBITERS_WEB_PORT=127.0.0.1:8087`, `WEBSITE_WEB_PORT=127.0.0.1:8083`,
`PIGROCRM_WEB_PORT=127.0.0.1:8081`. Every path I route was probed on the host first:
`/hub/` and `/hub/freelance` 200 on 8087, `/` and `/pigrocrm` 200 on 8083, `/app/` 200
and `/` 302 on 8081, `/health` 200 on 8081 and 8086.

Nothing is installed on the server yet, because neither name resolves: both need an A
record to the deploy host, DNS-only rather than proxied, which is how the apex and
`pigro` are set up today (`www` is the proxied one). Once they resolve the install is
the vhost, `certbot --nginx`, and the `htpasswd` file.

## Anything a reviewer should look at twice

The basic auth is deliberate and I would argue against dropping it: these pages collect
a CV, an email address and a company request, they are a second copy of a public site
that a crawler would read as duplicate content, and they serve builds nobody has
approved. If we ever want a link that a client can open without a password, that is a
different thing from a preview environment and should get its own name.

I did not touch `_deploy-compose.yml`, so the deploy mechanism is unchanged; the two
callers only gained a correct `url`.

## Screenshots

Nothing visible changed: this is routing, documentation and two workflow inputs. The
pages themselves are the ones already merged.