### PR TITLE
feat(website): the landing's footer opens a door into the hub's admin area

### DIFF
--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -238,6 +238,7 @@
           <a class="quiet-link" href="/privacy">Privacy</a>
           <a class="quiet-link" href="/termini">Termini</a>
           <a class="quiet-link" href="https://example.com/">Studio Rossi</a>
+          <a class="quiet-link" href="/hub/admin">Admin</a>
         </p>
       </footer>
     </main>

--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -238,7 +238,7 @@
           <a class="quiet-link" href="/privacy">Privacy</a>
           <a class="quiet-link" href="/termini">Termini</a>
           <a class="quiet-link" href="https://example.com/">Studio Rossi</a>
-          <a class="quiet-link" href="/hub/admin">Admin</a>
+          <a class="quiet-link" href="/hub/admin/freelance">Admin</a>
         </p>
       </footer>
     </main>

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -186,6 +186,16 @@ describe('index.html', () => {
     expect(page).toMatch(/href="\/termini"/)
   })
 
+  it('opens a door into the hub admin area from its footer, and only there', () => {
+    // Ivan, 2026-09-10 (ORB-105): whoever reviews signups, freelancers and companies
+    // should not have to type `/hub/admin` by hand. One quiet link at the end of the
+    // footer, dressed like its neighbours; the hub's `AdminLayout` sends a visitor
+    // without a session to its login, so the page links the area and not the login.
+    const footer = page.match(/<footer[\s\S]*?<\/footer>/)?.[0] ?? ''
+    expect(footer).toMatch(/<a class="quiet-link" href="\/hub\/admin">Admin<\/a>\s*<\/p>/)
+    expect(page.match(/href="\/hub\/admin"/g)).toHaveLength(1)
+  })
+
   it('mounts the same field as the community page behind the whole page, from the shared script', () => {
     // Ivan, 2026-09-09: `/pigrocrm` has the same background as `/`. One fixed canvas
     // right after <body>, the same id, the same mount options in landing.js.

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -188,12 +188,15 @@ describe('index.html', () => {
 
   it('opens a door into the hub admin area from its footer, and only there', () => {
     // Ivan, 2026-09-10 (ORB-105): whoever reviews signups, freelancers and companies
-    // should not have to type `/hub/admin` by hand. One quiet link at the end of the
-    // footer, dressed like its neighbours; the hub's `AdminLayout` sends a visitor
-    // without a session to its login, so the page links the area and not the login.
+    // should not have to type the admin URL by hand. One quiet link, last in the
+    // footer, dressed like its neighbours. It goes to `/hub/admin/freelance`, the first
+    // screen of the area and where the hub's own login lands, rather than to `/hub/admin`:
+    // the hub router has no index route under `/admin`, so a signed-in admin sent there
+    // would see the frame with an empty panel (found in review of PR 28, filed as ORB-106).
+    // `AdminLayout` still sends a visitor without a session to its login first.
     const footer = page.match(/<footer[\s\S]*?<\/footer>/)?.[0] ?? ''
-    expect(footer).toMatch(/<a class="quiet-link" href="\/hub\/admin">Admin<\/a>\s*<\/p>/)
-    expect(page.match(/href="\/hub\/admin"/g)).toHaveLength(1)
+    expect(footer).toMatch(/<a[^>]*\bhref="\/hub\/admin\/freelance"[^>]*>Admin<\/a>\s*<\/p>/)
+    expect(page.match(/href="\/hub\/admin/g)).toHaveLength(1)
   })
 
   it('mounts the same field as the community page behind the whole page, from the shared script', () => {

--- a/projects/website/src/landing.css
+++ b/projects/website/src/landing.css
@@ -140,7 +140,7 @@ footer .quiet-link {
 
 /* Plain inline flow otherwise (privacy.html and termini.html's two-link footers
    carry no gap of their own), so consecutive links need their own breathing room;
-   the first stays flush with the content edge. On index.html's four-link footer,
+   the first stays flush with the content edge. On index.html's flex footer,
    which already carries a flex `gap`, the DOM adjacency still matches and this
    only adds a negligible amount on top. */
 footer .quiet-link + .quiet-link {


### PR DESCRIPTION
## What this changes

Nothing on the public site pointed at the hub's admin area, so whoever reviews signups, freelancers and companies had to remember `/hub/admin` and type it. The landing's footer (`/pigrocrm` today, the front door once ORB-71 lands) now ends with a quiet «Admin» link to `/hub/admin/freelance`, dressed like Orbiters, Privacy, Termini and the studio link beside it. It goes to the freelancers list, the first screen of the area and where the hub's own login lands, rather than to `/hub/admin`: the hub router has no index route under `/admin`, so a signed-in admin sent there would see an empty panel (found in review, filed as ORB-106). The hub's `AdminLayout` still sends a visitor without a session to `/hub/admin/login` first.

## How I verified it

- `pnpm --filter website test`: 204 passed, 11 files. The new test in `landing-pages.test.ts` failed before the markup change (the footer had no admin link) and passes after; it pins the anchor by href and text inside `<footer>`, last in its paragraph, and asserts the admin path appears once on the page.
- `pnpm --filter website lint`: clean. `pnpm --filter website build`: built in 516ms.
- `pnpm --filter website test:e2e`: 49 passed. The JavaScript-disabled link walk skips `/hub/` paths by design (another tenant of the origin), and `links.test.ts` resolves `/hub/admin/freelance` through `ELSEWHERE`, so nothing had to be added to a path map.
- After the review commit: 204 unit tests, lint, build and the 49 e2e tests again green.
- Opened `vite preview` on 4173 (this branch) and 4175 (`origin/main`), 1440x900, scrolled to the end: the link renders as the same bordered control as its neighbours, 70x44 CSS pixels, so it clears the 44px touch-target floor.

## What did not change, on purpose

The community page (`orbiters.html`, today's `/`) stays without a footer: ORB-19 removed it on Ivan's request on 2026-09-09 and `orbiters.test.ts` keeps it from coming back, and ORB-72 retires the page once the landing takes the front door. The privacy and terms footers and the hub's own `Shell` footer are left alone too: one door into the admin area, on the page that is becoming the home. Recorded on ORB-105.

## Anything a reviewer should look at twice

Whether an admin link belongs on a public page at all. It is discreet and leads to a guarded area, and Ivan asked for it in the footer, but it does tell a visitor that an admin area exists. The footer's fourth link, «Studio Rossi» to `example.com`, is a fixture that leaked onto the page (ORB-97 names the same on the hub); I left it as I found it.

## Screenshots

**1. The landing's footer at 1440x900, scrolled to the end**
![The landing footer, before and after](https://github.com/user-attachments/assets/af004ab0-3f84-47db-b132-b0187a89420a)

Linear: ORB-105.

