### PR TITLE
fix(pigrocrm): keep the root slug out of the production vhost

### DIFF
--- a/projects/pigrocrm/deploy/nginx/pigro.joinorbiters.conf
+++ b/projects/pigrocrm/deploy/nginx/pigro.joinorbiters.conf
@@ -5,6 +5,21 @@
 # the root goes into the CRM, and the four public paths redirect to joinorbiters.com,
 # which since 2026-09-09 is a different container in a different project.
 #
+# **The root slug is not in this file.** `__ROOT_SLUG__` below is a placeholder for the
+# value of `PIGROCRM_ROOT_SLUG` in that environment's `.env`, which is a real company's
+# name and therefore never committed (see `test_no_real_identity_in_the_repository.py`
+# and `orbiters-identity-scan`). Substitute it when installing:
+#
+#   slug=$(grep -oP '(?<=^PIGROCRM_ROOT_SLUG=).*' /opt/pigrocrm/.env)
+#   sed "s/__ROOT_SLUG__/$slug/g" pigro.joinorbiters.conf \
+#     | sudo tee /etc/nginx/sites-available/pigro.joinorbiters.conf
+#
+# A copy installed with the placeholder still resolves: every `/app/` deep link
+# redirects to a space that does not exist and the SPA answers its own 404, while the
+# login keeps working. That is the failure to look for if login works and nothing else
+# does. The same goes for the four OAuth paths, whose redirect carries the session
+# cookie's scope.
+#
 # TLS is added by `certbot --nginx`, which rewrites this file in place.
 
 server {
@@ -14,18 +29,18 @@ server {
 
     absolute_redirect off;
 
-    # The root installation's own space name (PIGROCRM_ROOT_SLUG=studiorossi on this
-    # server): the bare host and the unprefixed login land there, so the titolare's CRM
-    # has an address shaped like everyone else's. Deep links and assets under /app/ keep
-    # working unprefixed -- the same SPA, the same database.
-    location = /          { return 302 /studiorossi/app/; }
-    location = /app       { return 302 /studiorossi/app/; }
+    # The root installation's own space name (`PIGROCRM_ROOT_SLUG`): the bare host and
+    # the unprefixed login land there, so the titolare's CRM has an address shaped like
+    # everyone else's. Deep links and assets under /app/ keep working unprefixed -- the
+    # same SPA, the same database.
+    location = /          { return 302 /__ROOT_SLUG__/app/; }
+    location = /app       { return 302 /__ROOT_SLUG__/app/; }
     # Every page under /app/ moves under the root's name, so the address always says
     # whose CRM this is; the bundle's assets and the tab icon are not pages, and the
     # login and the signup are the two pages that stay bare on purpose (2026-09-09): a
     # person who has just logged out, or who is creating a space, is nobody's yet and
     # must not read a space's name in the address. The root's cookies live at `/`, so
-    # a session opened on the bare login is the same session under /studiorossi/app.
+    # a session opened on the bare login is the same session under the root's prefix.
     location = /app/login {
         proxy_pass http://127.0.0.1:8080;
         include /etc/nginx/snippets/orbiters-proxy.conf;
@@ -42,7 +57,7 @@ server {
         proxy_pass http://127.0.0.1:8080;
         include /etc/nginx/snippets/orbiters-proxy.conf;
     }
-    location ^~ /app/ { return 302 /studiorossi$request_uri; }
+    location ^~ /app/ { return 302 /__ROOT_SLUG__$request_uri; }
 
     # The public pages are the website's, on its own name and its own container since
     # 2026-09-09. They used to answer here too, because one image served both: a
@@ -55,13 +70,13 @@ server {
 
     # The Google OAuth flow starts from a plain `/api/.../oauth/start` anchor and comes
     # back to the registered `/api/.../oauth/callback`; both need the session cookie,
-    # which is scoped to /studiorossi/. Moving the four under the root's name is what
-    # lets the cookie travel (2026-09-09). A space's own callback is registered with its
-    # prefix and never lands here.
-    location = /api/gmail/oauth/start    { return 302 /studiorossi$request_uri; }
-    location = /api/gmail/oauth/callback { return 302 /studiorossi$request_uri; }
-    location = /api/drive/oauth/start    { return 302 /studiorossi$request_uri; }
-    location = /api/drive/oauth/callback { return 302 /studiorossi$request_uri; }
+    # which is scoped to the root space's prefix. Moving the four under the root's name
+    # is what lets the cookie travel (2026-09-09). A space's own callback is registered
+    # with its prefix and never lands here.
+    location = /api/gmail/oauth/start    { return 302 /__ROOT_SLUG__$request_uri; }
+    location = /api/gmail/oauth/callback { return 302 /__ROOT_SLUG__$request_uri; }
+    location = /api/drive/oauth/start    { return 302 /__ROOT_SLUG__$request_uri; }
+    location = /api/drive/oauth/callback { return 302 /__ROOT_SLUG__$request_uri; }
 
     location / {
         proxy_pass http://127.0.0.1:8080;

--- a/projects/pigrocrm/packages/core/tests/test_no_real_identity_in_the_repository.py
+++ b/projects/pigrocrm/packages/core/tests/test_no_real_identity_in_the_repository.py
@@ -224,3 +224,32 @@ def test_no_unapproved_identifier_appears_anywhere(
         "synthetic, in which case add it to the allowlist above with a note saying so: "
         + "; ".join(sorted(set(offenders)))
     )
+
+
+# `return 302 /<segment>/app/` and `return 302 /<segment>$request_uri` are the two shapes
+# in the deploy vhosts that carry the root installation's slug, which is a real company's
+# name. The public-page redirects are absolute URLs and do not match.
+_VHOST_SLUG_REDIRECT = re.compile(r"return\s+30\d\s+/([A-Za-z0-9_-]+)(?:/app/|\$request_uri)")
+
+
+def test_the_deploy_vhosts_keep_the_root_slug_as_a_placeholder() -> None:
+    """The installed copy must never come back into the repository.
+
+    The vhosts on the server are edited in place and hold the real slug; the copies here
+    are the source of truth for the rules and hold `__ROOT_SLUG__`. Pasting the server's
+    copy back is how the name returned once already (ORB-104), and it is invisible: nginx
+    accepts it, the login keeps working, and only the deep links land on a space that
+    does not exist.
+    """
+    confs = sorted((_repository_root() / "projects/pigrocrm/deploy/nginx").glob("*.conf"))
+    assert confs, "no CRM vhost was found, so a pass here means nothing"
+
+    matches = [(c.name, m) for c in confs for m in _VHOST_SLUG_REDIRECT.findall(c.read_text())]
+    assert len(matches) >= 12, (
+        f"the slug-carrying redirects stopped matching, so this test guards nothing: {matches}"
+    )
+    offenders = sorted({f"{name}: /{slug}" for name, slug in matches if slug != "__ROOT_SLUG__"})
+    assert not offenders, (
+        "a deploy vhost redirects under a literal space name instead of `__ROOT_SLUG__`. "
+        "The repository copy is plain and substituted at install time: " + "; ".join(offenders)
+    )


### PR DESCRIPTION
## What this changes

`projects/pigrocrm/deploy/nginx/pigro.joinorbiters.conf` redirected under a literal space name in nine places, and the comment above them said `PIGROCRM_ROOT_SLUG=<name> on this server`, which was not true: the installed copy on the host carries the real slug, the repository copy carried a substituted one. This is the sanitisation landing in an operational file instead of a fixture, so the file documented a route nobody has.

It now uses `__ROOT_SLUG__` with the `sed` line that substitutes it at install time, the same shape as the preview vhost added yesterday, and the comments describe the cookie scope without naming a prefix.

The guard test gains the invariant. That is the part worth arguing for: pasting the server's copy back into the repository is invisible. nginx accepts it, the login keeps working, and only the deep links under `/app/` land on a space that does not exist, which is the hardest failure to read.

## Why

Refs ORB-104. No behaviour change on the server: the vhosts there are edited in place and are not overwritten from the repository.

## Verification

- `uv run pytest -q projects/pigrocrm/packages/core/tests/test_no_real_identity_in_the_repository.py`: 4 passed.
- The new test fails on the thing it is for. Substituting a literal slug back into the file gives `AssertionError: a deploy vhost redirects under a literal space name instead of __ROOT_SLUG__: pigro.joinorbiters.conf: /somestudio`, and it passes again once reverted.
- Substituting `PIGROCRM_ROOT_SLUG` from `/opt/pigrocrm/.env` into this file gives redirect targets **byte-identical** to `/etc/nginx/sites-available/pigro.joinorbiters.conf` as installed (`diff` of every `return 30x` target: no output), and `nginx -t` passes on it in a throwaway context on the host. The real config was not touched.
- `uv run ruff check projects/pigrocrm`, `ruff format --check`, `uv run mypy`: clean.
- `orbiters-identity-scan`: clean against 28 names.
