### PR TITLE
docs(skills): name the field save_status_update actually wants

### DIFF
--- a/.claude/skills/linear-ticket/SKILL.md
+++ b/.claude/skills/linear-ticket/SKILL.md
@@ -105,10 +105,13 @@ Not: "working on it". Replies in a thread take `parentId`.
 
 ## Project updates
 
-`save_status_update` with `type: "project"`, the project id, a `health` (`onTrack`,
-`atRisk`, `offTrack`) and a body per the `linear-content` skill. Post one when the board
-alone would mislead a reader: a release shipped, a milestone slipped, a decision taken.
-Not one that restates the issue list.
+`save_status_update` with `type: "project"`, the project id in a key called **`project`**,
+a `health` (`onTrack`, `atRisk`, `offTrack`) and a body per the `linear-content` skill.
+Both of those are easy to get wrong once: omitting `type` fails on `type: is required`,
+and passing the id as `projectId` fails on `project is required when creating a project
+status update` while the id is right there in the payload. Post one when the board alone
+would mislead a reader: a release shipped, a milestone slipped, a decision taken. Not one
+that restates the issue list.
 
 ## References in code and commits
 


### PR DESCRIPTION
## What this changes

The `linear-ticket` skill's project-update section said "the project id" without naming the key. The MCP call wants `project`, and passing `projectId` fails with `project is required when creating a project status update` while the id is sitting in the payload, which reads like a server bug rather than a wrong field name. Omitting `type` fails separately.

## Why

Posting one project update cost three calls today because of it. The skill's own description promises "the API quirks that otherwise cost a wasted call", so this belongs there.

## Verification

Documentation only. Both failure messages in the new text are the ones the server returned today, and the corrected call (`type: "project"` plus `project: <id>`) is what posted the update on `Deploy and access hygiene v1`.