### PR TITLE
fix(website): the landing's footer links the studio again, not a fixture

### DIFF
--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -237,7 +237,7 @@
           <a class="quiet-link" href="/">Orbiters</a>
           <a class="quiet-link" href="/privacy">Privacy</a>
           <a class="quiet-link" href="/termini">Termini</a>
-          <a class="quiet-link" href="https://example.com/">Studio Rossi</a>
+          <a class="quiet-link" href="https://humancraft.tech/">Humancraft</a>
           <a class="quiet-link" href="/hub/admin/freelance">Admin</a>
         </p>
       </footer>

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -57,7 +57,7 @@ describe.each(PAGES)('%s', (name) => {
       // repository, and `bin/identity-scan` knows about these three paths for the same
       // reason.
       expect(url, 'external subresource').toMatch(
-        /^https:\/\/(?:github\.com|pigro\.joinorbiters\.com|example\.com|openai\.com|humancraft\.tech)\//,
+        /^https:\/\/(?:github\.com|pigro\.joinorbiters\.com|openai\.com|humancraft\.tech)\//,
       )
     }
     expect(page).not.toMatch(/fonts\.googleapis\.com|fonts\.gstatic\.com/)
@@ -184,6 +184,16 @@ describe('index.html', () => {
   it('links the two pages Google reads during verification', () => {
     expect(page).toMatch(/href="\/privacy"/)
     expect(page).toMatch(/href="\/termini"/)
+  })
+
+  it('signs its footer with the studio behind the site, never with a fixture', () => {
+    // ORB-116: the pre-publication sanitisation swapped this link for «Studio Rossi» at
+    // example.com, the suite's stock customer, and website-v0.4.0 shipped it. The studio
+    // is the same entity the two policy pages name as titolare, so the footer says what
+    // they say; a fixture host on a public page fails here and in links.test.ts.
+    const footer = page.match(/<footer[\s\S]*?<\/footer>/)?.[0] ?? ''
+    expect(footer).toMatch(/<a[^>]*\bhref="https:\/\/humancraft\.tech\/"[^>]*>Humancraft<\/a>/)
+    expect(page).not.toMatch(/Studio Rossi|example\.com/)
   })
 
   it('opens a door into the hub admin area from its footer, and only there', () => {

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -50,12 +50,14 @@ describe.each(PAGES)('%s', (name) => {
     for (const [, url] of page.matchAll(/(?:href|src)="(https?:\/\/[^"]+)"/g)) {
       // An href the reader clicks -- the repository, the hosted signup, or OpenAI's
       // own privacy policy, which the cookie section has to point at -- is fine; a
-      // subresource is not. `humancraft.tech` is in the list for one reason: Italian
-      // law requires the privacy and terms pages to name the titolare del trattamento
-      // and link to it, so those two pages carry a real company's site and this test
-      // has to allow the origin. It is the only real identity left anywhere in this
-      // repository, and `bin/identity-scan` knows about these three paths for the same
-      // reason.
+      // subresource is not. `humancraft.tech` is in the list because Italian law
+      // requires the privacy and terms pages to name the titolare del trattamento and
+      // link to it, so those two pages carry a real company's site and this test has to
+      // allow the origin; since ORB-116 index.html's footer links the same studio,
+      // restored to what production served before website-v0.4.0. It is the only real
+      // identity left anywhere in this repository, and `orbiters-identity-scan`
+      // (`.github/preflight.json`, `identity-names`) is told about these pages for the
+      // same reason.
       expect(url, 'external subresource').toMatch(
         /^https:\/\/(?:github\.com|pigro\.joinorbiters\.com|openai\.com|humancraft\.tech)\//,
       )

--- a/projects/website/src/links.test.ts
+++ b/projects/website/src/links.test.ts
@@ -63,9 +63,10 @@ function idsOn(page: string): Set<string> {
  *  enforces for `href`/`src` subresources, kept as its own list here because that
  *  file does not cover `orbiters.html`, and because an `<a>` a visitor clicks is a
  *  different concern from a subresource the page fetches for itself: this list is
- *  free to diverge from that one without either test lying about what it guarantees. */
-// No `example.com` here on purpose: it is the host the suite's fixtures use, and a link
-// to it on a page is a fixture that leaked into the markup (ORB-116, after ORB-97 on the hub).
+ *  free to diverge from that one without either test lying about what it guarantees.
+ *  No `example.com` here on purpose: it is the host the suite's fixtures use, and a link
+ *  to it on a page is a fixture that leaked into the markup (ORB-116, after ORB-97 on
+ *  the hub). */
 const EXTERNAL_HOSTS = ['github.com', 'pigro.joinorbiters.com', 'openai.com', 'humancraft.tech']
 
 function checkExternal(href: string): string | undefined {

--- a/projects/website/src/links.test.ts
+++ b/projects/website/src/links.test.ts
@@ -64,7 +64,9 @@ function idsOn(page: string): Set<string> {
  *  file does not cover `orbiters.html`, and because an `<a>` a visitor clicks is a
  *  different concern from a subresource the page fetches for itself: this list is
  *  free to diverge from that one without either test lying about what it guarantees. */
-const EXTERNAL_HOSTS = ['github.com', 'pigro.joinorbiters.com', 'example.com', 'openai.com', 'humancraft.tech']
+// No `example.com` here on purpose: it is the host the suite's fixtures use, and a link
+// to it on a page is a fixture that leaked into the markup (ORB-116, after ORB-97 on the hub).
+const EXTERNAL_HOSTS = ['github.com', 'pigro.joinorbiters.com', 'openai.com', 'humancraft.tech']
 
 function checkExternal(href: string): string | undefined {
   let url: URL


### PR DESCRIPTION
## What this changes

`website-v0.4.0` put a test fixture on the public landing: the footer's fourth link went out as «Studio Rossi» to `example.com`, where production had said «Humancraft» to `humancraft.tech` until that deploy. The pre-publication sanitisation had swapped the link on `main` and nothing caught it, because `example.com` sat in both link allowlists. The link is back to what the site said, `example.com` is out of both allowlists so a fixture host fails the suite, and a test pins the studio link in the footer. This is a restore, not new copy: `privacy.html` and `termini.html` on `main` name the same studio as titolare del trattamento, and CI is green with them.

## How I verified it

- `pnpm --filter website test`: 205 passed, 11 files. With the tests changed and the markup not yet, three failed (the new footer test, the origin allowlist in `landing-pages.test.ts`, and `links.test.ts` on `example.com`); all pass after the one-line restore.
- `uv run pytest -q projects/pigrocrm/packages/core/tests/test_no_real_identity_in_the_repository.py`: 4 passed. The identity guard checks fiscal shapes and email domains; a link to the studio's site on the landing is not what it bans, and the two policy pages already carry the same host.
- `pnpm --filter website lint`: clean. `build`: ok. `test:e2e`: 49 passed.
- Production before and after `website-v0.4.0`, read with `curl` on `https://joinorbiters.com/pigrocrm`: `href="https://humancraft.tech/">Humancraft` before, `href="https://example.com/">Studio Rossi` after. This PR is the fix for that.

## What did not change, on purpose

The hub's footer sentence «Orbiters è un progetto di Studio Rossi» (`projects/hub/apps/web/src/components/Shell.tsx:52`) is ORB-97's: that one names the entity behind the service in a sentence, and its wording is Lorenzo's and Ivan's to choose. The website's link had a known previous value and only that is restored.

## Anything a reviewer should look at twice

Whether restoring the studio's name on the landing is in tension with the repository being public. My reading: the two policy pages already carry the studio's name, VAT number and email by legal requirement, `landing-pages.test.ts` says so in its own comment, and the identity guard does not flag the host. If the intent was to keep the studio off the landing specifically, the fix would be to drop the link rather than to link a fixture, and that is a decision to record, not something this PR takes.

## Screenshots

**1. The landing's footer at 1440x900, scrolled to the end**
![The landing footer, before and after](https://github.com/user-attachments/assets/61b758be-32f6-406b-b767-31d337a93621)

Linear: ORB-116.
