### PR TITLE
fix(infra): the proxy snippet never spools an upstream response to disk

### DIFF
--- a/projects/pigrocrm/deploy/nginx/orbiters-proxy.conf
+++ b/projects/pigrocrm/deploy/nginx/orbiters-proxy.conf
@@ -2,3 +2,8 @@ proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
+# Never spool an upstream response to disk. During a deploy the host worker got EACCES
+# on /var/lib/nginx/proxy temp files and truncated every SPA bundle (2026-09-10,
+# ORB-117); with no temp file nginx reads the upstream at the client's pace instead,
+# which is right for small static assets and JSON from containers on the loopback.
+proxy_max_temp_file_size 0;


### PR DESCRIPTION
## What this changes

During today's deploys the host nginx worker got `open() … failed (13: Permission denied)` on its `/var/lib/nginx/proxy` temp files, and every SPA bundle that had to be spooled arrived truncated: `ERR_CONTENT_LENGTH_MISMATCH` on `joinorbiters.com/hub/…` and on `pigro.joinorbiters.com/app/…`. The shared snippet every proxied location includes now carries `proxy_max_temp_file_size 0;`: nginx never writes an upstream response to disk and reads the upstream at the client's pace instead. For containers on the loopback serving small assets and JSON that is the right trade. The same line is already live on the host since 16:27 UTC; this is the repository copy catching up.

## How I verified it

On the host: `nginx -t` clean, `systemctl reload nginx`. From outside, with a client throttled to 40 kB/s so nginx has to buffer: `joinorbiters.com/hub/assets/index-BC_G4y_1.js` 396937 of 396937 bytes and `pigro.joinorbiters.com/app/assets/index-DkhXzIh4.js` 429665 of 429665, both 200; before the change the same fetch from outside stopped at 130775 bytes. No nginx error line after the reload; `/var/lib/nginx/proxy` holds no file.

## Anything a reviewer should look at twice

The root cause is not found. The worker is `www-data`, unconfined, every temp directory is `www-data:www-data 700` and a write as `www-data` into the failing directory succeeds; the denials cluster only inside deploy windows. The evidence and the next steps are on ORB-117. This change removes the failure mode, it does not explain it.

## Screenshots

Nothing a person could see changed on purpose: the pages are the same, they now arrive whole. The failing state was a blank page with a console error, captured by Ivan.

Linear: ORB-117.
