### PR TITLE
style(hub): the public pages sit straight on the grid, without a panel around them

### DIFF
--- a/projects/hub/apps/web/src/components/Shell.tsx
+++ b/projects/hub/apps/web/src/components/Shell.tsx
@@ -3,15 +3,18 @@ import type { ReactNode } from 'react'
 import { BrandMark } from '@/components/BrandMark'
 
 /** The public frame: the mark and the name up top, the two legal links and the
- *  attribution at the foot, one boxed panel in between -- the site's own visual
- *  system (ORB-73's `.site` scope) rather than the application's, so a visitor who
- *  clicked a CTA on joinorbiters.com does not land on a different product. `site`
- *  also carries the page's ground (the same faint grid the landing sits on), and the
- *  panel is centred in the space between header and footer instead of sitting at the
- *  top of an empty page: `justify-center` on `main` only has room to act when the
- *  step is shorter than the viewport, which is the common case here. Each link over
- *  the grid keeps a sliver of the page's own surface behind it, the same treatment
- *  `landing.css`'s `.top a` and `footer .quiet-link` give theirs. */
+ *  attribution at the foot, and the page content straight on the grid in between --
+ *  the site's own visual system (ORB-73's `.site` scope) rather than the
+ *  application's, so a visitor who clicked a CTA on joinorbiters.com does not land on
+ *  a different product. `site` also carries the page's ground (the same faint grid
+ *  the landing sits on). There is no panel around the content: the doors of the
+ *  chooser and the wizard fields draw their own boxes, and a box around those boxes
+ *  read as one frame too many. The content is centred in the space between header
+ *  and footer instead of sitting at the top of an empty page: `justify-center` on
+ *  `main` only has room to act when the step is shorter than the viewport, which is
+ *  the common case here. Each link over the grid keeps a sliver of the page's own
+ *  surface behind it, the same treatment `landing.css`'s `.top a` and
+ *  `footer .quiet-link` give theirs. */
 export function Shell({ children }: { children: ReactNode }) {
   return (
     <div className="site flex min-h-full flex-col">
@@ -36,9 +39,7 @@ export function Shell({ children }: { children: ReactNode }) {
         </nav>
       </header>
       <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center px-6 py-12">
-        <div className="w-full border-[length:var(--landing-border-width)] bg-card px-6 py-10 shadow-xs sm:px-10">
-          {children}
-        </div>
+        <div className="w-full">{children}</div>
       </main>
       <footer className="mx-auto flex w-full max-w-5xl flex-wrap items-center gap-6 border-t-[length:var(--landing-border-width)] px-6 py-8 text-xs text-muted-foreground">
         <a

--- a/projects/hub/apps/web/src/components/Shell.tsx
+++ b/projects/hub/apps/web/src/components/Shell.tsx
@@ -7,13 +7,16 @@ import { BrandMark } from '@/components/BrandMark'
  *  the site's own visual system (ORB-73's `.site` scope) rather than the
  *  application's, so a visitor who clicked a CTA on joinorbiters.com does not land on
  *  a different product. `site` also carries the page's ground (the same faint grid
- *  the landing sits on). There is no panel around the content: the doors of the
- *  chooser and the wizard fields draw their own boxes, and a box around those boxes
- *  read as one frame too many. The content is centred in the space between header
- *  and footer instead of sitting at the top of an empty page: `justify-center` on
- *  `main` only has room to act when the step is shorter than the viewport, which is
- *  the common case here. Each link over the grid keeps a sliver of the page's own
- *  surface behind it, the same treatment `landing.css`'s `.top a` and
+ *  the landing sits on). There is no panel around the content (ORB-124): the pages
+ *  draw their own cards, the chooser's doors, the wizard's fields and review list,
+ *  the member area's boxes, and a box around those boxes read as one frame too many.
+ *  The bare `w-full` wrapper is load-bearing: `main` is `items-center`, and a page
+ *  such as the chooser sets `max-w-2xl` without `w-full`, so without the wrapper it
+ *  would shrink to the width of its text. The content is centred in the space
+ *  between header and footer instead of sitting at the top of an empty page:
+ *  `justify-center` on `main` only has room to act when the step is shorter than the
+ *  viewport, which is the common case here. Each link over the grid keeps a sliver of
+ *  the page's own surface behind it, the same treatment `landing.css`'s `.top a` and
  *  `footer .quiet-link` give theirs. */
 export function Shell({ children }: { children: ReactNode }) {
   return (

--- a/projects/hub/apps/web/src/components/ui/button.tsx
+++ b/projects/hub/apps/web/src/components/ui/button.tsx
@@ -10,8 +10,10 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/80",
-        /* The secondary button of the reference: a 12% line on the white surface,
-           not on the Paper page behind it -- these sit inside the content panel. */
+        /* The secondary button of the reference: a 12% line on a white surface the
+           button paints itself (`bg-card`), so it reads the same inside the admin's
+           panel and straight on the site's grid, where the public pages sit since
+           ORB-124 took their panel away. */
         outline:
           "border-border bg-card hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/projects/hub/apps/web/src/pages/member/Accedi.tsx
+++ b/projects/hub/apps/web/src/pages/member/Accedi.tsx
@@ -71,7 +71,7 @@ export function Accedi() {
         />
       </div>
       {error && (
-        <p role="alert" className="text-sm text-destructive">
+        <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
           {error}
         </p>
       )}

--- a/projects/hub/apps/web/src/pages/member/Guard.tsx
+++ b/projects/hub/apps/web/src/pages/member/Guard.tsx
@@ -15,7 +15,7 @@ export function MemberGuard() {
   if (me.isPending) return <p className="text-sm text-muted-foreground">Caricamento…</p>
   if (me.isError)
     return (
-      <p role="alert" className="text-sm text-destructive">
+      <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
         Non riusciamo a leggere la tua area. Riprova tra poco.
       </p>
     )

--- a/projects/hub/apps/web/src/pages/member/Modifica.tsx
+++ b/projects/hub/apps/web/src/pages/member/Modifica.tsx
@@ -104,7 +104,7 @@ export function Modifica() {
             autoFocus: false,
           })}
           {errors[step.id] && (
-            <p role="alert" className="text-sm text-destructive">
+            <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
               {errors[step.id]}
             </p>
           )}
@@ -112,7 +112,7 @@ export function Modifica() {
       ))}
 
       {failure && (
-        <p role="alert" className="text-sm text-destructive">
+        <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
           {failure}
         </p>
       )}

--- a/projects/hub/apps/web/src/wizard/Wizard.tsx
+++ b/projects/hub/apps/web/src/wizard/Wizard.tsx
@@ -125,7 +125,7 @@ export function Wizard<T>({
           aria-valuemin={0}
           aria-valuemax={100}
           aria-label="Avanzamento"
-          className="h-2 w-full overflow-hidden border-(length:--landing-border-width)"
+          className="h-2 w-full overflow-hidden border-(length:--landing-border-width) bg-card"
         >
           <div
             className="h-full bg-(--landing-ink) transition-[width] duration-300"
@@ -166,7 +166,7 @@ export function Wizard<T>({
             ))}
           </dl>
           {submitError && !submitError.step && (
-            <p role="alert" className="text-sm text-destructive">
+            <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
               {submitError.message}
             </p>
           )}
@@ -194,7 +194,7 @@ export function Wizard<T>({
           </div>
           <div>{step.render({ value, set, next, error, autoFocus: true })}</div>
           {error && (
-            <p role="alert" className="text-sm text-destructive">
+            <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
               {error}
             </p>
           )}

--- a/projects/hub/apps/web/src/wizard/site-controls.css
+++ b/projects/hub/apps/web/src/wizard/site-controls.css
@@ -51,6 +51,12 @@
    a fixed height, which the padding below only ever grows past, so it is untouched. */
 .site [data-slot='input'],
 .site [data-slot='textarea'] {
+  /* The application's Input and Textarea are `bg-transparent`, which was fine while
+     the public frame put a white panel behind them (ORB-74) and is not now that the
+     content sits straight on the grid (ORB-124): the grid ran through every field.
+     The landing's own input on the same grid paints white, orbiters.css:178
+     `.signup input { background-color: #ffffff }`, and so do these. */
+  background-color: var(--card);
   border-width: var(--landing-border-width);
   padding-block: var(--landing-control-padding-block);
   padding-inline: var(--landing-control-padding-inline);


### PR DESCRIPTION
## What this changes

The chooser at `/hub/`, the two wizards and the thank-you page all sat inside a white panel with the site's thick border and hard shadow, and the two door cards inside the chooser drew the same border and shadow again: a frame around two frames, which read as too heavy at 1440px. I drop the panel from `Shell` and let the content sit straight on the grid, the way the landing does. The header, the footer and the centring of the content between them do not move. The door cards, the wizard fields and the review list keep their own boxes and are the frame now.

## How I verified it

In `projects/hub/apps/web`: `pnpm lint` clean, `tsc --noEmit` clean, `vitest run` 12 files, 44 tests passed. I ran the hub dev server from this branch on 5180 and from a worktree on `origin/main` on 5182, opened `/hub/` in both at 1440×900 and compared them: only the panel is gone, the heading and the cards keep the same position (the `h1` sits at the same coordinates in both frames).

## Anything a reviewer should look at twice

The 2026-09-09 hub spec still says the web keeps "the same header/panel shapes" as the CRM. I left the spec alone: the panel decision was already superseded by ORB-73, which moved the wizards into the site's own visual system, and this PR only removes the last piece of it. If you want that sentence rewritten I would do it in the same PR.

The copy of the chooser now sits directly on the grid, with no surface behind it, unlike the header and footer links which keep their sliver of surface. At 1440px it reads fine to my eye. Whether the wizard steps want a surface behind their labels is a second look and is noted on the issue.

## What did not change, on purpose

The door cards, the wizard fields, the review list and the tokens. The decision is recorded on ORB-124.

## Screenshots

**1. The chooser at 1440×900, panel gone, cards and heading where they were**
![The chooser before and after](https://github.com/user-attachments/assets/4fdc5a7c-82e5-4bcd-a5cf-5f027136f038)

Linear: ORB-124.
