### PR TITLE
feat(hub): an admin creates the next admin from the area, and sees who is there

### DIFF
--- a/projects/hub/README.md
+++ b/projects/hub/README.md
@@ -21,7 +21,8 @@ Three public flows and the admin area behind them:
 - `/hub/accedi` and `/hub/io`: a freelancer gets back in with a magic link by mail, to
   see or change what they sent.
 - `/hub/admin/login` and the freelancer, company and signup lists behind it — a cookie
-  session, created with `orbiters createadmin` (below).
+  session. The first admin is created with `orbiters createadmin` (below); the next ones
+  from «Amministratori» inside the area.
 
 `POST /api/orbiters/signups` is the community site's signup endpoint, moved here
 unchanged on 2026-09-09: the website's form and the ChatGPT Ads conversion still post

--- a/projects/hub/apps/api/src/orbiters_api/routers/admin.py
+++ b/projects/hub/apps/api/src/orbiters_api/routers/admin.py
@@ -3,14 +3,15 @@
 One cookie, `orbiters_admin`, opaque and httpOnly, resolved against `admin_sessions` on
 every request (`deps.get_admin`). The login shares the public token bucket, so a
 password guess costs the same budget as a signup flood. Everything under this router
-reads or moves rows other people wrote; nothing here writes on their behalf.
+reads or moves rows other people wrote, or adds one more admin (ORB-123); nothing here
+writes on an applicant's behalf.
 """
 
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response, status
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 from orbiters_api.deps import ADMIN_COOKIE, AdminDep, SessionDep, SettingsDep
 from orbiters_api.downloads import cv_response
@@ -19,6 +20,7 @@ from orbiters_core.admin import AdminRead, AdminService
 from orbiters_core.comments import CommentService
 from orbiters_core.companies import CompanyService
 from orbiters_core.freelancers import FreelancerService
+from orbiters_core.models import NAME_MAX_LENGTH
 from orbiters_core.schemas import (
     CommentCreate,
     CommentRead,
@@ -30,6 +32,7 @@ from orbiters_core.schemas import (
     StatusChange,
 )
 from orbiters_core.service import SignupService
+from orbiters_core.validation import SafeStr
 
 router = APIRouter(prefix="/api/hub", tags=["hub-admin"])
 
@@ -41,11 +44,16 @@ class LoginRequest(BaseModel):
 
 class AdminCreate(BaseModel):
     """The form behind «Amministratori»: the creating admin chooses the password and
-    hands it over out of band, as `orbiters createadmin` does (ORB-123). The length rule
-    lives in `AdminService.create`, once, so the CLI and the form agree."""
+    hands it over out of band, as `orbiters createadmin` does (ORB-123). The rules on the
+    password and the name live in `AdminService.create`, once, so the CLI and the form
+    agree; this only closes what a body can carry that a prompt cannot: a NUL byte, a
+    key nobody declared (`attivo` is not for the caller to choose), and a name past the
+    column before Postgres sees it."""
+
+    model_config = ConfigDict(extra="forbid")
 
     email: EmailStr
-    nome: str
+    nome: SafeStr = Field(min_length=1, max_length=NAME_MAX_LENGTH)
     password: str
 
 

--- a/projects/hub/apps/api/src/orbiters_api/routers/admin.py
+++ b/projects/hub/apps/api/src/orbiters_api/routers/admin.py
@@ -39,6 +39,16 @@ class LoginRequest(BaseModel):
     password: str
 
 
+class AdminCreate(BaseModel):
+    """The form behind «Amministratori»: the creating admin chooses the password and
+    hands it over out of band, as `orbiters createadmin` does (ORB-123). The length rule
+    lives in `AdminService.create`, once, so the CLI and the form agree."""
+
+    email: EmailStr
+    nome: str
+    password: str
+
+
 @router.post("/auth/login", response_model=AdminRead)
 def login(
     payload: LoginRequest,
@@ -77,6 +87,24 @@ def logout(
 @router.get("/auth/me", response_model=AdminRead)
 def me(admin: AdminDep) -> AdminRead:
     return admin
+
+
+# ---- the admins ------------------------------------------------------------------------
+#
+# Who reads this area, and one more of them. No deactivation and no deletion here, on
+# purpose (ORB-123): the `attivo` flag exists and nothing in the area changes it yet.
+
+
+@router.get("/admins", response_model=list[AdminRead])
+def list_admins(_: AdminDep, session: SessionDep, settings: SettingsDep) -> list[AdminRead]:
+    return AdminService(session, settings).list()
+
+
+@router.post("/admins", response_model=AdminRead, status_code=status.HTTP_201_CREATED)
+def create_admin(
+    _: AdminDep, session: SessionDep, settings: SettingsDep, payload: AdminCreate
+) -> AdminRead:
+    return AdminService(session, settings).create(payload.email, payload.nome, payload.password)
 
 
 # ---- the lists -------------------------------------------------------------------------

--- a/projects/hub/apps/api/tests/test_admin_api.py
+++ b/projects/hub/apps/api/tests/test_admin_api.py
@@ -52,8 +52,14 @@ def test_without_the_cookie_every_admin_route_is_a_401(client: TestClient, admin
         "/api/hub/freelancers",
         "/api/hub/companies",
         "/api/hub/signups",
+        "/api/hub/admins",
     ):
         assert client.get(path).status_code == 401, path
+    refused = client.post(
+        "/api/hub/admins",
+        json={"email": "x@orbiters.it", "nome": "X", "password": "una-password-lunga"},
+    )
+    assert refused.status_code == 401
 
 
 def test_login_sets_a_secure_httponly_cookie_and_the_lists_open(
@@ -203,3 +209,68 @@ def test_a_comment_on_a_missing_row_is_a_404_and_an_empty_one_a_422_naming_the_f
     )
     assert forged.status_code == 422
     assert client.get(f"/api/hub/freelancers/{freelancer_id}/comments").json() == []
+
+
+# ---- admins ----------------------------------------------------------------------------
+#
+# ORB-123: an admin creates the next one from the area, with the CLI's own rules, and the
+# list says who is there. No deactivation and no deletion here, on purpose.
+
+
+def test_an_admin_lists_the_admins_and_creates_one_who_can_then_log_in(
+    client: TestClient, admin: None
+) -> None:
+    _login(client)
+    before = client.get("/api/hub/admins")
+    assert before.status_code == 200
+    assert [row["email"] for row in before.json()] == ["ivan@orbiters.it"]
+    assert before.json()[0]["attivo"] is True and "created_at" in before.json()[0]
+    assert "password_hash" not in before.json()[0]
+
+    created = client.post(
+        "/api/hub/admins",
+        json={
+            "email": "Lorenzo@Orbiters.it",
+            "nome": " Lorenzo ",
+            "password": "una-password-lunga",
+        },
+    )
+    assert created.status_code == 201, created.text
+    assert created.json()["email"] == "lorenzo@orbiters.it"
+    assert created.json()["nome"] == "Lorenzo"
+    assert "password" not in created.text and "password_hash" not in created.text
+
+    after = client.get("/api/hub/admins").json()
+    assert [row["email"] for row in after] == ["ivan@orbiters.it", "lorenzo@orbiters.it"]
+
+    # The new admin's credentials open a session of their own.
+    assert client.post("/api/hub/auth/logout").status_code == 204
+    login = client.post(
+        "/api/hub/auth/login",
+        json={"email": "lorenzo@orbiters.it", "password": "una-password-lunga"},
+    )
+    assert login.status_code == 200 and login.json()["nome"] == "Lorenzo"
+
+
+def test_creating_an_admin_points_the_form_at_the_field_that_is_wrong(
+    client: TestClient, admin: None
+) -> None:
+    _login(client)
+    duplicate = client.post(
+        "/api/hub/admins",
+        json={"email": "IVAN@orbiters.it", "nome": "Ancora", "password": "una-password-lunga"},
+    )
+    assert duplicate.status_code == 422
+    assert duplicate.json()["detail"][0]["loc"][-1] == "email"
+    short = client.post(
+        "/api/hub/admins", json={"email": "corta@orbiters.it", "nome": "Corta", "password": "breve"}
+    )
+    assert short.status_code == 422
+    assert short.json()["detail"][0]["loc"][-1] == "password"
+    malformed = client.post(
+        "/api/hub/admins",
+        json={"email": "non-una-mail", "nome": "X", "password": "una-password-lunga"},
+    )
+    assert malformed.status_code == 422
+    assert malformed.json()["detail"][0]["loc"][-1] == "email"
+    assert [row["email"] for row in client.get("/api/hub/admins").json()] == ["ivan@orbiters.it"]

--- a/projects/hub/apps/api/tests/test_admin_api.py
+++ b/projects/hub/apps/api/tests/test_admin_api.py
@@ -273,4 +273,23 @@ def test_creating_an_admin_points_the_form_at_the_field_that_is_wrong(
     )
     assert malformed.status_code == 422
     assert malformed.json()["detail"][0]["loc"][-1] == "email"
+    for nome in ("   ", "x" * 121, "Ada\x00"):
+        bad_name = client.post(
+            "/api/hub/admins",
+            json={"email": "nome@orbiters.it", "nome": nome, "password": "una-password-lunga"},
+        )
+        assert bad_name.status_code == 422, nome
+        assert bad_name.json()["detail"][0]["loc"][-1] == "nome"
+    # A key the schema does not declare is refused, not silently dropped: nobody creates
+    # an admin with `attivo` chosen from outside.
+    extra = client.post(
+        "/api/hub/admins",
+        json={
+            "email": "extra@orbiters.it",
+            "nome": "Extra",
+            "password": "una-password-lunga",
+            "attivo": False,
+        },
+    )
+    assert extra.status_code == 422
     assert [row["email"] for row in client.get("/api/hub/admins").json()] == ["ivan@orbiters.it"]

--- a/projects/hub/apps/web/src/lib/api.test.ts
+++ b/projects/hub/apps/web/src/lib/api.test.ts
@@ -76,6 +76,22 @@ describe('the api client', () => {
     expect((body.get('cv') as File).name).toBe('cv.pdf')
   })
 
+  it('lists the admins and creates one as JSON, with the password in the body only', async () => {
+    // ORB-123: the list and the form behind «Amministratori».
+    const spy = vi.spyOn(globalThis, 'fetch')
+    spy.mockResolvedValueOnce(answer(200, [{ id: '1', email: 'ivan@orbiters.it', nome: 'Ivan', attivo: true, created_at: '2026-09-10T10:00:00Z' }]))
+    const listed = await admin.admins()
+    expect(spy.mock.calls[0]![0]).toBe('/api/hub/admins')
+    expect(listed[0]!.email).toBe('ivan@orbiters.it')
+    spy.mockResolvedValueOnce(answer(201, { id: '2', email: 'lorenzo@orbiters.it', nome: 'Lorenzo', attivo: true, created_at: '2026-09-10T10:01:00Z' }))
+    const created = await admin.createAdmin({ email: 'lorenzo@orbiters.it', nome: 'Lorenzo', password: 'una-password-lunga' })
+    const [url, init] = spy.mock.calls[1]!
+    expect(url).toBe('/api/hub/admins')
+    expect(init?.method).toBe('POST')
+    expect(JSON.parse(init?.body as string)).toEqual({ email: 'lorenzo@orbiters.it', nome: 'Lorenzo', password: 'una-password-lunga' })
+    expect(created.nome).toBe('Lorenzo')
+  })
+
   it('points the admin at the CV route by id', () => {
     expect(admin.cvUrl('abc')).toBe('/api/hub/freelancers/abc/cv')
   })

--- a/projects/hub/apps/web/src/lib/api.ts
+++ b/projects/hub/apps/web/src/lib/api.ts
@@ -113,6 +113,15 @@ export interface Admin {
   id: string
   email: string
   nome: string
+  attivo: boolean
+  created_at: string
+}
+
+/** What the «Amministratori» form sends. The password travels here and nowhere else. */
+export interface AdminCreate {
+  email: string
+  nome: string
+  password: string
 }
 
 export interface Freelancer {
@@ -204,6 +213,9 @@ export const admin = {
       body: JSON.stringify({ stato, note }),
     }),
   signups: () => request<{ totale: number; iscrizioni: Signup[] }>('/api/hub/signups?limit=500'),
+  /** Who reads this area, oldest first, and one more of them (ORB-123). */
+  admins: () => request<Admin[]>('/api/hub/admins'),
+  createAdmin: (data: AdminCreate) => request<Admin>('/api/hub/admins', json(data)),
   comments: (kind: CommentKind, id: string) =>
     request<Comment[]>(`/api/hub/${kind}/${id}/comments`),
   /** The author is the session's, so the body is the text alone. */

--- a/projects/hub/apps/web/src/pages/admin/AdminLayout.tsx
+++ b/projects/hub/apps/web/src/pages/admin/AdminLayout.tsx
@@ -1,5 +1,5 @@
 import { Link, Outlet, useNavigate } from '@tanstack/react-router'
-import { Briefcase, LogOut, Mail, UserRound } from 'lucide-react'
+import { Briefcase, LogOut, Mail, ShieldCheck, UserRound } from 'lucide-react'
 import { useEffect } from 'react'
 import { BrandMark } from '@/components/BrandMark'
 import { Button } from '@/components/ui/button'
@@ -9,6 +9,7 @@ const NAV = [
   { to: '/admin/freelance', label: 'Developer e CTO', icon: UserRound },
   { to: '/admin/aziende', label: 'Aziende', icon: Briefcase },
   { to: '/admin/iscrizioni', label: 'Iscrizioni', icon: Mail },
+  { to: '/admin/amministratori', label: 'Amministratori', icon: ShieldCheck },
 ] as const
 
 /** The admin area's frame: the CRM's dark sidebar, in miniature. Nothing renders until

--- a/projects/hub/apps/web/src/pages/admin/Admins.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.tsx
@@ -9,6 +9,7 @@ import { formatDate } from '@/lib/format'
 import { Empty, Header } from './lists'
 
 const ADMINS_KEY = ['admins'] as const
+/** Mirrors `PASSWORD_MIN_LENGTH` in `orbiters_core.admin`; the API is the one that refuses. */
 const PASSWORD_MIN_LENGTH = 10
 
 const EMPTY: AdminCreate = { nome: '', email: '', password: '' }
@@ -105,7 +106,6 @@ export function AdminAdmins() {
               value={draft.nome}
               onChange={(event) => field('nome')(event.target.value)}
               aria-invalid={wrong('nome')}
-              disabled={create.isPending}
             />
           </div>
           <div className="space-y-2">
@@ -118,7 +118,6 @@ export function AdminAdmins() {
               value={draft.email}
               onChange={(event) => field('email')(event.target.value)}
               aria-invalid={wrong('email')}
-              disabled={create.isPending}
             />
           </div>
           <div className="space-y-2">
@@ -132,7 +131,6 @@ export function AdminAdmins() {
               value={draft.password}
               onChange={(event) => field('password')(event.target.value)}
               aria-invalid={wrong('password')}
-              disabled={create.isPending}
             />
           </div>
           {message && (

--- a/projects/hub/apps/web/src/pages/admin/Admins.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.tsx
@@ -1,0 +1,158 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState, type FormEvent } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ApiError, admin, type AdminCreate } from '@/lib/api'
+import { formatDate } from '@/lib/format'
+import { Empty, Header } from './lists'
+
+const ADMINS_KEY = ['admins'] as const
+const PASSWORD_MIN_LENGTH = 10
+
+const EMPTY: AdminCreate = { nome: '', email: '', password: '' }
+
+/**
+ * Who reads this area, and the form that adds one more (ORB-123). The creating admin
+ * chooses the password and hands it over out of band, as `orbiters createadmin` does on
+ * the server; the rules (one address, ten characters) are the service's, and a 422
+ * comes back naming the field, so the form points at it rather than blaming everything.
+ * No deactivation and no deletion here, on purpose.
+ */
+export function AdminAdmins() {
+  const client = useQueryClient()
+  const list = useQuery({ queryKey: ADMINS_KEY, queryFn: () => admin.admins() })
+  const [draft, setDraft] = useState<AdminCreate>(EMPTY)
+  const [created, setCreated] = useState<string | null>(null)
+  const create = useMutation({
+    mutationFn: (data: AdminCreate) => admin.createAdmin(data),
+    onSuccess: (made) => {
+      setDraft(EMPTY)
+      setCreated(made.email)
+      void client.invalidateQueries({ queryKey: ADMINS_KEY })
+    },
+  })
+
+  const failure = create.error instanceof ApiError ? create.error : null
+  const message = failure
+    ? failure.message
+    : create.error
+      ? 'Non riesco a creare l’amministratore.'
+      : null
+  const wrong = (field: keyof AdminCreate) => failure?.fields.includes(field) || undefined
+
+  function submit(event: FormEvent) {
+    event.preventDefault()
+    setCreated(null)
+    create.mutate({ ...draft, nome: draft.nome.trim(), email: draft.email.trim() })
+  }
+
+  function field(name: keyof AdminCreate) {
+    return (value: string) => setDraft((current) => ({ ...current, [name]: value }))
+  }
+
+  return (
+    <>
+      <Header title="Amministratori" count={list.data?.length} />
+
+      {list.isError ? (
+        <Empty>Non riesco a leggere la lista.</Empty>
+      ) : list.isPending ? (
+        <Empty>Caricamento…</Empty>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs text-muted-foreground">
+            <tr className="border-b">
+              <th className="px-6 py-2 font-medium">Chi</th>
+              <th className="px-3 py-2 font-medium">Stato</th>
+              <th className="px-6 py-2 text-right font-medium">Da quando</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.data.map((row) => (
+              <tr key={row.id} className="border-b last:border-0 hover:bg-muted">
+                <td className="px-6 py-2.5">
+                  <p className="font-medium">{row.nome}</p>
+                  <p className="text-xs text-muted-foreground">{row.email}</p>
+                </td>
+                <td className="px-3 py-2.5">
+                  <Badge variant="pill">{row.attivo ? 'Attivo' : 'Disattivato'}</Badge>
+                </td>
+                <td className="px-6 py-2.5 text-right text-muted-foreground">{formatDate(row.created_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <section aria-labelledby="nuovo-admin" className="border-t px-6 py-6">
+        <h2 id="nuovo-admin" className="text-sm font-medium">
+          Nuovo amministratore
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Scegli tu la password, almeno {PASSWORD_MIN_LENGTH} caratteri, e comunicala a voce o su un
+          canale sicuro: qui non viene inviata nessuna email.
+        </p>
+        <form onSubmit={submit} className="mt-4 grid max-w-2xl gap-4 sm:grid-cols-3">
+          <div className="space-y-2">
+            <Label htmlFor="admin-nome">Nome</Label>
+            <Input
+              id="admin-nome"
+              required
+              maxLength={120}
+              autoComplete="off"
+              value={draft.nome}
+              onChange={(event) => field('nome')(event.target.value)}
+              aria-invalid={wrong('nome')}
+              disabled={create.isPending}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="admin-email">Email</Label>
+            <Input
+              id="admin-email"
+              type="email"
+              required
+              autoComplete="off"
+              value={draft.email}
+              onChange={(event) => field('email')(event.target.value)}
+              aria-invalid={wrong('email')}
+              disabled={create.isPending}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="admin-password">Password</Label>
+            <Input
+              id="admin-password"
+              type="password"
+              required
+              minLength={PASSWORD_MIN_LENGTH}
+              autoComplete="new-password"
+              value={draft.password}
+              onChange={(event) => field('password')(event.target.value)}
+              aria-invalid={wrong('password')}
+              disabled={create.isPending}
+            />
+          </div>
+          {message && (
+            <p role="alert" className="text-sm text-destructive sm:col-span-3">
+              {message}
+            </p>
+          )}
+          {created && !create.isPending && !create.error && (
+            <p role="status" className="text-sm sm:col-span-3">
+              Amministratore creato: <span className="font-medium">{created}</span>. Ora può accedere
+              con la password che gli hai dato.
+            </p>
+          )}
+          <div className="sm:col-span-3">
+            <Button type="submit" size="sm" disabled={create.isPending}>
+              {create.isPending ? 'Creo…' : 'Crea amministratore'}
+            </Button>
+          </div>
+        </form>
+      </section>
+    </>
+  )
+}

--- a/projects/hub/apps/web/src/pages/admin/lists.tsx
+++ b/projects/hub/apps/web/src/pages/admin/lists.tsx
@@ -36,7 +36,7 @@ function StatePill({ stato }: { stato: string }) {
   )
 }
 
-function Header({ title, count, children }: { title: string; count?: number; children?: React.ReactNode }) {
+export function Header({ title, count, children }: { title: string; count?: number; children?: React.ReactNode }) {
   return (
     <header className="flex flex-wrap items-center justify-between gap-3 border-b px-6 py-5">
       <h1 className="text-2xl font-semibold tracking-tight">
@@ -76,7 +76,7 @@ function StateFilter({
   )
 }
 
-function Empty({ children }: { children: React.ReactNode }) {
+export function Empty({ children }: { children: React.ReactNode }) {
   return <p className="px-6 py-10 text-center text-sm text-muted-foreground">{children}</p>
 }
 

--- a/projects/hub/apps/web/src/router.tsx
+++ b/projects/hub/apps/web/src/router.tsx
@@ -10,6 +10,7 @@ import { CompanyWizard } from '@/pages/CompanyWizard'
 import { FreelancerWizard } from '@/pages/FreelancerWizard'
 import { Thanks } from '@/pages/Thanks'
 import { AdminLayout } from '@/pages/admin/AdminLayout'
+import { AdminAdmins } from '@/pages/admin/Admins'
 import { AdminLogin } from '@/pages/admin/Login'
 import {
   AdminCompanies,
@@ -97,6 +98,11 @@ const adminIscrizioni = createRoute({
   path: '/iscrizioni',
   component: AdminSignups,
 })
+const adminAmministratori = createRoute({
+  getParentRoute: () => adminArea,
+  path: '/amministratori',
+  component: AdminAdmins,
+})
 
 const routeTree = root.addChildren([
   publicLayout.addChildren([
@@ -109,7 +115,14 @@ const routeTree = root.addChildren([
     io.addChildren([ioIndex, ioModifica]),
   ]),
   adminLogin,
-  adminArea.addChildren([adminFreelance, adminFreelanceDetail, adminAziende, adminAziendeDetail, adminIscrizioni]),
+  adminArea.addChildren([
+    adminFreelance,
+    adminFreelanceDetail,
+    adminAziende,
+    adminAziendeDetail,
+    adminIscrizioni,
+    adminAmministratori,
+  ]),
 ])
 
 export const router = createRouter({ routeTree, basepath: '/hub' })

--- a/projects/hub/packages/core/src/orbiters_core/admin.py
+++ b/projects/hub/packages/core/src/orbiters_core/admin.py
@@ -21,11 +21,16 @@ _hasher = PasswordHasher()
 
 
 class AdminRead(BaseModel):
+    """An admin as the area shows them: never the hash. `attivo` and `created_at` are
+    here for the list of admins (ORB-123); `/auth/me` carries them too, harmlessly."""
+
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
     email: str
     nome: str
+    attivo: bool
+    created_at: datetime
 
 
 def _hash_token(raw: str) -> str:
@@ -37,9 +42,17 @@ class AdminService:
         self.session = session
         self.settings = settings
 
+    def list(self) -> list[AdminRead]:
+        """Every admin, oldest first, so the page reads as a history (ORB-123)."""
+        rows = self.session.scalars(
+            select(AdminUser).order_by(AdminUser.created_at, AdminUser.id)
+        ).all()
+        return [AdminRead.model_validate(row) for row in rows]
+
     def create(self, email: str, nome: str, password: str) -> AdminRead:
-        """`orbiters createadmin`. Refuses a second admin with the same address and a
-        password shorter than ten characters; hashes with argon2, never stores it."""
+        """`orbiters createadmin`, and since ORB-123 the form in the admin area. Refuses
+        a second admin with the same address and a password shorter than ten characters;
+        hashes with argon2, never stores it."""
         email = email.strip().lower()
         if len(password) < PASSWORD_MIN_LENGTH:
             raise ValidationFailed(ENTITY, "password", f"almeno {PASSWORD_MIN_LENGTH} caratteri")

--- a/projects/hub/packages/core/src/orbiters_core/admin.py
+++ b/projects/hub/packages/core/src/orbiters_core/admin.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 
 from orbiters_core.config import Settings
 from orbiters_core.errors import ValidationFailed
-from orbiters_core.models import AdminSession, AdminUser
+from orbiters_core.models import NAME_MAX_LENGTH, AdminSession, AdminUser
 
 ENTITY = "admin"
 PASSWORD_MIN_LENGTH = 10
@@ -51,14 +51,19 @@ class AdminService:
 
     def create(self, email: str, nome: str, password: str) -> AdminRead:
         """`orbiters createadmin`, and since ORB-123 the form in the admin area. Refuses
-        a second admin with the same address and a password shorter than ten characters;
-        hashes with argon2, never stores it."""
+        a second admin with the same address, a blank or over-long name and a password
+        shorter than ten characters; hashes with argon2, never stores it."""
         email = email.strip().lower()
+        nome = nome.strip()
+        if not nome:
+            raise ValidationFailed(ENTITY, "nome", "serve un nome")
+        if len(nome) > NAME_MAX_LENGTH:
+            raise ValidationFailed(ENTITY, "nome", f"al massimo {NAME_MAX_LENGTH} caratteri")
         if len(password) < PASSWORD_MIN_LENGTH:
             raise ValidationFailed(ENTITY, "password", f"almeno {PASSWORD_MIN_LENGTH} caratteri")
         if self._by_email(email) is not None:
             raise ValidationFailed(ENTITY, "email", "esiste già un amministratore con questa email")
-        row = AdminUser(email=email, nome=nome.strip(), password_hash=_hasher.hash(password))
+        row = AdminUser(email=email, nome=nome, password_hash=_hasher.hash(password))
         self.session.add(row)
         self.session.commit()
         return AdminRead.model_validate(row)

--- a/projects/hub/packages/core/src/orbiters_core/models.py
+++ b/projects/hub/packages/core/src/orbiters_core/models.py
@@ -189,8 +189,9 @@ ADMIN_SESSION_TOKEN_HASH_LENGTH = 64  # sha256, hex
 
 
 class AdminUser(Base, PrimaryKeyMixin, TimestampMixin):
-    """Whoever reads the hub's admin area. Created by `orbiters createadmin`, never by a
-    form: the hub has no public account, only applicants and the people who read them."""
+    """Whoever reads the hub's admin area. Created by `orbiters createadmin` or, since
+    ORB-123, by another admin from «Amministratori»; never by a public form: the hub has
+    no public account, only applicants and the people who read them."""
 
     __tablename__ = "admin_users"
 

--- a/projects/hub/packages/core/tests/test_admin.py
+++ b/projects/hub/packages/core/tests/test_admin.py
@@ -74,3 +74,21 @@ def test_a_session_is_opaque_hashed_sliding_and_closable(
     again = admins.open_session(admin.id)
     admins.close_session(again)
     assert admins.resolve(again) is None
+
+
+def test_list_names_every_admin_oldest_first_and_says_who_is_active(
+    admins: AdminService, hub_session: Session
+) -> None:
+    # ORB-123: the admin area lists who reads it. Oldest first, so the page reads as a
+    # history; `attivo` and `created_at` come along, the hash never does.
+    first = admins.create("ivan@orbiters.it", "Ivan", "una-password-lunga")
+    second = admins.create("lorenzo@orbiters.it", "Lorenzo", "altra-password-lunga")
+    hub_session.execute(
+        text("UPDATE admin_users SET attivo = false WHERE email = 'lorenzo@orbiters.it'")
+    )
+    hub_session.commit()
+    listed = admins.list()
+    assert [row.email for row in listed] == [first.email, second.email]
+    assert [row.attivo for row in listed] == [True, False]
+    assert all(row.created_at is not None for row in listed)
+    assert not any(hasattr(row, "password_hash") for row in listed)

--- a/projects/hub/packages/core/tests/test_admin.py
+++ b/projects/hub/packages/core/tests/test_admin.py
@@ -36,6 +36,14 @@ def test_an_admin_is_created_once_and_the_password_is_never_stored(
         admins.create("ivan@orbiters.it", "Ancora", "altra-password-lunga")
     with pytest.raises(ValidationFailed):
         admins.create("corta@orbiters.it", "Corta", "breve")
+    # A name that is only whitespace, or longer than the column, is refused here and not
+    # left to Postgres (ORB-123 review): the CLI and the form share the rule.
+    with pytest.raises(ValidationFailed) as blank:
+        admins.create("vuoto@orbiters.it", "   ", "una-password-lunga")
+    assert blank.value.details["field"] == "nome"
+    with pytest.raises(ValidationFailed) as long_name:
+        admins.create("lungo@orbiters.it", "x" * 121, "una-password-lunga")
+    assert long_name.value.details["field"] == "nome"
 
 
 def test_authenticate_answers_none_for_every_wrong_answer(admins: AdminService) -> None:


### PR DESCRIPTION
## What this changes

Until now the only way to add a reader of the hub's admin area was ssh and `orbiters createadmin` on the server, and nothing in the area said who the admins are. The sidebar gains a fourth entry, «Amministratori», at `/hub/admin/amministratori`: the list of admins (nome, email, «Attivo» or «Disattivato», since when) and a form with nome, email and password, «Crea amministratore». On success the list grows by one row, the form empties and a line says «Amministratore creato: ada@orbiters.it. Ora può accedere con la password che gli hai dato.» A duplicate address or a short password comes back as a 422 naming the field, and the form marks that field and shows the sentence.

Behind it, `GET /api/hub/admins` and `POST /api/hub/admins`, both under the same cookie as everything else in the area. The POST reuses `AdminService.create`, so the rules are the CLI's (one address, ten characters, argon2). `AdminRead` now carries `attivo` and `created_at`; the hash never leaves the service.

Ivan chose, on 2026-09-10, that the creating admin picks the password and hands it over out of band, as the CLI does; an invitation by email with a set-password link was the other option and is a possible follow-up (recorded on ORB-123).

## How I verified it

- `uv run pytest -q projects/hub/packages/core/tests projects/hub/apps/api/tests projects/hub/apps/mcp/tests`: 164 passed. The four new tests failed before the implementation (`AttributeError` on `list`, 404s on `/api/hub/admins`) and pass after. They cover: the core list (oldest first, `attivo`, no hash), the two routes without a cookie (401), the list and a creation whose new admin then logs in, and the three refusals (duplicate email, short password, malformed address) as 422 on the right field.
- `uv run ruff check projects/hub`, `ruff format --check`, `uv run mypy`: clean.
- `pnpm --filter hub test`: 45 passed (a new client test for `admins()` and `createAdmin()`); `lint` clean; `build` (vite plus `tsc --noEmit`) ok.
- In a real browser against a throwaway Postgres, migrated to head, with the API on 8084 and the dev server on 5190: logged in, opened «Amministratori», tried a five-character password (the browser's own `minLength` stops it), then a duplicate address (the alert reads «esiste già un amministratore con questa email» and the email field is `aria-invalid`), then a valid one: the status line appears, the table goes from two rows to three, the fields empty. The new admin's credentials then answer 200 on `/api/hub/auth/login`.

## What did not change, on purpose

Deactivating or deleting an admin: the `attivo` flag exists and the list shows it, but nothing in the area changes it. A change-password flow for the admin themself. A `create_admin` MCP tool: `projects/hub/apps/mcp` is an admin by construction and nobody asked an agent to create accounts, so `tests/test_tools.py` is untouched. All three recorded on ORB-123.

## API changes

- `GET /api/hub/admins`, admin cookie, 200 with a list of `AdminRead`.
- `POST /api/hub/admins`, admin cookie, body `{email, nome, password}`, 201 with the `AdminRead`; 422 in FastAPI's shape on `email` (duplicate, or not an address) or `password` (under ten characters); 401 without the cookie.
- `AdminRead` (also the shape of `/auth/me` and of the login response) gains `attivo: bool` and `created_at: datetime`.
- The hub's hand-written client `projects/hub/apps/web/src/lib/api.ts`: `Admin` gains the two fields, a new `AdminCreate` type, and `admin.admins()` / `admin.createAdmin()`.

## Anything a reviewer should look at twice

- `AdminRead` widening also reaches `/auth/me`: harmless, but it is a shape shared by three responses.
- `Header` and `Empty` in `pages/admin/lists.tsx` are now exported and reused by the new page rather than copied.
- The form disables its fields while the request runs; the password field uses `autoComplete="new-password"` so a browser does not offer to save the creating admin's own password into it.

## Screenshots

**1. The sidebar, on the freelancers list**
![The admin sidebar, before and after](https://github.com/user-attachments/assets/aab88980-b9b9-41c8-922a-530e7b1f0180)

**2. /hub/admin/amministratori: Not Found before, the list and the form after**
![The Amministratori page, before and after](https://github.com/user-attachments/assets/88990c54-496d-4939-b1a8-3eee42392b23)

Linear: ORB-123.
