### PR TITLE
feat(hub): the new-admin form lives in a dialog behind a button, not on the page

### DIFF
--- a/projects/hub/apps/web/src/components/ui/dialog.tsx
+++ b/projects/hub/apps/web/src/components/ui/dialog.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react'
+import { XIcon } from 'lucide-react'
+import { Dialog as DialogPrimitive } from 'radix-ui'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+/**
+ * The hub's dialog, copied from PigroCRM's primitive as the others here are (hub spec §
+ * Web: the two products copy, never import across). Radix does the work that matters in
+ * a modal: focus goes in on open and back to the trigger on close, Escape and the
+ * backdrop close it, the page behind is inert. No entrance animation on purpose: the
+ * tokens file declares none of the variants PigroCRM's copy relies on.
+ */
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn('fixed inset-0 z-50 bg-black/20', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl border bg-card p-6 text-sm shadow-lg outline-none sm:max-w-md',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close data-slot="dialog-close" asChild>
+          <Button variant="ghost" size="icon-sm" className="absolute top-3 right-3">
+            <XIcon />
+            <span className="sr-only">Chiudi</span>
+          </Button>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="dialog-header" className={cn('flex flex-col gap-1.5', className)} {...props} />
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg font-semibold tracking-tight', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/projects/hub/apps/web/src/pages/admin/Admins.test.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AdminAdmins } from './Admins'
+
+const IVAN = { id: '1', email: 'ivan@orbiters.it', nome: 'Ivan', attivo: true, created_at: '2026-09-10T10:00:00Z' }
+const ADA = { id: '2', email: 'ada@orbiters.it', nome: 'Ada', attivo: true, created_at: '2026-09-10T11:00:00Z' }
+
+function answer(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+function mount() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <AdminAdmins />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('the Amministratori page', () => {
+  it('shows the list alone, and the form only inside a dialog the button opens', async () => {
+    // ORB-125: Ivan wants the form behind a button, not on the page.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(200, [IVAN]))
+    mount()
+    await screen.findByText('ivan@orbiters.it')
+    expect(screen.queryByLabelText('Nome')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Nuovo amministratore' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Nuovo amministratore' })
+    expect(within(dialog).getByLabelText('Nome')).toHaveFocus()
+    expect(within(dialog).getByLabelText('Email')).toBeInTheDocument()
+    expect(within(dialog).getByLabelText('Password')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Nuovo amministratore' })).toHaveFocus())
+  })
+
+  it('keeps a refused creation inside the dialog, on the field the server names', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch')
+    spy.mockResolvedValueOnce(answer(200, [IVAN]))
+    spy.mockResolvedValueOnce(
+      answer(422, { detail: [{ loc: ['body', 'email'], msg: 'esiste già un amministratore con questa email' }] }),
+    )
+    mount()
+    await screen.findByText('ivan@orbiters.it')
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Nuovo amministratore' }))
+    const dialog = await screen.findByRole('dialog')
+    await user.type(within(dialog).getByLabelText('Nome'), 'Ancora')
+    await user.type(within(dialog).getByLabelText('Email'), 'ivan@orbiters.it')
+    await user.type(within(dialog).getByLabelText('Password'), 'una-password-lunga')
+    await user.click(within(dialog).getByRole('button', { name: 'Crea amministratore' }))
+
+    const alert = await within(dialog).findByRole('alert')
+    expect(alert).toHaveTextContent('esiste già un amministratore con questa email')
+    expect(within(dialog).getByLabelText('Email')).toHaveAttribute('aria-invalid', 'true')
+    expect(within(dialog).getByLabelText('Nome')).not.toHaveAttribute('aria-invalid')
+    // Still open, the draft still there: the person corrects one field, not three.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(within(dialog).getByLabelText('Nome')).toHaveValue('Ancora')
+  })
+
+  it('closes on success, refreshes the list and says who was created on the page', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch')
+    spy.mockResolvedValueOnce(answer(200, [IVAN]))
+    spy.mockResolvedValueOnce(answer(201, ADA))
+    spy.mockResolvedValueOnce(answer(200, [IVAN, ADA]))
+    mount()
+    await screen.findByText('ivan@orbiters.it')
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Nuovo amministratore' }))
+    const dialog = await screen.findByRole('dialog')
+    await user.type(within(dialog).getByLabelText('Nome'), 'Ada')
+    await user.type(within(dialog).getByLabelText('Email'), 'ada@orbiters.it')
+    await user.type(within(dialog).getByLabelText('Password'), 'una-password-lunga')
+    await user.click(within(dialog).getByRole('button', { name: 'Crea amministratore' }))
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(await screen.findByRole('status')).toHaveTextContent('ada@orbiters.it')
+    await screen.findByText('ada@orbiters.it', { selector: 'td p' })
+    const [, init] = spy.mock.calls[1]!
+    expect(init?.method).toBe('POST')
+    expect(JSON.parse(init?.body as string)).toEqual({ nome: 'Ada', email: 'ada@orbiters.it', password: 'una-password-lunga' })
+
+    // Opening it again starts from an empty form.
+    await user.click(screen.getByRole('button', { name: 'Nuovo amministratore' }))
+    expect(within(await screen.findByRole('dialog')).getByLabelText('Nome')).toHaveValue('')
+  })
+})

--- a/projects/hub/apps/web/src/pages/admin/Admins.test.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.test.tsx
@@ -25,7 +25,7 @@ afterEach(() => vi.restoreAllMocks())
 describe('the Amministratori page', () => {
   it('shows the list alone, and the form only inside a dialog the button opens', async () => {
     // ORB-125: Ivan wants the form behind a button, not on the page.
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(200, [IVAN]))
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => answer(200, [IVAN]))
     mount()
     await screen.findByText('ivan@orbiters.it')
     expect(screen.queryByLabelText('Nome')).toBeNull()
@@ -66,6 +66,43 @@ describe('the Amministratori page', () => {
     // Still open, the draft still there: the person corrects one field, not three.
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(within(dialog).getByLabelText('Nome')).toHaveValue('Ancora')
+
+    // «Annulla» closes it, and the next opening carries neither the error nor the draft.
+    await user.click(within(dialog).getByRole('button', { name: 'Annulla' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    await user.click(screen.getByRole('button', { name: 'Nuovo amministratore' }))
+    const again = await screen.findByRole('dialog')
+    expect(within(again).queryByRole('alert')).toBeNull()
+    expect(within(again).getByLabelText('Email')).not.toHaveAttribute('aria-invalid')
+    expect(within(again).getByLabelText('Nome')).toHaveValue('')
+  })
+
+  it('stays open while the request is out, so a late answer lands where it was asked', async () => {
+    let settle: (response: Response) => void = () => {}
+    const pending = new Promise<Response>((resolve) => (settle = resolve))
+    const spy = vi.spyOn(globalThis, 'fetch')
+    spy.mockResolvedValueOnce(answer(200, [IVAN]))
+    spy.mockReturnValueOnce(pending)
+    spy.mockResolvedValueOnce(answer(200, [IVAN, ADA]))
+    mount()
+    await screen.findByText('ivan@orbiters.it')
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Nuovo amministratore' }))
+    const dialog = await screen.findByRole('dialog')
+    await user.type(within(dialog).getByLabelText('Nome'), 'Ada')
+    await user.type(within(dialog).getByLabelText('Email'), 'ada@orbiters.it')
+    await user.type(within(dialog).getByLabelText('Password'), 'una-password-lunga')
+    await user.click(within(dialog).getByRole('button', { name: 'Crea amministratore' }))
+    expect(await within(dialog).findByRole('button', { name: 'Creo…' })).toBeDisabled()
+
+    await user.keyboard('{Escape}')
+    expect(within(dialog).getByRole('button', { name: 'Annulla' })).toBeDisabled()
+    await user.click(within(dialog).getByRole('button', { name: 'Annulla' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    settle(answer(201, ADA))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(screen.getByRole('status')).toHaveTextContent('ada@orbiters.it')
   })
 
   it('closes on success, refreshes the list and says who was created on the page', async () => {

--- a/projects/hub/apps/web/src/pages/admin/Admins.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -48,8 +49,12 @@ export function AdminAdmins() {
     },
   })
 
-  /** Every opening starts clean: an empty draft and no error from the last attempt. */
+  /** Every opening starts clean: an empty draft and no error from the last attempt. While
+   *  a request is out the dialog stays: closing it would swallow a late refusal, and a
+   *  late success would close whatever dialog had been reopened in the meantime, since
+   *  the mutation's `onSuccess` outlives `reset()`. */
   function toggle(next: boolean) {
+    if (!next && create.isPending) return
     if (next) {
       setDraft(EMPTY)
       create.reset()
@@ -75,117 +80,120 @@ export function AdminAdmins() {
   }
 
   return (
-    <>
-      <Dialog open={open} onOpenChange={toggle}>
-        <Header title="Amministratori" count={list.data?.length}>
-          {/* A Radix trigger rather than a plain button, so focus comes back here on close. */}
-          <DialogTrigger asChild>
-            <Button type="button" size="sm">
-              <Plus data-icon="inline-start" aria-hidden="true" />
-              Nuovo amministratore
-            </Button>
-          </DialogTrigger>
-        </Header>
+    <Dialog open={open} onOpenChange={toggle}>
+      <Header title="Amministratori" count={list.data?.length}>
+        {/* A Radix trigger rather than a plain button, so focus comes back here on close. */}
+        <DialogTrigger asChild>
+          <Button type="button" size="sm">
+            <Plus data-icon="inline-start" />
+            Nuovo amministratore
+          </Button>
+        </DialogTrigger>
+      </Header>
 
+      {/* Always mounted: a live region that appears already filled is often not read out. */}
+      <p role="status" aria-live="polite" className={created ? 'border-b px-6 py-3 text-sm' : undefined}>
         {created && (
-          <p role="status" className="border-b px-6 py-3 text-sm">
-            Amministratore creato: <span className="font-medium">{created}</span>. Ora può accedere con la
-            password che gli hai dato.
-          </p>
+          <>
+            Amministratore creato: <span className="font-medium">{created}</span>. Ora può accedere con
+            la password che gli hai dato.
+          </>
         )}
+      </p>
 
-        {list.isError ? (
-          <Empty>Non riesco a leggere la lista.</Empty>
-        ) : list.isPending ? (
-          <Empty>Caricamento…</Empty>
-        ) : (
-          <table className="w-full text-sm">
-            <thead className="text-left text-xs text-muted-foreground">
-              <tr className="border-b">
-                <th className="px-6 py-2 font-medium">Chi</th>
-                <th className="px-3 py-2 font-medium">Stato</th>
-                <th className="px-6 py-2 text-right font-medium">Da quando</th>
+      {list.isError ? (
+        <Empty>Non riesco a leggere la lista.</Empty>
+      ) : list.isPending ? (
+        <Empty>Caricamento…</Empty>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs text-muted-foreground">
+            <tr className="border-b">
+              <th className="px-6 py-2 font-medium">Chi</th>
+              <th className="px-3 py-2 font-medium">Stato</th>
+              <th className="px-6 py-2 text-right font-medium">Da quando</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.data.map((row) => (
+              <tr key={row.id} className="border-b last:border-0 hover:bg-muted">
+                <td className="px-6 py-2.5">
+                  <p className="font-medium">{row.nome}</p>
+                  <p className="text-xs text-muted-foreground">{row.email}</p>
+                </td>
+                <td className="px-3 py-2.5">
+                  <Badge variant="pill">{row.attivo ? 'Attivo' : 'Disattivato'}</Badge>
+                </td>
+                <td className="px-6 py-2.5 text-right text-muted-foreground">{formatDate(row.created_at)}</td>
               </tr>
-            </thead>
-            <tbody>
-              {list.data.map((row) => (
-                <tr key={row.id} className="border-b last:border-0 hover:bg-muted">
-                  <td className="px-6 py-2.5">
-                    <p className="font-medium">{row.nome}</p>
-                    <p className="text-xs text-muted-foreground">{row.email}</p>
-                  </td>
-                  <td className="px-3 py-2.5">
-                    <Badge variant="pill">{row.attivo ? 'Attivo' : 'Disattivato'}</Badge>
-                  </td>
-                  <td className="px-6 py-2.5 text-right text-muted-foreground">{formatDate(row.created_at)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
+            ))}
+          </tbody>
+        </table>
+      )}
 
-        <DialogContent>
-          <form onSubmit={submit} className="grid gap-4">
-            <DialogHeader>
-              <DialogTitle>Nuovo amministratore</DialogTitle>
-              <DialogDescription>
-                Scegli tu la password, almeno {PASSWORD_MIN_LENGTH} caratteri, e comunicala a voce o su un
-                canale sicuro: qui non viene inviata nessuna email.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-2">
-              <Label htmlFor="admin-nome">Nome</Label>
-              <Input
-                id="admin-nome"
-                required
-                maxLength={120}
-                autoComplete="off"
-                value={draft.nome}
-                onChange={(event) => field('nome')(event.target.value)}
-                aria-invalid={wrong('nome')}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="admin-email">Email</Label>
-              <Input
-                id="admin-email"
-                type="email"
-                required
-                autoComplete="off"
-                value={draft.email}
-                onChange={(event) => field('email')(event.target.value)}
-                aria-invalid={wrong('email')}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="admin-password">Password</Label>
-              <Input
-                id="admin-password"
-                type="password"
-                required
-                minLength={PASSWORD_MIN_LENGTH}
-                autoComplete="new-password"
-                value={draft.password}
-                onChange={(event) => field('password')(event.target.value)}
-                aria-invalid={wrong('password')}
-              />
-            </div>
-            {message && (
-              <p role="alert" className="text-sm text-destructive">
-                {message}
-              </p>
-            )}
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => toggle(false)}>
+      <DialogContent>
+        <form onSubmit={submit} className="grid gap-4">
+          <DialogHeader>
+            <DialogTitle>Nuovo amministratore</DialogTitle>
+            <DialogDescription>
+              Scegli tu la password, almeno {PASSWORD_MIN_LENGTH} caratteri, e comunicala a voce o su un
+              canale sicuro: qui non viene inviata nessuna email.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="admin-nome">Nome</Label>
+            <Input
+              id="admin-nome"
+              required
+              maxLength={120}
+              autoComplete="off"
+              value={draft.nome}
+              onChange={(event) => field('nome')(event.target.value)}
+              aria-invalid={wrong('nome')}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="admin-email">Email</Label>
+            <Input
+              id="admin-email"
+              type="email"
+              required
+              autoComplete="off"
+              value={draft.email}
+              onChange={(event) => field('email')(event.target.value)}
+              aria-invalid={wrong('email')}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="admin-password">Password</Label>
+            <Input
+              id="admin-password"
+              type="password"
+              required
+              minLength={PASSWORD_MIN_LENGTH}
+              autoComplete="new-password"
+              value={draft.password}
+              onChange={(event) => field('password')(event.target.value)}
+              aria-invalid={wrong('password')}
+            />
+          </div>
+          {message && (
+            <p role="alert" className="text-sm text-destructive">
+              {message}
+            </p>
+          )}
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline" disabled={create.isPending}>
                 Annulla
               </Button>
-              <Button type="submit" disabled={create.isPending}>
-                {create.isPending ? 'Creo…' : 'Crea amministratore'}
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
-    </>
+            </DialogClose>
+            <Button type="submit" disabled={create.isPending}>
+              {create.isPending ? 'Creo…' : 'Crea amministratore'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/projects/hub/apps/web/src/pages/admin/Admins.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.tsx
@@ -1,7 +1,17 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Plus } from 'lucide-react'
 import { useState, type FormEvent } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ApiError, admin, type AdminCreate } from '@/lib/api'
@@ -15,25 +25,37 @@ const PASSWORD_MIN_LENGTH = 10
 const EMPTY: AdminCreate = { nome: '', email: '', password: '' }
 
 /**
- * Who reads this area, and the form that adds one more (ORB-123). The creating admin
- * chooses the password and hands it over out of band, as `orbiters createadmin` does on
- * the server; the rules (one address, ten characters) are the service's, and a 422
- * comes back naming the field, so the form points at it rather than blaming everything.
- * No deactivation and no deletion here, on purpose.
+ * Who reads this area, and a button that adds one more (ORB-123, ORB-125). The page is
+ * the list; the form lives in a dialog behind «Nuovo amministratore», so the list reads
+ * as a list. The creating admin chooses the password and hands it over out of band, as
+ * `orbiters createadmin` does on the server; the rules (one address, ten characters) are
+ * the service's, and a 422 comes back naming the field, so the dialog stays open and
+ * points at it rather than blaming everything. On success it closes, the list refreshes
+ * and the page says who was created. No deactivation and no deletion here, on purpose.
  */
 export function AdminAdmins() {
   const client = useQueryClient()
   const list = useQuery({ queryKey: ADMINS_KEY, queryFn: () => admin.admins() })
-  const [draft, setDraft] = useState<AdminCreate>(EMPTY)
+  const [open, setOpen] = useState(false)
   const [created, setCreated] = useState<string | null>(null)
+  const [draft, setDraft] = useState<AdminCreate>(EMPTY)
   const create = useMutation({
     mutationFn: (data: AdminCreate) => admin.createAdmin(data),
     onSuccess: (made) => {
-      setDraft(EMPTY)
+      setOpen(false)
       setCreated(made.email)
       void client.invalidateQueries({ queryKey: ADMINS_KEY })
     },
   })
+
+  /** Every opening starts clean: an empty draft and no error from the last attempt. */
+  function toggle(next: boolean) {
+    if (next) {
+      setDraft(EMPTY)
+      create.reset()
+    }
+    setOpen(next)
+  }
 
   const failure = create.error instanceof ApiError ? create.error : null
   const message = failure
@@ -45,7 +67,6 @@ export function AdminAdmins() {
 
   function submit(event: FormEvent) {
     event.preventDefault()
-    setCreated(null)
     create.mutate({ ...draft, nome: draft.nome.trim(), email: draft.email.trim() })
   }
 
@@ -55,102 +76,116 @@ export function AdminAdmins() {
 
   return (
     <>
-      <Header title="Amministratori" count={list.data?.length} />
-
-      {list.isError ? (
-        <Empty>Non riesco a leggere la lista.</Empty>
-      ) : list.isPending ? (
-        <Empty>Caricamento…</Empty>
-      ) : (
-        <table className="w-full text-sm">
-          <thead className="text-left text-xs text-muted-foreground">
-            <tr className="border-b">
-              <th className="px-6 py-2 font-medium">Chi</th>
-              <th className="px-3 py-2 font-medium">Stato</th>
-              <th className="px-6 py-2 text-right font-medium">Da quando</th>
-            </tr>
-          </thead>
-          <tbody>
-            {list.data.map((row) => (
-              <tr key={row.id} className="border-b last:border-0 hover:bg-muted">
-                <td className="px-6 py-2.5">
-                  <p className="font-medium">{row.nome}</p>
-                  <p className="text-xs text-muted-foreground">{row.email}</p>
-                </td>
-                <td className="px-3 py-2.5">
-                  <Badge variant="pill">{row.attivo ? 'Attivo' : 'Disattivato'}</Badge>
-                </td>
-                <td className="px-6 py-2.5 text-right text-muted-foreground">{formatDate(row.created_at)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-
-      <section aria-labelledby="nuovo-admin" className="border-t px-6 py-6">
-        <h2 id="nuovo-admin" className="text-sm font-medium">
-          Nuovo amministratore
-        </h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Scegli tu la password, almeno {PASSWORD_MIN_LENGTH} caratteri, e comunicala a voce o su un
-          canale sicuro: qui non viene inviata nessuna email.
-        </p>
-        <form onSubmit={submit} className="mt-4 grid max-w-2xl gap-4 sm:grid-cols-3">
-          <div className="space-y-2">
-            <Label htmlFor="admin-nome">Nome</Label>
-            <Input
-              id="admin-nome"
-              required
-              maxLength={120}
-              autoComplete="off"
-              value={draft.nome}
-              onChange={(event) => field('nome')(event.target.value)}
-              aria-invalid={wrong('nome')}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="admin-email">Email</Label>
-            <Input
-              id="admin-email"
-              type="email"
-              required
-              autoComplete="off"
-              value={draft.email}
-              onChange={(event) => field('email')(event.target.value)}
-              aria-invalid={wrong('email')}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="admin-password">Password</Label>
-            <Input
-              id="admin-password"
-              type="password"
-              required
-              minLength={PASSWORD_MIN_LENGTH}
-              autoComplete="new-password"
-              value={draft.password}
-              onChange={(event) => field('password')(event.target.value)}
-              aria-invalid={wrong('password')}
-            />
-          </div>
-          {message && (
-            <p role="alert" className="text-sm text-destructive sm:col-span-3">
-              {message}
-            </p>
-          )}
-          {created && !create.isPending && !create.error && (
-            <p role="status" className="text-sm sm:col-span-3">
-              Amministratore creato: <span className="font-medium">{created}</span>. Ora può accedere
-              con la password che gli hai dato.
-            </p>
-          )}
-          <div className="sm:col-span-3">
-            <Button type="submit" size="sm" disabled={create.isPending}>
-              {create.isPending ? 'Creo…' : 'Crea amministratore'}
+      <Dialog open={open} onOpenChange={toggle}>
+        <Header title="Amministratori" count={list.data?.length}>
+          {/* A Radix trigger rather than a plain button, so focus comes back here on close. */}
+          <DialogTrigger asChild>
+            <Button type="button" size="sm">
+              <Plus data-icon="inline-start" aria-hidden="true" />
+              Nuovo amministratore
             </Button>
-          </div>
-        </form>
-      </section>
+          </DialogTrigger>
+        </Header>
+
+        {created && (
+          <p role="status" className="border-b px-6 py-3 text-sm">
+            Amministratore creato: <span className="font-medium">{created}</span>. Ora può accedere con la
+            password che gli hai dato.
+          </p>
+        )}
+
+        {list.isError ? (
+          <Empty>Non riesco a leggere la lista.</Empty>
+        ) : list.isPending ? (
+          <Empty>Caricamento…</Empty>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-left text-xs text-muted-foreground">
+              <tr className="border-b">
+                <th className="px-6 py-2 font-medium">Chi</th>
+                <th className="px-3 py-2 font-medium">Stato</th>
+                <th className="px-6 py-2 text-right font-medium">Da quando</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.data.map((row) => (
+                <tr key={row.id} className="border-b last:border-0 hover:bg-muted">
+                  <td className="px-6 py-2.5">
+                    <p className="font-medium">{row.nome}</p>
+                    <p className="text-xs text-muted-foreground">{row.email}</p>
+                  </td>
+                  <td className="px-3 py-2.5">
+                    <Badge variant="pill">{row.attivo ? 'Attivo' : 'Disattivato'}</Badge>
+                  </td>
+                  <td className="px-6 py-2.5 text-right text-muted-foreground">{formatDate(row.created_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        <DialogContent>
+          <form onSubmit={submit} className="grid gap-4">
+            <DialogHeader>
+              <DialogTitle>Nuovo amministratore</DialogTitle>
+              <DialogDescription>
+                Scegli tu la password, almeno {PASSWORD_MIN_LENGTH} caratteri, e comunicala a voce o su un
+                canale sicuro: qui non viene inviata nessuna email.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2">
+              <Label htmlFor="admin-nome">Nome</Label>
+              <Input
+                id="admin-nome"
+                required
+                maxLength={120}
+                autoComplete="off"
+                value={draft.nome}
+                onChange={(event) => field('nome')(event.target.value)}
+                aria-invalid={wrong('nome')}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="admin-email">Email</Label>
+              <Input
+                id="admin-email"
+                type="email"
+                required
+                autoComplete="off"
+                value={draft.email}
+                onChange={(event) => field('email')(event.target.value)}
+                aria-invalid={wrong('email')}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="admin-password">Password</Label>
+              <Input
+                id="admin-password"
+                type="password"
+                required
+                minLength={PASSWORD_MIN_LENGTH}
+                autoComplete="new-password"
+                value={draft.password}
+                onChange={(event) => field('password')(event.target.value)}
+                aria-invalid={wrong('password')}
+              />
+            </div>
+            {message && (
+              <p role="alert" className="text-sm text-destructive">
+                {message}
+              </p>
+            )}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => toggle(false)}>
+                Annulla
+              </Button>
+              <Button type="submit" disabled={create.isPending}>
+                {create.isPending ? 'Creo…' : 'Crea amministratore'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }


### PR DESCRIPTION
## What this changes

Ivan, after seeing ORB-123 live: «il form deve finire in una modale aperta da un pulsante non in pagina». «Amministratori» is now the list alone. A «Nuovo amministratore» button sits in the header's right slot, where the other lists keep their state filters, and opens a dialog with the same three fields. The button is a Radix trigger, so focus lands in «Nome» on open and returns to the button on close; Escape, the backdrop, the × and «Annulla» all close it. A refusal from the server keeps the dialog open with the draft and marks the field it names («esiste già un amministratore con questa email» on the email field). A success closes it, refreshes the list and leaves one line on the page: «Amministratore creato: ada@orbiters.it. Ora può accedere con la password che gli hai dato.» Every opening starts from an empty form.

The dialog primitive (`components/ui/dialog.tsx`) is the hub's own copy of PigroCRM's, as the other primitives here are, without the entrance animation whose Tailwind variants the hub's tokens do not declare.

## How I verified it

- `pnpm --filter hub test`: 48 passed, 13 files. The three new component tests in `Admins.test.tsx` failed before the change (no button, form on the page) and pass after: the list alone with the form only inside the dialog, focus in and out; a 422 kept inside the dialog on the named field with the draft intact; a 201 closing it, refreshing the list, showing the status line, and the next opening empty.
- `pnpm --filter hub lint`: clean. `build` (vite plus `tsc --noEmit`): ok.
- In a real browser against a throwaway Postgres migrated to head, API on 8084, dev server on 5190: opened the page (no form), clicked the button (dialog, focus on «Nome»), submitted a duplicate address (alert inside the dialog, still open), corrected it (dialog closed, status line, the table from two rows to three, focus back on the button).
- Nothing on the API changed; the Python suites are untouched by this diff.

## What did not change, on purpose

The API, the list, and what ORB-123 left out (deactivation, deletion, a change-password flow, an MCP tool).

## Anything a reviewer should look at twice

- The dialog primitive drops PigroCRM's `data-open:`/`data-closed:` animation classes on purpose; a copy with them would silently do nothing here.
- The status line lives on the page, not in the dialog, because the dialog is gone by the time there is something to say. It stays until the next successful creation replaces it.

## Screenshots

**1. The page: the inline form gone, the button in the header**
![The Amministratori page, before and after](https://github.com/user-attachments/assets/7bdfa3b9-1046-42ac-8d67-4cf70d923d23)

**2. The dialog open, focus on «Nome»**
![The new-admin dialog, before and after](https://github.com/user-attachments/assets/1ed5d695-f1b0-4a02-9ed8-22e17655b0f0)

Linear: ORB-125.
