### PR TITLE
feat(web): the invoice list shows the accrual period beside the date

### DIFF
--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoicesTab.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoicesTab.test.tsx
@@ -42,6 +42,12 @@ describe('InvoicesTab', () => {
     expect(screen.queryByRole('columnheader', { name: 'Cliente' })).not.toBeInTheDocument()
   })
 
+  /** The period is not what the page title already says, so the tab shows it (ORB-126). */
+  it('says which period each invoice is about, like the list page', async () => {
+    renderWithClient(<InvoicesTab owner={{ customerId: 'c1' }} />)
+    expect(await screen.findByRole('columnheader', { name: 'Competenza' })).toBeInTheDocument()
+  })
+
   /**
    * The slot exists so the button that creates an invoice sits on the tab that lists
    * them, rather than in the page header where it would be offered from every other tab

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
@@ -28,6 +28,12 @@ const PROFORMA = {
 
 const WITH_CUSTOMER = { ...ISSUED, customer_ragione_sociale: 'ACME S.r.l.' } as Invoice
 
+const WITH_PERIOD = {
+  ...ISSUED,
+  competenza_da: '2026-08-01',
+  competenza_a: '2026-08-31',
+} as Invoice
+
 function accessor(id: string, row: Invoice, options?: InvoiceColumnOptions): unknown {
   const column = buildInvoiceColumns(options).find((candidate) => candidate.id === id)
   if (column === undefined || !('accessorFn' in column) || column.accessorFn === undefined) {
@@ -189,6 +195,39 @@ describe('the customer column', () => {
     expect(screen.getByText('ACME S.r.l.')).toBeInTheDocument()
 
     renderCell('cliente', ISSUED, CLIENTE)
+    expect(screen.getByText('—').className).toContain('text-muted-foreground')
+  })
+})
+
+/**
+ * The «Competenza» column (ORB-126). Invoicing runs late here, August's work issued in
+ * September, so the emission date alone does not say which month a row is about. In the
+ * list and in the tab alike: unlike the customer's name, the period is not what the
+ * page title already says.
+ */
+describe('the accrual period column', () => {
+  it('sits right after the date, in the default columns too', () => {
+    const ids = buildInvoiceColumns().map((candidate) => candidate.id ?? '')
+    expect(ids.indexOf('competenza')).toBe(ids.indexOf('data_emissione') + 1)
+    expect(column('competenza').header).toBe('Competenza')
+  })
+
+  it('reads the period the way the detail page states it', () => {
+    expect(accessor('competenza', WITH_PERIOD)).toBe('01/08/2026 - 31/08/2026')
+  })
+
+  it('shows the em dash when the document declares no period', () => {
+    expect(accessor('competenza', ISSUED)).toBe('—')
+  })
+
+  /** The emission date is the one column with a calendar: a second icon two columns
+   *  over would make the two read as the same kind of value, and they are not. */
+  it('renders as plain text, with no calendar icon, and the dash quietly', () => {
+    const { container } = renderCell('competenza', WITH_PERIOD)
+    expect(screen.getByText('01/08/2026 - 31/08/2026')).toBeInTheDocument()
+    expect(container.querySelector('svg')).toBeNull()
+
+    renderCell('competenza', ISSUED)
     expect(screen.getByText('—').className).toContain('text-muted-foreground')
   })
 })

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
@@ -206,9 +206,11 @@ describe('the customer column', () => {
  * page title already says.
  */
 describe('the accrual period column', () => {
-  it('sits right after the date, in the default columns too', () => {
-    const ids = buildInvoiceColumns().map((candidate) => candidate.id ?? '')
-    expect(ids.indexOf('competenza')).toBe(ids.indexOf('data_emissione') + 1)
+  it('sits right after the date, with and without the customer column', () => {
+    for (const options of [undefined, { cliente: true }]) {
+      const ids = buildInvoiceColumns(options).map((candidate) => candidate.id ?? '')
+      expect(ids.indexOf('competenza')).toBe(ids.indexOf('data_emissione') + 1)
+    }
     expect(column('competenza').header).toBe('Competenza')
   })
 

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
@@ -39,6 +39,16 @@ function customerName(row: Invoice): string {
   return name === null || name === undefined || name === '' ? EMPTY : name
 }
 
+/**
+ * The accrual period the document declares (ORB-61), as the detail page states it, or
+ * the dash. One helper for the accessor and the cell, as `customerName` above: the two
+ * halves of a column disagreeing about what nothing looks like is a defect this file
+ * has already shipped once (see the `data_emissione` column).
+ */
+function accrualPeriod(row: Invoice): string {
+  return formatPeriod(row.competenza_da, row.competenza_a)
+}
+
 export function buildInvoiceColumns(
   options: InvoiceColumnOptions = {},
 ): ColumnDef<DataTableFeatures, Invoice>[] {
@@ -95,18 +105,14 @@ export function buildInvoiceColumns(
     {
       header: 'Competenza',
       id: 'competenza',
-      // The accrual period the document declares (ORB-61), beside the date it was
-      // issued on (ORB-126): invoicing runs late here, so the two often name different
-      // months, and a list showing only the second does not say what a row is about.
-      // Through `formatPeriod`, the same string the detail page states, and as plain
-      // text: the emission date is the one column with a calendar icon, and a second one
-      // two columns over would make two different kinds of value read as the same.
-      accessorFn: (row) => formatPeriod(row.competenza_da ?? null, row.competenza_a ?? null),
+      // Beside the date the document was issued on (ORB-126): invoicing runs late here,
+      // so the two often name different months, and a list showing only the second does
+      // not say what a row is about. Plain text: the emission date is the one column with
+      // a calendar icon, and a second one two columns over would make two different kinds
+      // of value read as the same.
+      accessorFn: (row) => accrualPeriod(row),
       cell: ({ row }) => {
-        const period = formatPeriod(
-          row.original.competenza_da ?? null,
-          row.original.competenza_a ?? null,
-        )
+        const period = accrualPeriod(row.original)
         return period === EMPTY ? <span className="text-muted-foreground">{EMPTY}</span> : period
       },
     },

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
@@ -3,7 +3,7 @@ import { DateCell, MoneyCell } from '@/components/cells'
 import type { DataTableFeatures } from '@/components/DataTable'
 import { StatusPill } from '@/components/StatusPill'
 import { InvoiceStateBadge } from './InvoiceStateBadge'
-import { formatDate, formatInvoiceNumber, formatMoney } from './format'
+import { formatDate, formatInvoiceNumber, formatMoney, formatPeriod } from './format'
 import {
   INVOICE_TYPE_LABELS,
   PAYMENT_STATE_LABELS,
@@ -91,6 +91,24 @@ export function buildInvoiceColumns(
       // identical string this accessor does.
       accessorFn: (row) => formatDate(row.data_emissione),
       cell: ({ row }) => <DateCell value={row.original.data_emissione} />,
+    },
+    {
+      header: 'Competenza',
+      id: 'competenza',
+      // The accrual period the document declares (ORB-61), beside the date it was
+      // issued on (ORB-126): invoicing runs late here, so the two often name different
+      // months, and a list showing only the second does not say what a row is about.
+      // Through `formatPeriod`, the same string the detail page states, and as plain
+      // text: the emission date is the one column with a calendar icon, and a second one
+      // two columns over would make two different kinds of value read as the same.
+      accessorFn: (row) => formatPeriod(row.competenza_da ?? null, row.competenza_a ?? null),
+      cell: ({ row }) => {
+        const period = formatPeriod(
+          row.original.competenza_da ?? null,
+          row.original.competenza_a ?? null,
+        )
+        return period === EMPTY ? <span className="text-muted-foreground">{EMPTY}</span> : period
+      },
     },
     {
       header: 'Totale',

--- a/projects/pigrocrm/apps/web/src/routes/app/fatture/index.test.tsx
+++ b/projects/pigrocrm/apps/web/src/routes/app/fatture/index.test.tsx
@@ -138,6 +138,8 @@ describe('the invoice list', () => {
                 data_emissione: '2026-08-20',
                 totale: '1500.00',
                 customer_ragione_sociale: 'ACME S.r.l.',
+                competenza_da: '2026-08-01',
+                competenza_a: '2026-08-31',
               },
             ],
             next_cursor: null,
@@ -146,6 +148,35 @@ describe('the invoice list', () => {
     renderList()
     expect(await screen.findByRole('columnheader', { name: 'Cliente' })).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'ACME S.r.l.' })).toBeInTheDocument()
+  })
+
+  it('says which period each invoice is about, beside its date (ORB-126)', async () => {
+    mockGet.mockImplementation(((path: string) =>
+      path === '/api/invoices'
+        ? ok({
+            items: [
+              {
+                id: 'f1',
+                anno: 2026,
+                numero: 7,
+                riferimento: null,
+                tipo: 'fattura',
+                stato: 'emessa',
+                stato_pagamento: 'da_incassare',
+                data_emissione: '2026-09-02',
+                totale: '1500.00',
+                customer_ragione_sociale: 'ACME S.r.l.',
+                competenza_da: '2026-08-01',
+                competenza_a: '2026-08-31',
+              },
+            ],
+            next_cursor: null,
+          })
+        : ok({ items: [], next_cursor: null })) as never)
+    renderList()
+    const headers = (await screen.findAllByRole('columnheader')).map((h) => h.textContent)
+    expect(headers.indexOf('Competenza')).toBe(headers.indexOf('Data') + 1)
+    expect(screen.getByRole('cell', { name: '01/08/2026 - 31/08/2026' })).toBeInTheDocument()
   })
 
   it('still explains the «scadute» drill-through it arrives with', async () => {

--- a/projects/pigrocrm/apps/web/src/routes/app/fatture/index.test.tsx
+++ b/projects/pigrocrm/apps/web/src/routes/app/fatture/index.test.tsx
@@ -52,6 +52,33 @@ function renderList(scadute?: boolean): ReactElement {
   return <></>
 }
 
+/** One issued invoice as the API sends it, with whatever a test needs changed. */
+function invoice(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'f1',
+    anno: 2026,
+    numero: 7,
+    riferimento: null,
+    tipo: 'fattura',
+    stato: 'emessa',
+    stato_pagamento: 'da_incassare',
+    data_emissione: '2026-08-20',
+    competenza_da: null,
+    competenza_a: null,
+    totale: '1500.00',
+    customer_ragione_sociale: 'ACME S.r.l.',
+    ...overrides,
+  }
+}
+
+/** Makes the list endpoint answer these rows; every other endpoint stays empty. */
+function mockInvoices(items: Record<string, unknown>[]): void {
+  mockGet.mockImplementation(((path: string) =>
+    path === '/api/invoices'
+      ? ok({ items, next_cursor: null })
+      : ok({ items: [], next_cursor: null })) as never)
+}
+
 /** The `stato` the page last asked the API for, or `undefined` when it asked for none. */
 function lastRequestedStato(): unknown {
   const calls = mockGet.mock.calls.filter((call) => call[0] === '/api/invoices')
@@ -123,56 +150,20 @@ describe('the invoice list', () => {
    *  invoice each row is (ORB-98). The tab inside a customer's page does not: see
    *  `InvoicesTab.test.tsx`. */
   it('says which customer each invoice belongs to', async () => {
-    mockGet.mockImplementation(((path: string) =>
-      path === '/api/invoices'
-        ? ok({
-            items: [
-              {
-                id: 'f1',
-                anno: 2026,
-                numero: 7,
-                riferimento: null,
-                tipo: 'fattura',
-                stato: 'emessa',
-                stato_pagamento: 'da_incassare',
-                data_emissione: '2026-08-20',
-                totale: '1500.00',
-                customer_ragione_sociale: 'ACME S.r.l.',
-                competenza_da: '2026-08-01',
-                competenza_a: '2026-08-31',
-              },
-            ],
-            next_cursor: null,
-          })
-        : ok({ items: [], next_cursor: null })) as never)
+    mockInvoices([invoice()])
     renderList()
     expect(await screen.findByRole('columnheader', { name: 'Cliente' })).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'ACME S.r.l.' })).toBeInTheDocument()
   })
 
   it('says which period each invoice is about, beside its date (ORB-126)', async () => {
-    mockGet.mockImplementation(((path: string) =>
-      path === '/api/invoices'
-        ? ok({
-            items: [
-              {
-                id: 'f1',
-                anno: 2026,
-                numero: 7,
-                riferimento: null,
-                tipo: 'fattura',
-                stato: 'emessa',
-                stato_pagamento: 'da_incassare',
-                data_emissione: '2026-09-02',
-                totale: '1500.00',
-                customer_ragione_sociale: 'ACME S.r.l.',
-                competenza_da: '2026-08-01',
-                competenza_a: '2026-08-31',
-              },
-            ],
-            next_cursor: null,
-          })
-        : ok({ items: [], next_cursor: null })) as never)
+    mockInvoices([
+      invoice({
+        data_emissione: '2026-09-02',
+        competenza_da: '2026-08-01',
+        competenza_a: '2026-08-31',
+      }),
+    ])
     renderList()
     const headers = (await screen.findAllByRole('columnheader')).map((h) => h.textContent)
     expect(headers.indexOf('Competenza')).toBe(headers.indexOf('Data') + 1)


### PR DESCRIPTION
## What this changes

The Fatture list showed the emission date and nothing about the period an invoice is for. Invoicing runs late here, August's work issued in September, so the list did not say which month a row was about; the accrual period (`competenza_da`/`competenza_a`, ORB-61) was readable only on the detail page. Ivan asked for both on 2026-09-10 («nella tabella delle fatture vorrei vedere sia la data che la competenza»).

Now a «Competenza» column sits right after «Data», in the list page and in the Fatture tab of a customer or a deal alike. It reads «01/08/2026 - 31/08/2026», the same string the detail page states through `formatPeriod`, or the em dash when the document declares no period. Plain text: the emission date stays the one column with a calendar icon.

## How I verified it

- Red then green: `columns.test.ts` (position right after `data_emissione`, header, the period string, the dash, plain text with no icon and a quiet dash) and `fatture/index.test.tsx` (the list renders the header after Data and the period cell). Five tests, all failing on `origin/main`, passing now.
- `pnpm --filter web test`: 1063 passed, 101 files. `pnpm --filter web lint`, `pnpm --filter web build`, `tsc --noEmit`: clean.
- `bash projects/pigrocrm/apps/web/scripts/e2e.sh` (the Playwright suite, serial, its own Postgres): 39 passed in 1.3m.
- After the independent review (recorded as a comment on this PR): the eleven invoice test files 135 passed; eslint and `tsc --noEmit` clean.
- Opened http://localhost:5173/app/fatture against a local stack with an issued invoice for August issued on 2 September, a draft with no period, and a proforma for September: the column reads the two periods and a dash on the draft. The pair below is that page, before from `origin/main` on 5175 and after from this branch on 5173, same API.

## Anything a reviewer should look at twice

- Eight columns at 1440px: the table still fits its frame on the reference data (the pair shows it). A narrower viewport scrolls the table inside its box, the way `DataTable` already does for every list.
- The accessor and the cell both go through `formatPeriod`, so they cannot disagree about what nothing looks like; the `?? null` on the two fields is for a payload that predates the columns and has no key at all.

## What did not change, on purpose

- No filter or sort by period, and no API change: the fields were already on every row.
- The column is on the tab inside a customer's and a deal's page too, unlike «Cliente» (ORB-98): the period is not what the page title already says.

## Screenshots

**1. Fatture list, the «Competenza» column after Data**
![Fatture list, before and after](https://github.com/user-attachments/assets/40400b48-9eff-474c-b504-e2a581878205)

Linear: ORB-126.