### PR TITLE
fix(hub): the panel is back on every public page, and off on the chooser alone

### DIFF
--- a/projects/hub/apps/web/src/components/Shell.test.tsx
+++ b/projects/hub/apps/web/src/components/Shell.test.tsx
@@ -6,7 +6,7 @@ import {
   createRoute,
   createRouter,
 } from '@tanstack/react-router'
-import { cleanup, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { Shell } from './Shell'
 
@@ -38,13 +38,15 @@ describe('the public frame', () => {
     expect(document.body.textContent).not.toMatch(/Studio Rossi|example\.com/)
   })
 
-  it('boxes the content in a panel unless a page asks for the bare grid', async () => {
-    // ORB-128: ORB-124 took the panel off the frame itself, so every public page lost
-    // it when only the chooser should have. The panel is the default; the chooser's
-    // layout passes `panel={false}` and is the one page that sits straight on the grid.
+  // ORB-128: ORB-124 took the panel off the frame itself, so every public page lost it
+  // when only the chooser should have. The panel is the default; the chooser's layout
+  // passes `panel={false}` and is the one page that sits straight on the grid.
+  it('boxes the content in a panel by default', async () => {
     mount()
     expect((await screen.findByText('a step')).className).toContain('bg-card')
-    cleanup()
+  })
+
+  it('leaves the content on the bare grid when a page asks for it', async () => {
     mount(false)
     expect((await screen.findByText('a step')).className).not.toContain('bg-card')
   })

--- a/projects/hub/apps/web/src/components/Shell.test.tsx
+++ b/projects/hub/apps/web/src/components/Shell.test.tsx
@@ -6,16 +6,16 @@ import {
   createRoute,
   createRouter,
 } from '@tanstack/react-router'
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { Shell } from './Shell'
 
-function mount() {
+function mount(panel?: boolean) {
   const root = createRootRoute({ component: () => <Outlet /> })
   const home = createRoute({
     getParentRoute: () => root,
     path: '/',
-    component: () => <Shell>a step</Shell>,
+    component: () => <Shell panel={panel}>a step</Shell>,
   })
   const router = createRouter({
     routeTree: root.addChildren([home]),
@@ -36,6 +36,17 @@ describe('the public frame', () => {
       'https://humancraft.tech/',
     )
     expect(document.body.textContent).not.toMatch(/Studio Rossi|example\.com/)
+  })
+
+  it('boxes the content in a panel unless a page asks for the bare grid', async () => {
+    // ORB-128: ORB-124 took the panel off the frame itself, so every public page lost
+    // it when only the chooser should have. The panel is the default; the chooser's
+    // layout passes `panel={false}` and is the one page that sits straight on the grid.
+    mount()
+    expect((await screen.findByText('a step')).className).toContain('bg-card')
+    cleanup()
+    mount(false)
+    expect((await screen.findByText('a step')).className).not.toContain('bg-card')
   })
 
   it('links the two policy pages on the site they belong to', async () => {

--- a/projects/hub/apps/web/src/components/Shell.tsx
+++ b/projects/hub/apps/web/src/components/Shell.tsx
@@ -15,9 +15,10 @@ import { BrandMark } from '@/components/BrandMark'
  *
  *  `panel={false}` drops the panel and leaves the content straight on the grid. Only
  *  the chooser asks for it (ORB-124, then ORB-128): its two doors draw their own
- *  boxes, and a box around those boxes read as one frame too many. A wizard step, the
- *  thank-you page and the member area have no cards of their own and keep the panel;
- *  ORB-128 is what happened when they lost it too. The bare wrapper is still `w-full`
+ *  boxes, and a box around those boxes read as one frame too many. A wizard step and
+ *  the thank-you page have no cards of their own; the member area draws some, and
+ *  keeps the panel anyway because the owner asked for the chooser alone to go bare
+ *  (ORB-128 is what happened when every page lost it). The bare wrapper is still `w-full`
  *  because `main` is `items-center` and the chooser sets `max-w-2xl` without
  *  `w-full`, so without it the page would shrink to the width of its text. */
 export function Shell({ children, panel = true }: { children: ReactNode; panel?: boolean }) {

--- a/projects/hub/apps/web/src/components/Shell.tsx
+++ b/projects/hub/apps/web/src/components/Shell.tsx
@@ -3,22 +3,24 @@ import type { ReactNode } from 'react'
 import { BrandMark } from '@/components/BrandMark'
 
 /** The public frame: the mark and the name up top, the two legal links and the
- *  attribution at the foot, and the page content straight on the grid in between --
- *  the site's own visual system (ORB-73's `.site` scope) rather than the
- *  application's, so a visitor who clicked a CTA on joinorbiters.com does not land on
- *  a different product. `site` also carries the page's ground (the same faint grid
- *  the landing sits on). There is no panel around the content (ORB-124): the pages
- *  draw their own cards, the chooser's doors, the wizard's fields and review list,
- *  the member area's boxes, and a box around those boxes read as one frame too many.
- *  The bare `w-full` wrapper is load-bearing: `main` is `items-center`, and a page
- *  such as the chooser sets `max-w-2xl` without `w-full`, so without the wrapper it
- *  would shrink to the width of its text. The content is centred in the space
- *  between header and footer instead of sitting at the top of an empty page:
- *  `justify-center` on `main` only has room to act when the step is shorter than the
- *  viewport, which is the common case here. Each link over the grid keeps a sliver of
- *  the page's own surface behind it, the same treatment `landing.css`'s `.top a` and
- *  `footer .quiet-link` give theirs. */
-export function Shell({ children }: { children: ReactNode }) {
+ *  attribution at the foot, one boxed panel in between -- the site's own visual
+ *  system (ORB-73's `.site` scope) rather than the application's, so a visitor who
+ *  clicked a CTA on joinorbiters.com does not land on a different product. `site`
+ *  also carries the page's ground (the same faint grid the landing sits on), and the
+ *  panel is centred in the space between header and footer instead of sitting at the
+ *  top of an empty page: `justify-center` on `main` only has room to act when the
+ *  step is shorter than the viewport, which is the common case here. Each link over
+ *  the grid keeps a sliver of the page's own surface behind it, the same treatment
+ *  `landing.css`'s `.top a` and `footer .quiet-link` give theirs.
+ *
+ *  `panel={false}` drops the panel and leaves the content straight on the grid. Only
+ *  the chooser asks for it (ORB-124, then ORB-128): its two doors draw their own
+ *  boxes, and a box around those boxes read as one frame too many. A wizard step, the
+ *  thank-you page and the member area have no cards of their own and keep the panel;
+ *  ORB-128 is what happened when they lost it too. The bare wrapper is still `w-full`
+ *  because `main` is `items-center` and the chooser sets `max-w-2xl` without
+ *  `w-full`, so without it the page would shrink to the width of its text. */
+export function Shell({ children, panel = true }: { children: ReactNode; panel?: boolean }) {
   return (
     <div className="site flex min-h-full flex-col">
       <header className="mx-auto flex w-full max-w-5xl flex-wrap items-center justify-between gap-y-2 px-6 py-5">
@@ -42,7 +44,15 @@ export function Shell({ children }: { children: ReactNode }) {
         </nav>
       </header>
       <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center px-6 py-12">
-        <div className="w-full">{children}</div>
+        <div
+          className={
+            panel
+              ? 'w-full border-[length:var(--landing-border-width)] bg-card px-6 py-10 shadow-xs sm:px-10'
+              : 'w-full'
+          }
+        >
+          {children}
+        </div>
       </main>
       <footer className="mx-auto flex w-full max-w-5xl flex-wrap items-center gap-6 border-t-[length:var(--landing-border-width)] px-6 py-8 text-xs text-muted-foreground">
         <a

--- a/projects/hub/apps/web/src/components/ui/button.tsx
+++ b/projects/hub/apps/web/src/components/ui/button.tsx
@@ -10,10 +10,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/80",
-        /* The secondary button of the reference: a 12% line on a white surface the
-           button paints itself (`bg-card`), so it reads the same inside the admin's
-           panel and straight on the site's grid, where the public pages sit since
-           ORB-124 took their panel away. */
+        /* The secondary button of the reference: a 12% line on the white surface,
+           not on the Paper page behind it -- these sit inside the content panel. */
         outline:
           "border-border bg-card hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/projects/hub/apps/web/src/pages/member/Accedi.tsx
+++ b/projects/hub/apps/web/src/pages/member/Accedi.tsx
@@ -71,7 +71,7 @@ export function Accedi() {
         />
       </div>
       {error && (
-        <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
+        <p role="alert" className="text-sm text-destructive">
           {error}
         </p>
       )}

--- a/projects/hub/apps/web/src/pages/member/Guard.tsx
+++ b/projects/hub/apps/web/src/pages/member/Guard.tsx
@@ -15,7 +15,7 @@ export function MemberGuard() {
   if (me.isPending) return <p className="text-sm text-muted-foreground">Caricamento…</p>
   if (me.isError)
     return (
-      <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
+      <p role="alert" className="text-sm text-destructive">
         Non riusciamo a leggere la tua area. Riprova tra poco.
       </p>
     )

--- a/projects/hub/apps/web/src/pages/member/Modifica.tsx
+++ b/projects/hub/apps/web/src/pages/member/Modifica.tsx
@@ -104,7 +104,7 @@ export function Modifica() {
             autoFocus: false,
           })}
           {errors[step.id] && (
-            <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
+            <p role="alert" className="text-sm text-destructive">
               {errors[step.id]}
             </p>
           )}
@@ -112,7 +112,7 @@ export function Modifica() {
       ))}
 
       {failure && (
-        <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
+        <p role="alert" className="text-sm text-destructive">
           {failure}
         </p>
       )}

--- a/projects/hub/apps/web/src/router.tsx
+++ b/projects/hub/apps/web/src/router.tsx
@@ -27,8 +27,9 @@ import { Modifica } from '@/pages/member/Modifica'
 
 /**
  * The route tree, in code: eleven screens is not enough to want a file-based router and
- * a generated tree beside it. The public pages sit in the `Shell`; the admin area
- * brings its own frame and its own guard (`AdminLayout`).
+ * a generated tree beside it. The public pages sit in the `Shell`, the chooser alone in
+ * a `Shell` without its panel (ORB-128); the admin area brings its own frame and its
+ * own guard (`AdminLayout`).
  */
 const root = createRootRoute({ component: () => <Outlet /> })
 
@@ -42,7 +43,17 @@ const publicLayout = createRoute({
   ),
 })
 
-const chooser = createRoute({ getParentRoute: () => publicLayout, path: '/', component: Chooser })
+const bareLayout = createRoute({
+  getParentRoute: () => root,
+  id: 'bare',
+  component: () => (
+    <Shell panel={false}>
+      <Outlet />
+    </Shell>
+  ),
+})
+
+const chooser = createRoute({ getParentRoute: () => bareLayout, path: '/', component: Chooser })
 const freelance = createRoute({
   getParentRoute: () => publicLayout,
   path: '/freelance',
@@ -105,8 +116,8 @@ const adminAmministratori = createRoute({
 })
 
 const routeTree = root.addChildren([
+  bareLayout.addChildren([chooser]),
   publicLayout.addChildren([
-    chooser,
     freelance,
     aziende,
     grazie,

--- a/projects/hub/apps/web/src/router.tsx
+++ b/projects/hub/apps/web/src/router.tsx
@@ -26,7 +26,7 @@ import { MemberGuard } from '@/pages/member/Guard'
 import { Modifica } from '@/pages/member/Modifica'
 
 /**
- * The route tree, in code: eleven screens is not enough to want a file-based router and
+ * The route tree, in code: this many screens is not enough to want a file-based router and
  * a generated tree beside it. The public pages sit in the `Shell`, the chooser alone in
  * a `Shell` without its panel (ORB-128); the admin area brings its own frame and its
  * own guard (`AdminLayout`).

--- a/projects/hub/apps/web/src/wizard/Wizard.tsx
+++ b/projects/hub/apps/web/src/wizard/Wizard.tsx
@@ -125,7 +125,7 @@ export function Wizard<T>({
           aria-valuemin={0}
           aria-valuemax={100}
           aria-label="Avanzamento"
-          className="h-2 w-full overflow-hidden border-(length:--landing-border-width) bg-card"
+          className="h-2 w-full overflow-hidden border-(length:--landing-border-width)"
         >
           <div
             className="h-full bg-(--landing-ink) transition-[width] duration-300"
@@ -166,7 +166,7 @@ export function Wizard<T>({
             ))}
           </dl>
           {submitError && !submitError.step && (
-            <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
+            <p role="alert" className="text-sm text-destructive">
               {submitError.message}
             </p>
           )}
@@ -194,7 +194,7 @@ export function Wizard<T>({
           </div>
           <div>{step.render({ value, set, next, error, autoFocus: true })}</div>
           {error && (
-            <p role="alert" className="inline-block bg-card p-(--landing-link-pad) text-sm text-destructive">
+            <p role="alert" className="text-sm text-destructive">
               {error}
             </p>
           )}

--- a/projects/hub/apps/web/src/wizard/site-controls.css
+++ b/projects/hub/apps/web/src/wizard/site-controls.css
@@ -51,12 +51,6 @@
    a fixed height, which the padding below only ever grows past, so it is untouched. */
 .site [data-slot='input'],
 .site [data-slot='textarea'] {
-  /* The application's Input and Textarea are `bg-transparent`, which was fine while
-     the public frame put a white panel behind them (ORB-74) and is not now that the
-     content sits straight on the grid (ORB-124): the grid ran through every field.
-     The landing's own input on the same grid paints white, orbiters.css:178
-     `.signup input { background-color: #ffffff }`, and so do these. */
-  background-color: var(--card);
   border-width: var(--landing-border-width);
   padding-block: var(--landing-control-padding-block);
   padding-inline: var(--landing-control-padding-inline);


### PR DESCRIPTION
## What this changes

`hub-v0.4.0` (PR #35, ORB-124) took the boxed panel off `Shell`, the frame every public page shares, so the wizards, the thank-you page, `/accedi`, `/entra` and the member area went straight on the grid together with the chooser. Only the chooser was meant to: its two door cards draw their own frame, a wizard step does not. `Shell` now takes a `panel` flag, on by default, and the chooser is the one route mounted in a `Shell` with `panel={false}`. Every other public page renders exactly as it did on `hub-v0.3.1`: the review fixes of PR #35 (white inputs, alert slivers, white progress track, two comments) were compensating for the missing panel and are undone here, file by file identical to `hub-v0.3.1`.

## How I verified it

In `projects/hub/apps/web`: `pnpm lint` clean, `tsc --noEmit` clean, `vitest run` 13 files, 50 tests passed, one new: `Shell.test.tsx` pins the panel as the default and its absence with `panel={false}`. `git diff hub-v0.3.1 HEAD -- src/wizard src/pages/member src/components/ui` shows only `dialog.tsx`, which ORB-125 added and this PR does not touch. Hub dev server from this branch on 5180 beside one from `origin/main` on 5182, both at 1440×900: the company wizard's first step has its panel back, the chooser is pixel-identical between the two.

## Anything a reviewer should look at twice

The chooser sits under a second layout route (`bareLayout`) rather than under `publicLayout` with a flag read from the location: two `Shell`s in the tree, one per look, so the choice is visible in the route table and no component reads `pathname`. Moving between `/` and `/freelance` therefore remounts `Shell` (header and footer), which costs nothing visible since neither holds state.

## What did not change, on purpose

The chooser keeps the bare grid ORB-124 gave it. The admin area, which brings its own frame, is untouched. Recorded on ORB-128.

## Screenshots

**1. The company wizard's first step at 1440×900: the panel is back around the step**
![The company wizard before and after](https://github.com/user-attachments/assets/74e2f51b-b4b5-46bd-b1ab-976fbfb039f7)

**2. The chooser at 1440×900: unchanged, still on the bare grid**
![The chooser before and after](https://github.com/user-attachments/assets/4a55ce98-b697-4a46-9923-02408d47531b)

Linear: ORB-128.
