### PR TITLE
feat(hub): a pencil on every admin row edits the name, the address or the password

### DIFF
--- a/projects/hub/README.md
+++ b/projects/hub/README.md
@@ -22,7 +22,7 @@ Three public flows and the admin area behind them:
   see or change what they sent.
 - `/hub/admin/login` and the freelancer, company and signup lists behind it — a cookie
   session. The first admin is created with `orbiters createadmin` (below); the next ones
-  from «Amministratori» inside the area.
+  from «Amministratori» inside the area, where they are also edited.
 
 `POST /api/orbiters/signups` is the community site's signup endpoint, moved here
 unchanged on 2026-09-09: the website's form and the ChatGPT Ads conversion still post

--- a/projects/hub/apps/api/src/orbiters_api/routers/admin.py
+++ b/projects/hub/apps/api/src/orbiters_api/routers/admin.py
@@ -57,6 +57,19 @@ class AdminCreate(BaseModel):
     password: str
 
 
+class AdminUpdate(BaseModel):
+    """The pencil on a row (ORB-129): each field optional, absent means «keep it». An
+    empty password is «keep it» too, since that is what an untouched password field
+    sends; a present one goes through the service's ten-character rule. `attivo` is not
+    here on purpose: Ivan does not want deactivation from the area yet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    email: EmailStr | None = None
+    nome: SafeStr | None = Field(default=None, min_length=1, max_length=NAME_MAX_LENGTH)
+    password: str | None = None
+
+
 @router.post("/auth/login", response_model=AdminRead)
 def login(
     payload: LoginRequest,
@@ -99,8 +112,9 @@ def me(admin: AdminDep) -> AdminRead:
 
 # ---- the admins ------------------------------------------------------------------------
 #
-# Who reads this area, and one more of them. No deactivation and no deletion here, on
-# purpose (ORB-123): the `attivo` flag exists and nothing in the area changes it yet.
+# Who reads this area, one more of them, and a change to one (ORB-123, ORB-129). No
+# deactivation and no deletion here, on purpose: the `attivo` flag exists and nothing in
+# the area changes it yet.
 
 
 @router.get("/admins", response_model=list[AdminRead])
@@ -113,6 +127,18 @@ def create_admin(
     _: AdminDep, session: SessionDep, settings: SettingsDep, payload: AdminCreate
 ) -> AdminRead:
     return AdminService(session, settings).create(payload.email, payload.nome, payload.password)
+
+
+@router.patch("/admins/{admin_id}", response_model=AdminRead)
+def update_admin(
+    _: AdminDep, session: SessionDep, settings: SettingsDep, admin_id: UUID, payload: AdminUpdate
+) -> AdminRead:
+    return AdminService(session, settings).update(
+        admin_id,
+        nome=payload.nome,
+        email=payload.email,
+        password=payload.password or None,
+    )
 
 
 # ---- the lists -------------------------------------------------------------------------

--- a/projects/hub/apps/api/src/orbiters_api/routers/admin.py
+++ b/projects/hub/apps/api/src/orbiters_api/routers/admin.py
@@ -131,13 +131,21 @@ def create_admin(
 
 @router.patch("/admins/{admin_id}", response_model=AdminRead)
 def update_admin(
-    _: AdminDep, session: SessionDep, settings: SettingsDep, admin_id: UUID, payload: AdminUpdate
+    _: AdminDep,
+    request: Request,
+    session: SessionDep,
+    settings: SettingsDep,
+    admin_id: UUID,
+    payload: AdminUpdate,
 ) -> AdminRead:
+    # The caller's own cookie is spared when a new password revokes the row's sessions,
+    # so an admin resetting their own password is not logged out by it.
     return AdminService(session, settings).update(
         admin_id,
         nome=payload.nome,
         email=payload.email,
         password=payload.password or None,
+        keep_session=request.cookies.get(ADMIN_COOKIE),
     )
 
 

--- a/projects/hub/apps/api/tests/test_admin_api.py
+++ b/projects/hub/apps/api/tests/test_admin_api.py
@@ -60,6 +60,7 @@ def test_without_the_cookie_every_admin_route_is_a_401(client: TestClient, admin
         json={"email": "x@orbiters.it", "nome": "X", "password": "una-password-lunga"},
     )
     assert refused.status_code == 401
+    assert client.patch(f"/api/hub/admins/{MISSING}", json={"nome": "X"}).status_code == 401
 
 
 def test_login_sets_a_secure_httponly_cookie_and_the_lists_open(
@@ -293,3 +294,76 @@ def test_creating_an_admin_points_the_form_at_the_field_that_is_wrong(
     )
     assert extra.status_code == 422
     assert [row["email"] for row in client.get("/api/hub/admins").json()] == ["ivan@orbiters.it"]
+
+
+def test_an_admin_changes_another_admins_name_address_or_password(
+    client: TestClient, admin: None
+) -> None:
+    # ORB-129. The password field is optional and means «keep it» when absent.
+    _login(client)
+    created = client.post(
+        "/api/hub/admins",
+        json={"email": "lorenzo@orbiters.it", "nome": "Lorenzo", "password": "una-password-lunga"},
+    ).json()
+
+    renamed = client.patch(f"/api/hub/admins/{created['id']}", json={"nome": " Lorenzo Fiore "})
+    assert renamed.status_code == 200, renamed.text
+    assert (
+        renamed.json()["nome"] == "Lorenzo Fiore"
+        and renamed.json()["email"] == "lorenzo@orbiters.it"
+    )
+    assert "password" not in renamed.text
+
+    moved = client.patch(
+        f"/api/hub/admins/{created['id']}",
+        json={"email": "Lorenzo.Fiore@Orbiters.it", "password": "nuova-password-lunga"},
+    )
+    assert moved.status_code == 200, moved.text
+    assert moved.json()["email"] == "lorenzo.fiore@orbiters.it"
+    listed = client.get("/api/hub/admins").json()
+    assert [row["email"] for row in listed] == ["ivan@orbiters.it", "lorenzo.fiore@orbiters.it"]
+
+    # The new credentials open a session; the old password does not.
+    assert client.post("/api/hub/auth/logout").status_code == 204
+    old = client.post(
+        "/api/hub/auth/login",
+        json={"email": "lorenzo.fiore@orbiters.it", "password": "una-password-lunga"},
+    )
+    assert old.status_code == 401
+    new = client.post(
+        "/api/hub/auth/login",
+        json={"email": "lorenzo.fiore@orbiters.it", "password": "nuova-password-lunga"},
+    )
+    assert new.status_code == 200 and new.json()["nome"] == "Lorenzo Fiore"
+
+
+def test_changing_an_admin_points_the_form_at_the_field_that_is_wrong(
+    client: TestClient, admin: None
+) -> None:
+    _login(client)
+    me = client.get("/api/hub/auth/me").json()
+    other = client.post(
+        "/api/hub/admins",
+        json={"email": "lorenzo@orbiters.it", "nome": "Lorenzo", "password": "una-password-lunga"},
+    ).json()
+    for body, field in (
+        ({"email": "IVAN@orbiters.it"}, "email"),
+        ({"email": "non-una-mail"}, "email"),
+        ({"nome": "   "}, "nome"),
+        ({"nome": "x" * 121}, "nome"),
+        ({"password": "breve"}, "password"),
+        ({"attivo": False}, "attivo"),
+    ):
+        refused = client.patch(f"/api/hub/admins/{other['id']}", json=body)
+        assert refused.status_code == 422, body
+        assert refused.json()["detail"][0]["loc"][-1] == field, body
+    # An empty password in the body is «keep it», not a five-character password.
+    kept = client.patch(f"/api/hub/admins/{other['id']}", json={"password": ""})
+    assert kept.status_code == 200
+    # One's own row is editable like any other; the same address on itself is no duplicate.
+    own = client.patch(
+        f"/api/hub/admins/{me['id']}", json={"email": "IVAN@orbiters.it", "nome": "Ivan S."}
+    )
+    assert own.status_code == 200 and own.json()["nome"] == "Ivan S."
+    assert client.get("/api/hub/auth/me").json()["nome"] == "Ivan S."
+    assert client.patch(f"/api/hub/admins/{MISSING}", json={"nome": "Nessuno"}).status_code == 404

--- a/projects/hub/apps/api/tests/test_admin_api.py
+++ b/projects/hub/apps/api/tests/test_admin_api.py
@@ -367,3 +367,37 @@ def test_changing_an_admin_points_the_form_at_the_field_that_is_wrong(
     assert own.status_code == 200 and own.json()["nome"] == "Ivan S."
     assert client.get("/api/hub/auth/me").json()["nome"] == "Ivan S."
     assert client.patch(f"/api/hub/admins/{MISSING}", json={"nome": "Nessuno"}).status_code == 404
+
+
+def test_a_new_password_logs_the_other_admin_out_and_keeps_me_in(
+    client: TestClient, admin: None
+) -> None:
+    _login(client)
+    other = client.post(
+        "/api/hub/admins",
+        json={"email": "lorenzo@orbiters.it", "nome": "Lorenzo", "password": "una-password-lunga"},
+    ).json()
+    # Lorenzo logs in from his own browser.
+    lorenzo = TestClient(client.app, base_url="https://testserver")
+    assert (
+        lorenzo.post(
+            "/api/hub/auth/login",
+            json={"email": "lorenzo@orbiters.it", "password": "una-password-lunga"},
+        ).status_code
+        == 200
+    )
+    assert lorenzo.get("/api/hub/auth/me").status_code == 200
+
+    # I change his password: his session is gone, mine is untouched.
+    changed = client.patch(
+        f"/api/hub/admins/{other['id']}", json={"password": "nuova-password-lunga"}
+    )
+    assert changed.status_code == 200
+    assert lorenzo.get("/api/hub/auth/me").status_code == 401
+    assert client.get("/api/hub/auth/me").status_code == 200
+
+    # I change my own: I am still in.
+    me = client.get("/api/hub/auth/me").json()
+    own = client.patch(f"/api/hub/admins/{me['id']}", json={"password": "anche-la-mia-nuova"})
+    assert own.status_code == 200
+    assert client.get("/api/hub/auth/me").status_code == 200

--- a/projects/hub/apps/web/src/lib/api.test.ts
+++ b/projects/hub/apps/web/src/lib/api.test.ts
@@ -92,6 +92,18 @@ describe('the api client', () => {
     expect(created.nome).toBe('Lorenzo')
   })
 
+  it('changes an admin with a PATCH carrying only what changed', async () => {
+    // ORB-129: an empty password is not sent, so the server keeps the old one.
+    const spy = vi.spyOn(globalThis, 'fetch')
+    spy.mockResolvedValueOnce(answer(200, { id: '2', email: 'lorenzo@orbiters.it', nome: 'Lorenzo Fiore', attivo: true, created_at: '2026-09-10T10:01:00Z' }))
+    const changed = await admin.updateAdmin({ id: '2', nome: 'Lorenzo Fiore', email: 'lorenzo@orbiters.it', password: '' })
+    const [url, init] = spy.mock.calls[0]!
+    expect(url).toBe('/api/hub/admins/2')
+    expect(init?.method).toBe('PATCH')
+    expect(JSON.parse(init?.body as string)).toEqual({ nome: 'Lorenzo Fiore', email: 'lorenzo@orbiters.it' })
+    expect(changed.nome).toBe('Lorenzo Fiore')
+  })
+
   it('points the admin at the CV route by id', () => {
     expect(admin.cvUrl('abc')).toBe('/api/hub/freelancers/abc/cv')
   })

--- a/projects/hub/apps/web/src/lib/api.ts
+++ b/projects/hub/apps/web/src/lib/api.ts
@@ -124,6 +124,9 @@ export interface AdminCreate {
   password: string
 }
 
+/** The same three fields when the pencil edits a row; an empty password means «keep it». */
+export type AdminUpdate = AdminCreate
+
 export interface Freelancer {
   id: string
   nome: string
@@ -216,6 +219,12 @@ export const admin = {
   /** Who reads this area, oldest first, and one more of them (ORB-123). */
   admins: () => request<Admin[]>('/api/hub/admins'),
   createAdmin: (data: AdminCreate) => request<Admin>('/api/hub/admins', json(data)),
+  /** PATCH with what the form holds; an empty password is left out, so the old one stays. */
+  updateAdmin: ({ password, ...rest }: AdminUpdate & { id: string }) =>
+    request<Admin>(`/api/hub/admins/${rest.id}`, {
+      ...json({ nome: rest.nome, email: rest.email, ...(password ? { password } : {}) }),
+      method: 'PATCH',
+    }),
   comments: (kind: CommentKind, id: string) =>
     request<Comment[]>(`/api/hub/${kind}/${id}/comments`),
   /** The author is the session's, so the body is the text alone. */

--- a/projects/hub/apps/web/src/pages/admin/Admins.test.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.test.tsx
@@ -93,7 +93,7 @@ describe('the Amministratori page', () => {
     await user.type(within(dialog).getByLabelText('Email'), 'ada@orbiters.it')
     await user.type(within(dialog).getByLabelText('Password'), 'una-password-lunga')
     await user.click(within(dialog).getByRole('button', { name: 'Crea amministratore' }))
-    expect(await within(dialog).findByRole('button', { name: 'Creo…' })).toBeDisabled()
+    expect(await within(dialog).findByRole('button', { name: 'Salvo…' })).toBeDisabled()
 
     await user.keyboard('{Escape}')
     expect(within(dialog).getByRole('button', { name: 'Annulla' })).toBeDisabled()
@@ -130,5 +130,73 @@ describe('the Amministratori page', () => {
     // Opening it again starts from an empty form.
     await user.click(screen.getByRole('button', { name: 'Nuovo amministratore' }))
     expect(within(await screen.findByRole('dialog')).getByLabelText('Nome')).toHaveValue('')
+  })
+
+  it('opens a prefilled dialog from the pencil on a row, and saves without a password', async () => {
+    // ORB-129: the pencil edits one row; an empty password keeps the old one.
+    const spy = vi.spyOn(globalThis, 'fetch')
+    spy.mockResolvedValueOnce(answer(200, [IVAN, ADA]))
+    spy.mockResolvedValueOnce(answer(200, { ...ADA, nome: 'Ada Lovelace' }))
+    spy.mockResolvedValueOnce(answer(200, [IVAN, { ...ADA, nome: 'Ada Lovelace' }]))
+    mount()
+    await screen.findByText('ada@orbiters.it')
+    expect(screen.queryByRole('dialog')).toBeNull()
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Modifica Ada' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Modifica amministratore' })
+    expect(within(dialog).getByLabelText('Nome')).toHaveValue('Ada')
+    expect(within(dialog).getByLabelText('Email')).toHaveValue('ada@orbiters.it')
+    expect(within(dialog).getByLabelText('Nuova password')).toHaveValue('')
+    expect(within(dialog).getByLabelText('Nuova password')).not.toBeRequired()
+
+    // Escape brings focus back to the pencil that opened it, then the edit goes through.
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Modifica Ada' })).toHaveFocus())
+    await user.click(screen.getByRole('button', { name: 'Modifica Ada' }))
+    await screen.findByRole('dialog', { name: 'Modifica amministratore' })
+
+    const reopened = screen.getByRole('dialog')
+    await user.clear(within(reopened).getByLabelText('Nome'))
+    await user.type(within(reopened).getByLabelText('Nome'), 'Ada Lovelace')
+    await user.click(within(reopened).getByRole('button', { name: 'Salva modifiche' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(screen.getByRole('status')).toHaveTextContent('Amministratore aggiornato: ada@orbiters.it')
+    await screen.findByText('Ada Lovelace')
+    const [url, init] = spy.mock.calls[1]!
+    expect(url).toBe('/api/hub/admins/2')
+    expect(init?.method).toBe('PATCH')
+    expect(JSON.parse(init?.body as string)).toEqual({ nome: 'Ada Lovelace', email: 'ada@orbiters.it' })
+
+    // The create dialog after an edit is empty again, not Ada's row.
+    await user.click(screen.getByRole('button', { name: 'Nuovo amministratore' }))
+    const fresh = await screen.findByRole('dialog', { name: 'Nuovo amministratore' })
+    expect(within(fresh).getByLabelText('Nome')).toHaveValue('')
+    expect(within(fresh).getByLabelText('Password')).toBeRequired()
+  })
+
+  it('sends a new password from the pencil, and keeps a refusal on its field', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch')
+    spy.mockResolvedValueOnce(answer(200, [IVAN, ADA]))
+    spy.mockResolvedValueOnce(answer(422, { detail: [{ loc: ['body', 'password'], msg: 'almeno 10 caratteri' }] }))
+    spy.mockResolvedValueOnce(answer(200, ADA))
+    spy.mockResolvedValueOnce(answer(200, [IVAN, ADA]))
+    mount()
+    await screen.findByText('ada@orbiters.it')
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Modifica Ada' }))
+    const dialog = await screen.findByRole('dialog')
+    const password = within(dialog).getByLabelText('Nuova password')
+    // Ten characters typed, so the browser lets it through and the server has its say.
+    await user.type(password, 'dieci-lett')
+    await user.click(within(dialog).getByRole('button', { name: 'Salva modifiche' }))
+    expect(await within(dialog).findByRole('alert')).toHaveTextContent('almeno 10 caratteri')
+    expect(password).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    await user.type(password, '-ancora')
+    await user.click(within(dialog).getByRole('button', { name: 'Salva modifiche' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    const [, init] = spy.mock.calls[2]!
+    expect(JSON.parse(init?.body as string)).toEqual({ nome: 'Ada', email: 'ada@orbiters.it', password: 'dieci-lett-ancora' })
   })
 })

--- a/projects/hub/apps/web/src/pages/admin/Admins.test.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.test.tsx
@@ -142,7 +142,7 @@ describe('the Amministratori page', () => {
     await screen.findByText('ada@orbiters.it')
     expect(screen.queryByRole('dialog')).toBeNull()
     const user = userEvent.setup()
-    await user.click(screen.getByRole('button', { name: 'Modifica Ada' }))
+    await user.click(screen.getByRole('button', { name: 'Modifica Ada (ada@orbiters.it)' }))
     const dialog = await screen.findByRole('dialog', { name: 'Modifica amministratore' })
     expect(within(dialog).getByLabelText('Nome')).toHaveValue('Ada')
     expect(within(dialog).getByLabelText('Email')).toHaveValue('ada@orbiters.it')
@@ -151,8 +151,8 @@ describe('the Amministratori page', () => {
 
     // Escape brings focus back to the pencil that opened it, then the edit goes through.
     await user.keyboard('{Escape}')
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Modifica Ada' })).toHaveFocus())
-    await user.click(screen.getByRole('button', { name: 'Modifica Ada' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Modifica Ada (ada@orbiters.it)' })).toHaveFocus())
+    await user.click(screen.getByRole('button', { name: 'Modifica Ada (ada@orbiters.it)' }))
     await screen.findByRole('dialog', { name: 'Modifica amministratore' })
 
     const reopened = screen.getByRole('dialog')
@@ -183,7 +183,7 @@ describe('the Amministratori page', () => {
     mount()
     await screen.findByText('ada@orbiters.it')
     const user = userEvent.setup()
-    await user.click(screen.getByRole('button', { name: 'Modifica Ada' }))
+    await user.click(screen.getByRole('button', { name: 'Modifica Ada (ada@orbiters.it)' }))
     const dialog = await screen.findByRole('dialog')
     const password = within(dialog).getByLabelText('Nuova password')
     // Ten characters typed, so the browser lets it through and the server has its say.

--- a/projects/hub/apps/web/src/pages/admin/Admins.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.tsx
@@ -61,10 +61,11 @@ export function AdminAdmins() {
    *  the last attempt. While a request is out the dialog stays: closing it would swallow a
    *  late refusal, and a late success would close whatever dialog had been reopened in the
    *  meantime, since the mutation's `onSuccess` outlives `reset()`. */
-  function open(next: Mode) {
+  function open(next: Mode, from: HTMLElement | null = null) {
     if (next.kind === 'closed' && save.isPending) return
     if (next.kind !== 'closed') {
-      opener.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+      // From the event, not `document.activeElement`: Safari does not focus a clicked button.
+      opener.current = from
       setDraft(next.kind === 'edit' ? { nome: next.admin.nome, email: next.admin.email, password: '' } : EMPTY)
       save.reset()
     }
@@ -91,9 +92,9 @@ export function AdminAdmins() {
   }
 
   return (
-    <Dialog open={mode.kind !== 'closed'} onOpenChange={(isOpen) => open(isOpen ? { kind: 'create' } : { kind: 'closed' })}>
+    <Dialog open={mode.kind !== 'closed'} onOpenChange={(isOpen) => !isOpen && open({ kind: 'closed' })}>
       <Header title="Amministratori" count={list.data?.length}>
-        <Button type="button" size="sm" onClick={() => open({ kind: 'create' })}>
+        <Button type="button" size="sm" onClick={(event) => open({ kind: 'create' }, event.currentTarget)}>
           <Plus data-icon="inline-start" />
           Nuovo amministratore
         </Button>
@@ -142,9 +143,16 @@ export function AdminAdmins() {
                 </td>
                 <td className="px-3 py-2.5 text-right text-muted-foreground">{formatDate(row.created_at)}</td>
                 <td className="px-6 py-1.5 text-right">
-                  <Button type="button" variant="ghost" size="icon-sm" onClick={() => open({ kind: 'edit', admin: row })}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={(event) => open({ kind: 'edit', admin: row }, event.currentTarget)}
+                  >
                     <Pencil />
-                    <span className="sr-only">Modifica {row.nome}</span>
+                    <span className="sr-only">
+                      Modifica {row.nome} ({row.email})
+                    </span>
                   </Button>
                 </td>
               </tr>
@@ -164,7 +172,7 @@ export function AdminAdmins() {
             <DialogTitle>{editing ? 'Modifica amministratore' : 'Nuovo amministratore'}</DialogTitle>
             <DialogDescription>
               {editing
-                ? `Lascia la password vuota per non cambiarla. Una nuova password vale da subito, almeno ${PASSWORD_MIN_LENGTH} caratteri, e la comunichi tu a voce o su un canale sicuro.`
+                ? `Lascia la password vuota per non cambiarla. Una nuova password vale da subito, almeno ${PASSWORD_MIN_LENGTH} caratteri, chiude le sue sessioni aperte, e la comunichi tu a voce o su un canale sicuro.`
                 : `Scegli tu la password, almeno ${PASSWORD_MIN_LENGTH} caratteri, e comunicala a voce o su un canale sicuro: qui non viene inviata nessuna email.`}
             </DialogDescription>
           </DialogHeader>

--- a/projects/hub/apps/web/src/pages/admin/Admins.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Admins.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Plus } from 'lucide-react'
-import { useState, type FormEvent } from 'react'
+import { Pencil, Plus } from 'lucide-react'
+import { useRef, useState, type FormEvent } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -11,11 +11,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { ApiError, admin, type AdminCreate } from '@/lib/api'
+import { ApiError, admin, type Admin, type AdminCreate } from '@/lib/api'
 import { formatDate } from '@/lib/format'
 import { Empty, Header } from './lists'
 
@@ -25,54 +24,66 @@ const PASSWORD_MIN_LENGTH = 10
 
 const EMPTY: AdminCreate = { nome: '', email: '', password: '' }
 
+/** What the one dialog is doing: nothing, creating, or editing one row. */
+type Mode = { kind: 'closed' } | { kind: 'create' } | { kind: 'edit'; admin: Admin }
+
 /**
- * Who reads this area, and a button that adds one more (ORB-123, ORB-125). The page is
- * the list; the form lives in a dialog behind «Nuovo amministratore», so the list reads
- * as a list. The creating admin chooses the password and hands it over out of band, as
- * `orbiters createadmin` does on the server; the rules (one address, ten characters) are
- * the service's, and a 422 comes back naming the field, so the dialog stays open and
- * points at it rather than blaming everything. On success it closes, the list refreshes
- * and the page says who was created. No deactivation and no deletion here, on purpose.
+ * Who reads this area, a button that adds one more, and a pencil on every row (ORB-123,
+ * ORB-125, ORB-129). The page is the list; the form lives in one dialog that either
+ * creates or edits, so the two flows cannot drift. The creating admin chooses the
+ * password and hands it over out of band, as `orbiters createadmin` does on the server;
+ * when editing, an empty password means «keep it». The rules (one address, ten
+ * characters) are the service's, and a 422 comes back naming the field, so the dialog
+ * stays open and points at it. On success it closes, the list refreshes and the page says
+ * who was created or changed. No deactivation and no deletion here, on purpose.
  */
 export function AdminAdmins() {
   const client = useQueryClient()
   const list = useQuery({ queryKey: ADMINS_KEY, queryFn: () => admin.admins() })
-  const [open, setOpen] = useState(false)
-  const [created, setCreated] = useState<string | null>(null)
+  const [mode, setMode] = useState<Mode>({ kind: 'closed' })
+  const [done, setDone] = useState<{ verb: 'creato' | 'aggiornato'; email: string } | null>(null)
   const [draft, setDraft] = useState<AdminCreate>(EMPTY)
-  const create = useMutation({
-    mutationFn: (data: AdminCreate) => admin.createAdmin(data),
-    onSuccess: (made) => {
-      setOpen(false)
-      setCreated(made.email)
+  /** Whatever opened the dialog, the header button or one pencil, gets focus back on close. */
+  const opener = useRef<HTMLElement | null>(null)
+  const save = useMutation({
+    mutationFn: (data: AdminCreate & { id?: string }) =>
+      data.id ? admin.updateAdmin({ ...data, id: data.id }) : admin.createAdmin(data),
+    onSuccess: (saved, data) => {
+      setMode({ kind: 'closed' })
+      setDone({ verb: data.id ? 'aggiornato' : 'creato', email: saved.email })
       void client.invalidateQueries({ queryKey: ADMINS_KEY })
     },
   })
 
-  /** Every opening starts clean: an empty draft and no error from the last attempt. While
-   *  a request is out the dialog stays: closing it would swallow a late refusal, and a
-   *  late success would close whatever dialog had been reopened in the meantime, since
-   *  the mutation's `onSuccess` outlives `reset()`. */
-  function toggle(next: boolean) {
-    if (!next && create.isPending) return
-    if (next) {
-      setDraft(EMPTY)
-      create.reset()
+  const editing = mode.kind === 'edit' ? mode.admin : null
+
+  /** Every opening starts clean: the row's values or an empty draft, and no error from
+   *  the last attempt. While a request is out the dialog stays: closing it would swallow a
+   *  late refusal, and a late success would close whatever dialog had been reopened in the
+   *  meantime, since the mutation's `onSuccess` outlives `reset()`. */
+  function open(next: Mode) {
+    if (next.kind === 'closed' && save.isPending) return
+    if (next.kind !== 'closed') {
+      opener.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+      setDraft(next.kind === 'edit' ? { nome: next.admin.nome, email: next.admin.email, password: '' } : EMPTY)
+      save.reset()
     }
-    setOpen(next)
+    setMode(next)
   }
 
-  const failure = create.error instanceof ApiError ? create.error : null
+  const failure = save.error instanceof ApiError ? save.error : null
   const message = failure
     ? failure.message
-    : create.error
-      ? 'Non riesco a creare l’amministratore.'
+    : save.error
+      ? editing
+        ? 'Non riesco a salvare le modifiche.'
+        : 'Non riesco a creare l’amministratore.'
       : null
   const wrong = (field: keyof AdminCreate) => failure?.fields.includes(field) || undefined
 
   function submit(event: FormEvent) {
     event.preventDefault()
-    create.mutate({ ...draft, nome: draft.nome.trim(), email: draft.email.trim() })
+    save.mutate({ ...draft, nome: draft.nome.trim(), email: draft.email.trim(), id: editing?.id })
   }
 
   function field(name: keyof AdminCreate) {
@@ -80,23 +91,25 @@ export function AdminAdmins() {
   }
 
   return (
-    <Dialog open={open} onOpenChange={toggle}>
+    <Dialog open={mode.kind !== 'closed'} onOpenChange={(isOpen) => open(isOpen ? { kind: 'create' } : { kind: 'closed' })}>
       <Header title="Amministratori" count={list.data?.length}>
-        {/* A Radix trigger rather than a plain button, so focus comes back here on close. */}
-        <DialogTrigger asChild>
-          <Button type="button" size="sm">
-            <Plus data-icon="inline-start" />
-            Nuovo amministratore
-          </Button>
-        </DialogTrigger>
+        <Button type="button" size="sm" onClick={() => open({ kind: 'create' })}>
+          <Plus data-icon="inline-start" />
+          Nuovo amministratore
+        </Button>
       </Header>
 
       {/* Always mounted: a live region that appears already filled is often not read out. */}
-      <p role="status" aria-live="polite" className={created ? 'border-b px-6 py-3 text-sm' : undefined}>
-        {created && (
+      <p role="status" aria-live="polite" className={done ? 'border-b px-6 py-3 text-sm' : undefined}>
+        {done?.verb === 'creato' && (
           <>
-            Amministratore creato: <span className="font-medium">{created}</span>. Ora può accedere con
-            la password che gli hai dato.
+            Amministratore creato: <span className="font-medium">{done.email}</span>. Ora può accedere con la
+            password che gli hai dato.
+          </>
+        )}
+        {done?.verb === 'aggiornato' && (
+          <>
+            Amministratore aggiornato: <span className="font-medium">{done.email}</span>.
           </>
         )}
       </p>
@@ -111,7 +124,10 @@ export function AdminAdmins() {
             <tr className="border-b">
               <th className="px-6 py-2 font-medium">Chi</th>
               <th className="px-3 py-2 font-medium">Stato</th>
-              <th className="px-6 py-2 text-right font-medium">Da quando</th>
+              <th className="px-3 py-2 text-right font-medium">Da quando</th>
+              <th className="px-6 py-2">
+                <span className="sr-only">Azioni</span>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -124,20 +140,32 @@ export function AdminAdmins() {
                 <td className="px-3 py-2.5">
                   <Badge variant="pill">{row.attivo ? 'Attivo' : 'Disattivato'}</Badge>
                 </td>
-                <td className="px-6 py-2.5 text-right text-muted-foreground">{formatDate(row.created_at)}</td>
+                <td className="px-3 py-2.5 text-right text-muted-foreground">{formatDate(row.created_at)}</td>
+                <td className="px-6 py-1.5 text-right">
+                  <Button type="button" variant="ghost" size="icon-sm" onClick={() => open({ kind: 'edit', admin: row })}>
+                    <Pencil />
+                    <span className="sr-only">Modifica {row.nome}</span>
+                  </Button>
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       )}
 
-      <DialogContent>
+      <DialogContent
+        onCloseAutoFocus={(event) => {
+          event.preventDefault()
+          opener.current?.focus()
+        }}
+      >
         <form onSubmit={submit} className="grid gap-4">
           <DialogHeader>
-            <DialogTitle>Nuovo amministratore</DialogTitle>
+            <DialogTitle>{editing ? 'Modifica amministratore' : 'Nuovo amministratore'}</DialogTitle>
             <DialogDescription>
-              Scegli tu la password, almeno {PASSWORD_MIN_LENGTH} caratteri, e comunicala a voce o su un
-              canale sicuro: qui non viene inviata nessuna email.
+              {editing
+                ? `Lascia la password vuota per non cambiarla. Una nuova password vale da subito, almeno ${PASSWORD_MIN_LENGTH} caratteri, e la comunichi tu a voce o su un canale sicuro.`
+                : `Scegli tu la password, almeno ${PASSWORD_MIN_LENGTH} caratteri, e comunicala a voce o su un canale sicuro: qui non viene inviata nessuna email.`}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
@@ -165,13 +193,14 @@ export function AdminAdmins() {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="admin-password">Password</Label>
+            <Label htmlFor="admin-password">{editing ? 'Nuova password' : 'Password'}</Label>
             <Input
               id="admin-password"
               type="password"
-              required
-              minLength={PASSWORD_MIN_LENGTH}
+              required={!editing}
+              minLength={editing && !draft.password ? undefined : PASSWORD_MIN_LENGTH}
               autoComplete="new-password"
+              placeholder={editing ? 'Vuota: resta quella di adesso' : undefined}
               value={draft.password}
               onChange={(event) => field('password')(event.target.value)}
               aria-invalid={wrong('password')}
@@ -184,12 +213,12 @@ export function AdminAdmins() {
           )}
           <DialogFooter>
             <DialogClose asChild>
-              <Button type="button" variant="outline" disabled={create.isPending}>
+              <Button type="button" variant="outline" disabled={save.isPending}>
                 Annulla
               </Button>
             </DialogClose>
-            <Button type="submit" disabled={create.isPending}>
-              {create.isPending ? 'Creo…' : 'Crea amministratore'}
+            <Button type="submit" disabled={save.isPending}>
+              {save.isPending ? 'Salvo…' : editing ? 'Salva modifiche' : 'Crea amministratore'}
             </Button>
           </DialogFooter>
         </form>

--- a/projects/hub/packages/core/src/orbiters_core/admin.py
+++ b/projects/hub/packages/core/src/orbiters_core/admin.py
@@ -12,7 +12,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from orbiters_core.config import Settings
-from orbiters_core.errors import ValidationFailed
+from orbiters_core.errors import NotFound, ValidationFailed
 from orbiters_core.models import NAME_MAX_LENGTH, AdminSession, AdminUser
 
 ENTITY = "admin"
@@ -53,20 +53,58 @@ class AdminService:
         """`orbiters createadmin`, and since ORB-123 the form in the admin area. Refuses
         a second admin with the same address, a blank or over-long name and a password
         shorter than ten characters; hashes with argon2, never stores it."""
+        email = self._checked_email(email)
+        nome = self._checked_nome(nome)
+        self._check_password(password)
+        row = AdminUser(email=email, nome=nome, password_hash=_hasher.hash(password))
+        self.session.add(row)
+        self.session.commit()
+        return AdminRead.model_validate(row)
+
+    def update(
+        self,
+        admin_id: UUID,
+        *,
+        nome: str | None = None,
+        email: str | None = None,
+        password: str | None = None,
+    ) -> AdminRead:
+        """The pencil on a row (ORB-129): a new name, a new address, a new password, any
+        of them, under the same rules as `create`. `None` means «keep it». The row's own
+        address is no duplicate of itself; open sessions hang on the id and survive."""
+        row = self.session.get(AdminUser, admin_id)
+        if row is None:
+            raise NotFound(ENTITY, admin_id)
+        if email is not None:
+            row.email = self._checked_email(email, except_id=row.id)
+        if nome is not None:
+            row.nome = self._checked_nome(nome)
+        if password is not None:
+            self._check_password(password)
+            row.password_hash = _hasher.hash(password)
+        self.session.commit()
+        return AdminRead.model_validate(row)
+
+    def _checked_email(self, email: str, except_id: UUID | None = None) -> str:
         email = email.strip().lower()
+        other = self._by_email(email)
+        if other is not None and other.id != except_id:
+            raise ValidationFailed(ENTITY, "email", "esiste già un amministratore con questa email")
+        return email
+
+    @staticmethod
+    def _checked_nome(nome: str) -> str:
         nome = nome.strip()
         if not nome:
             raise ValidationFailed(ENTITY, "nome", "serve un nome")
         if len(nome) > NAME_MAX_LENGTH:
             raise ValidationFailed(ENTITY, "nome", f"al massimo {NAME_MAX_LENGTH} caratteri")
+        return nome
+
+    @staticmethod
+    def _check_password(password: str) -> None:
         if len(password) < PASSWORD_MIN_LENGTH:
             raise ValidationFailed(ENTITY, "password", f"almeno {PASSWORD_MIN_LENGTH} caratteri")
-        if self._by_email(email) is not None:
-            raise ValidationFailed(ENTITY, "email", "esiste già un amministratore con questa email")
-        row = AdminUser(email=email, nome=nome, password_hash=_hasher.hash(password))
-        self.session.add(row)
-        self.session.commit()
-        return AdminRead.model_validate(row)
 
     def authenticate(self, email: str, password: str) -> AdminRead | None:
         """The user, or `None` -- for an unknown address, a wrong password and a

--- a/projects/hub/packages/core/src/orbiters_core/admin.py
+++ b/projects/hub/packages/core/src/orbiters_core/admin.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.orm import Session
 
 from orbiters_core.config import Settings
@@ -68,20 +68,32 @@ class AdminService:
         nome: str | None = None,
         email: str | None = None,
         password: str | None = None,
+        keep_session: str | None = None,
     ) -> AdminRead:
         """The pencil on a row (ORB-129): a new name, a new address, a new password, any
-        of them, under the same rules as `create`. `None` means «keep it». The row's own
-        address is no duplicate of itself; open sessions hang on the id and survive."""
+        of them, under the same rules as `create`. `None` means «keep it». Every field is
+        checked before any is written, so a refused body leaves the row as it was. A new
+        password ends the admin's open sessions, because a reset is also what you do after
+        a leak; `keep_session` is the raw cookie of whoever is editing, spared so an admin
+        changing their own password stays logged in. A new address touches no session:
+        they hang on the id."""
         row = self.session.get(AdminUser, admin_id)
         if row is None:
             raise NotFound(ENTITY, admin_id)
-        if email is not None:
-            row.email = self._checked_email(email, except_id=row.id)
-        if nome is not None:
-            row.nome = self._checked_nome(nome)
+        new_email = self._checked_email(email, except_id=row.id) if email is not None else None
+        new_nome = self._checked_nome(nome) if nome is not None else None
         if password is not None:
             self._check_password(password)
+        if new_email is not None:
+            row.email = new_email
+        if new_nome is not None:
+            row.nome = new_nome
+        if password is not None:
             row.password_hash = _hasher.hash(password)
+            revoke = delete(AdminSession).where(AdminSession.user_id == row.id)
+            if keep_session:
+                revoke = revoke.where(AdminSession.token_hash != _hash_token(keep_session))
+            self.session.execute(revoke)
         self.session.commit()
         return AdminRead.model_validate(row)
 
@@ -103,6 +115,8 @@ class AdminService:
 
     @staticmethod
     def _check_password(password: str) -> None:
+        if not password.strip():
+            raise ValidationFailed(ENTITY, "password", "serve una password")
         if len(password) < PASSWORD_MIN_LENGTH:
             raise ValidationFailed(ENTITY, "password", f"almeno {PASSWORD_MIN_LENGTH} caratteri")
 

--- a/projects/hub/packages/core/tests/test_admin.py
+++ b/projects/hub/packages/core/tests/test_admin.py
@@ -143,3 +143,30 @@ def test_update_changes_only_what_is_given_and_keeps_the_rules_of_create(
         assert refused.value.details["field"] == field, kwargs
     with pytest.raises(NotFound):
         admins.update(UUID("00000000-0000-7000-8000-000000000000"), nome="Nessuno")
+    # A refused body leaves the row as it was, even when another field was fine.
+    with pytest.raises(ValidationFailed):
+        admins.update(ivan.id, email="altro@orbiters.it", nome="  ")
+    hub_session.expire_all()
+    assert admins.list()[0].email == "ivan.sala@orbiters.it"
+
+
+def test_a_new_password_ends_the_open_sessions_but_spares_the_editors_own(
+    admins: AdminService,
+) -> None:
+    # A reset is also what you do after a leak (ORB-129 review). The editor's own cookie
+    # survives, so changing your own password does not log you out; a new address or name
+    # touches nothing.
+    ivan = admins.create("ivan@orbiters.it", "Ivan", "una-password-lunga")
+    mine = admins.open_session(ivan.id)
+    phone = admins.open_session(ivan.id)
+    admins.update(ivan.id, nome="Ivan Sala", email="ivan.sala@orbiters.it")
+    assert admins.resolve(mine) is not None and admins.resolve(phone) is not None
+    admins.update(ivan.id, password="nuova-password-lunga", keep_session=mine)
+    assert admins.resolve(mine) is not None
+    assert admins.resolve(phone) is None
+    other = admins.open_session(ivan.id)
+    admins.update(ivan.id, password="terza-password-lunga")
+    assert admins.resolve(other) is None and admins.resolve(mine) is None
+    with pytest.raises(ValidationFailed) as blank:
+        admins.update(ivan.id, password="          ")
+    assert blank.value.details["field"] == "password"

--- a/projects/hub/packages/core/tests/test_admin.py
+++ b/projects/hub/packages/core/tests/test_admin.py
@@ -1,6 +1,7 @@
 """Admins and sessions: one cookie, hashed at rest, sliding, gone on logout."""
 
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 import pytest
 from sqlalchemy import Engine, select, text
@@ -8,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from orbiters_core.admin import AdminService
 from orbiters_core.config import Settings
-from orbiters_core.errors import ValidationFailed
+from orbiters_core.errors import NotFound, ValidationFailed
 from orbiters_core.models import AdminSession
 
 
@@ -100,3 +101,45 @@ def test_list_names_every_admin_oldest_first_and_says_who_is_active(
     assert [row.attivo for row in listed] == [True, False]
     assert all(row.created_at is not None for row in listed)
     assert not any(hasattr(row, "password_hash") for row in listed)
+
+
+def test_update_changes_only_what_is_given_and_keeps_the_rules_of_create(
+    admins: AdminService, hub_session: Session
+) -> None:
+    # ORB-129: a typo in the name, a new address, a forgotten password. Nothing given
+    # means nothing changed; the rules are create's, once; the hash is never stored raw.
+    ivan = admins.create("ivan@orbiters.it", "Ivan", "una-password-lunga")
+    admins.create("lorenzo@orbiters.it", "Lorenzo", "altra-password-lunga")
+    before = hub_session.execute(
+        text("SELECT password_hash FROM admin_users WHERE nome = 'Ivan'")
+    ).scalar()
+
+    same = admins.update(ivan.id)
+    assert (same.email, same.nome) == ("ivan@orbiters.it", "Ivan")
+
+    renamed = admins.update(ivan.id, nome="  Ivan Sala  ", email="Ivan.Sala@Orbiters.it")
+    assert (renamed.email, renamed.nome) == ("ivan.sala@orbiters.it", "Ivan Sala")
+    assert admins.authenticate("ivan.sala@orbiters.it", "una-password-lunga") is not None
+
+    rekeyed = admins.update(ivan.id, password="nuova-password-lunga")
+    assert rekeyed.email == "ivan.sala@orbiters.it"
+    after = hub_session.execute(
+        text("SELECT password_hash FROM admin_users WHERE id = :id"), {"id": ivan.id}
+    ).scalar()
+    assert after != before and after.startswith("$argon2") and "nuova" not in after
+    assert admins.authenticate("ivan.sala@orbiters.it", "una-password-lunga") is None
+    assert admins.authenticate("ivan.sala@orbiters.it", "nuova-password-lunga") is not None
+
+    # The same address on itself is fine; another admin's address is not.
+    assert admins.update(ivan.id, email="IVAN.SALA@orbiters.it").email == "ivan.sala@orbiters.it"
+    for kwargs, field in (
+        ({"email": "lorenzo@orbiters.it"}, "email"),
+        ({"nome": "  "}, "nome"),
+        ({"nome": "x" * 121}, "nome"),
+        ({"password": "breve"}, "password"),
+    ):
+        with pytest.raises(ValidationFailed) as refused:
+            admins.update(ivan.id, **kwargs)
+        assert refused.value.details["field"] == field, kwargs
+    with pytest.raises(NotFound):
+        admins.update(UUID("00000000-0000-7000-8000-000000000000"), nome="Nessuno")


### PR DESCRIPTION
## What this changes

Once created, an admin could not be changed: a typo in the name, a new address or a forgotten password had no fix short of the database. Every row of «Amministratori» now ends with a pencil («Modifica Lorenzo (demo)» for a screen reader) that opens the same dialog as the header button, prefilled, as «Modifica amministratore». The password field there reads «Nuova password», is optional, and its placeholder says «Vuota: resta quella di adesso». A refusal stays inside the dialog on the field the server names; a success closes it, refreshes the list and leaves «Amministratore aggiornato: lorenzo.fiore@orbiters.it.» on the page. Focus goes back to the pencil (or to the header button) on close.

Ivan chose the fields on 2026-09-10: name, address and password; not the `attivo` flag, not deletion.

## How I verified it

- `uv run pytest -q projects/hub/packages/core/tests projects/hub/apps/api/tests projects/hub/apps/mcp/tests`: 169 passed after the review commit (167 before). New: the service test (nothing given changes nothing; name, address and password each change; the old password stops authenticating and the new one works; the row's own address is no duplicate; each refusal on its field; 404 on an unknown id) and two route tests (401 without the cookie; the edit; the new credentials logging in and the old ones refused; every refusal as a 422 on `email`, `nome`, `password` or an undeclared `attivo`; an empty password as «keep it»; one's own row; 404).
- `uv run ruff check projects/hub`, `ruff format --check`, `uv run mypy`: clean.
- `pnpm --filter hub test`: 52 passed, 13 files. New: the client test (`PATCH /api/hub/admins/2` without the empty password), and two component tests (the pencil opens the dialog prefilled with the password field empty and not required; Escape returns focus to the pencil; a save without password; the create dialog empty again after an edit; a new password refused on its field and then accepted, sent in the body). `lint` clean, `build` ok.
- In a real browser against a throwaway Postgres: the pencil on the second row opened the dialog prefilled («Lorenzo (demo)», `lorenzo.demo@orbiters.it`, empty password); the first admin's address was refused with «esiste già un amministratore con questa email»; a rename to «Lorenzo Fiore», a new address and a new password went through, the list showed the new name, the status line appeared and focus was back on the pencil. Then, against the API: the old password answers 401 and the new one 200.

## What did not change, on purpose

No deactivation (the `attivo` flag stays as it is; a body carrying it is a 422), no deletion, no MCP tool. A new address or name does not touch the admin's open sessions: they hang on the id. A new password does end them (review finding, applied): a reset is also what you do after a leak, and with no `attivo` toggle there was no other way to close a colleague's sessions; the editor's own cookie is spared, so changing your own password keeps you in. Recorded on ORB-129.

## API changes

- `PATCH /api/hub/admins/{admin_id}`, admin cookie, body with `nome`, `email`, `password` all optional and `extra="forbid"`; 200 with the `AdminRead`; 404 for an unknown id; 422 in FastAPI's shape on the field. An empty `password` is treated as absent; a present one also deletes the admin's other sessions.
- `AdminService.create` and the new `AdminService.update` share three checks (`_checked_email`, `_checked_nome`, `_check_password`), so the rules exist once.
- Hub web client `projects/hub/apps/web/src/lib/api.ts`: `AdminUpdate` type and `admin.updateAdmin({ id, nome, email, password })`, which leaves an empty password out of the body.

## Anything a reviewer should look at twice

- The dialog is one component in three modes (`closed`, `create`, `edit`); the header button is no longer a Radix `DialogTrigger`, because there are now several openers, so focus return is done by hand in `onCloseAutoFocus` from the element the click event came from (not `document.activeElement`, which Safari does not move to a clicked button).
- The `minLength` on the password field is dropped while editing with an empty value, so the browser does not block «keep it»; once something is typed the ten-character floor is back.
- An admin can edit their own row, including their address and password; their current session keeps working because the route passes the caller's cookie to the service and the revocation spares it. Every field is checked before any is written, so a body with one good field and one bad leaves the row as it was.

## Screenshots

**1. The rows: a pencil at the end of each**
![The admin rows, before and after](https://github.com/user-attachments/assets/728795dc-0160-4d0c-a9bc-b84d751b5508)

**2. The edit dialog, prefilled, with the optional password**
![The edit dialog, before and after](https://github.com/user-attachments/assets/522bc5b9-65f5-413d-aa42-582821ba8bc5)

Linear: ORB-129.

