### PR TITLE
feat(web): the invoice list says what each invoice is for, without the «importata» pill

### DIFF
--- a/projects/pigrocrm/apps/web/src/components/DataTable.tsx
+++ b/projects/pigrocrm/apps/web/src/components/DataTable.tsx
@@ -38,7 +38,10 @@ import { cn } from '@/lib/utils'
  * itself would leave its own header on the left. `width` is a plain CSS length passed
  * to the header cell, which is enough to keep the «⋯» column from taking a fair share
  * of the table's width -- v9's real column sizing is a feature (`columnSizingFeature`)
- * this table deliberately does not register.
+ * this table deliberately does not register. A percentage works too, and means the
+ * opposite thing: in an auto-layout table a `100%` column is handed whatever the other
+ * columns leave, which is how the invoice list's «Descrizione» column stays flexible
+ * (`features/invoices/columns.tsx`).
  */
 export interface DataTableColumnMeta {
   align?: 'left' | 'right'

--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.test.tsx
@@ -294,14 +294,19 @@ describe('InvoiceActions', () => {
     expect(screen.getByRole('button', { name: /^PDF$/i })).toBeInTheDocument()
   })
 
+})
+
+/** The badge lives in its own file (see there for why); its tests live here beside the
+ *  actions that read the same `importata_da` flag. */
+describe('InvoiceStateBadge', () => {
   it('shows the "imported" badge next to the state badge, naming no source', () => {
     const imported = { ...ISSUED, importata_da: 'esterno' } as Invoice
     wrap(<InvoiceStateBadge invoice={imported} />)
     expect(screen.getByText(/^importata$/i)).toBeInTheDocument()
   })
 
-  /** The list turns the pill off (ORB-130); the detail page, which renders the badge
-   *  with no option, keeps it as the reason the XML actions are missing. */
+  /** The list turns the pill off (ORB-130). Rendered with no option, as the detail page
+   *  does, the badge keeps it: that is the test above this one. */
   it('leaves the "imported" badge out when asked to, and keeps the state', () => {
     const imported = { ...ISSUED, importata_da: 'esterno' } as Invoice
     wrap(<InvoiceStateBadge invoice={imported} importata={false} />)

--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.test.tsx
@@ -300,6 +300,15 @@ describe('InvoiceActions', () => {
     expect(screen.getByText(/^importata$/i)).toBeInTheDocument()
   })
 
+  /** The list turns the pill off (ORB-130); the detail page, which renders the badge
+   *  with no option, keeps it as the reason the XML actions are missing. */
+  it('leaves the "imported" badge out when asked to, and keeps the state', () => {
+    const imported = { ...ISSUED, importata_da: 'esterno' } as Invoice
+    wrap(<InvoiceStateBadge invoice={imported} importata={false} />)
+    expect(screen.getByText('Emessa')).toBeInTheDocument()
+    expect(screen.queryByText(/^importata$/i)).toBeNull()
+  })
+
   // Whatever the column holds -- the value is provenance the CRM keeps for itself, not
   // copy -- the badge says only that the invoice came from elsewhere. A source name
   // reaching the screen is the defect this assertion exists to catch.

--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoiceStateBadge.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoiceStateBadge.tsx
@@ -21,7 +21,15 @@ import {
  *  could fire (a wire string the cast below lies about) it would render a grey pill whose
  *  label is `undefined`, which is worse than nothing at all. If that cast ever stops being
  *  safe, the fix is to narrow it here, not to tint an empty pill. */
-export function InvoiceStateBadge({ invoice }: { invoice: Invoice }) {
+export function InvoiceStateBadge({
+  invoice,
+  importata = true,
+}: {
+  invoice: Invoice
+  /** Whether an imported invoice also gets its «importata» pill. The detail page wants
+   *  it, as the reason the XML actions are missing; the list does not (ORB-130). */
+  importata?: boolean
+}) {
   const stato = invoice.stato as InvoiceStato
   return (
     <span className="inline-flex items-center gap-1.5">
@@ -35,7 +43,7 @@ export function InvoiceStateBadge({ invoice }: { invoice: Invoice }) {
 
           A pill with no dot, deliberately: «importata» is not one of the fiscal states
           and must not read as a sixth one sitting in the same row. */}
-      {invoice.importata_da != null ? (
+      {importata && invoice.importata_da != null ? (
         <Badge variant="pill" className="text-muted-foreground">
           importata
         </Badge>

--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoicesTab.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoicesTab.test.tsx
@@ -48,6 +48,13 @@ describe('InvoicesTab', () => {
     expect(await screen.findByRole('columnheader', { name: 'Competenza' })).toBeInTheDocument()
   })
 
+  /** The tab has no customer column, so the description follows the number (ORB-130). */
+  it('says what each invoice is for, right after the number', async () => {
+    renderWithClient(<InvoicesTab owner={{ customerId: 'c1' }} />)
+    const headers = (await screen.findAllByRole('columnheader')).map((h) => h.textContent)
+    expect(headers.indexOf('Descrizione')).toBe(headers.indexOf('Numero') + 1)
+  })
+
   /**
    * The slot exists so the button that creates an invoice sits on the tab that lists
    * them, rather than in the page header where it would be offered from every other tab

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
@@ -243,8 +243,9 @@ describe('the accrual period column', () => {
 /**
  * The «Descrizione» column (ORB-130): the causale, which until now the list never
  * showed. A causale can be 200 characters long, so the cell is the one place in this
- * table that truncates: a block with a maximum width and an ellipsis, the whole text as
- * the cell's title, rather than a column that widens the table to fit the longest row.
+ * table that truncates: the column takes what the others leave, down to a floor, and the
+ * text clips there with the whole causale as the cell's title, rather than a column that
+ * widens the table to fit the longest row.
  */
 describe('the description column', () => {
   it('sits right after the customer when the list shows one, and after the number otherwise', () => {
@@ -262,14 +263,15 @@ describe('the description column', () => {
   })
 
   /** The column takes what the others leave (`width: 100%` on the header) and the span
-   *  fills exactly that (a block of width zero with a minimum of the whole cell), so
-   *  the text truncates at the column's width instead of widening the table. */
+   *  fills exactly that (a block of width zero whose minimum is the whole cell, never
+   *  less than 12rem), so the text truncates at the column's width instead of widening
+   *  the table, and the column cannot shrink to its header on a narrow screen. */
   it('truncates a long causale at the width the column gets and keeps the whole text as the title', () => {
     expect(column('descrizione').meta).toEqual({ width: '100%' })
     renderCell('descrizione', { ...ISSUED, causale: LONG_CAUSALE } as Invoice)
     const cell = screen.getByTitle(LONG_CAUSALE)
     expect(cell).toHaveTextContent(LONG_CAUSALE)
-    for (const cls of ['block', 'w-0', 'min-w-full', 'truncate']) {
+    for (const cls of ['block', 'w-0', 'min-w-[max(100%,12rem)]', 'truncate']) {
       expect(cell.className).toContain(cls)
     }
   })

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
@@ -261,13 +261,17 @@ describe('the description column', () => {
     expect(accessor('descrizione', { ...ISSUED, causale: '' } as Invoice)).toBe('—')
   })
 
-  it('truncates a long causale in a bounded block and keeps the whole text as the title', () => {
+  /** The column takes what the others leave (`width: 100%` on the header) and the span
+   *  fills exactly that (a block of width zero with a minimum of the whole cell), so
+   *  the text truncates at the column's width instead of widening the table. */
+  it('truncates a long causale at the width the column gets and keeps the whole text as the title', () => {
+    expect(column('descrizione').meta).toEqual({ width: '100%' })
     renderCell('descrizione', { ...ISSUED, causale: LONG_CAUSALE } as Invoice)
     const cell = screen.getByTitle(LONG_CAUSALE)
     expect(cell).toHaveTextContent(LONG_CAUSALE)
-    expect(cell.className).toContain('truncate')
-    expect(cell.className).toContain('block')
-    expect(cell.className).toMatch(/max-w-/)
+    for (const cls of ['block', 'w-0', 'min-w-full', 'truncate']) {
+      expect(cell.className).toContain(cls)
+    }
   })
 
   it('shows the missing causale as a quiet dash', () => {

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.test.ts
@@ -28,6 +28,12 @@ const PROFORMA = {
 
 const WITH_CUSTOMER = { ...ISSUED, customer_ragione_sociale: 'ACME S.r.l.' } as Invoice
 
+const LONG_CAUSALE =
+  'Consulenza tecnica e sviluppo software per il progetto di migrazione della piattaforma, ' +
+  'comprensiva di analisi, implementazione, test e supporto al rilascio in produzione'
+
+const WITH_CAUSALE = { ...ISSUED, causale: 'Consulenza agosto' } as Invoice
+
 const WITH_PERIOD = {
   ...ISSUED,
   competenza_da: '2026-08-01',
@@ -231,5 +237,55 @@ describe('the accrual period column', () => {
 
     renderCell('competenza', ISSUED)
     expect(screen.getByText('—').className).toContain('text-muted-foreground')
+  })
+})
+
+/**
+ * The «Descrizione» column (ORB-130): the causale, which until now the list never
+ * showed. A causale can be 200 characters long, so the cell is the one place in this
+ * table that truncates: a block with a maximum width and an ellipsis, the whole text as
+ * the cell's title, rather than a column that widens the table to fit the longest row.
+ */
+describe('the description column', () => {
+  it('sits right after the customer when the list shows one, and after the number otherwise', () => {
+    const withCustomer = buildInvoiceColumns({ cliente: true }).map((c) => c.id ?? '')
+    expect(withCustomer.indexOf('descrizione')).toBe(withCustomer.indexOf('cliente') + 1)
+    const plain = buildInvoiceColumns().map((c) => c.id ?? '')
+    expect(plain.indexOf('descrizione')).toBe(plain.indexOf('numero') + 1)
+    expect(column('descrizione').header).toBe('Descrizione')
+  })
+
+  it('reads the causale, or the em dash when there is none', () => {
+    expect(accessor('descrizione', WITH_CAUSALE)).toBe('Consulenza agosto')
+    expect(accessor('descrizione', { ...ISSUED, causale: null } as Invoice)).toBe('—')
+    expect(accessor('descrizione', { ...ISSUED, causale: '' } as Invoice)).toBe('—')
+  })
+
+  it('truncates a long causale in a bounded block and keeps the whole text as the title', () => {
+    renderCell('descrizione', { ...ISSUED, causale: LONG_CAUSALE } as Invoice)
+    const cell = screen.getByTitle(LONG_CAUSALE)
+    expect(cell).toHaveTextContent(LONG_CAUSALE)
+    expect(cell.className).toContain('truncate')
+    expect(cell.className).toContain('block')
+    expect(cell.className).toMatch(/max-w-/)
+  })
+
+  it('shows the missing causale as a quiet dash', () => {
+    renderCell('descrizione', { ...ISSUED, causale: null } as Invoice)
+    expect(screen.getByText('—').className).toContain('text-muted-foreground')
+  })
+})
+
+/**
+ * The state column no longer stamps «importata» on a row (ORB-130): in a register where
+ * most rows came from the previous system the word explains nothing a reader of the list
+ * can act on. The detail page keeps it, where it says why the XML and «Rigenera
+ * documenti» are missing.
+ */
+describe('the state column and an imported invoice', () => {
+  it('shows the state and not the provenance', () => {
+    renderCell('stato', { ...ISSUED, importata_da: 'esterno' } as Invoice)
+    expect(screen.getByText('Emessa')).toBeInTheDocument()
+    expect(screen.queryByText(/^importata$/i)).toBeNull()
   })
 })

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
@@ -35,8 +35,12 @@ export interface InvoiceColumnOptions {
  * a rendering fault rather than as what it is.
  */
 function customerName(row: Invoice): string {
-  const name = row.customer_ragione_sociale
-  return name === null || name === undefined || name === '' ? EMPTY : name
+  return textOrDash(row.customer_ragione_sociale)
+}
+
+/** `null`, `undefined` and `''` are all "nothing here", as everywhere else in this table. */
+function textOrDash(value: string | null | undefined): string {
+  return value === null || value === undefined || value === '' ? EMPTY : value
 }
 
 /**
@@ -49,11 +53,9 @@ function accrualPeriod(row: Invoice): string {
   return formatPeriod(row.competenza_da, row.competenza_a)
 }
 
-/** The causale, or the dash: `''` and `null` are both "nothing here", as everywhere
- *  else in this table. */
+/** The causale, or the dash. */
 function description(row: Invoice): string {
-  const causale = row.causale
-  return causale === null || causale === undefined || causale === '' ? EMPTY : causale
+  return textOrDash(row.causale)
 }
 
 export function buildInvoiceColumns(
@@ -97,17 +99,23 @@ export function buildInvoiceColumns(
       // pushed the other eight past the frame at 1440px (measured: 24rem left the table
       // 280px wider than its box). So it is sized the other way round: the header asks
       // for `100%`, which in an auto-layout table means "whatever the others leave", and
-      // the span is a block of width zero with a minimum of the whole cell, so the cell
-      // contributes nothing to the table's minimum and the text truncates at exactly the
-      // width the column got. `truncate` works here where it did not on the customer's
-      // name because the block has a width to clip against. The whole causale stays
-      // reachable as the cell's title.
+      // the span is a block of width zero whose minimum is the whole cell, so the text
+      // truncates at exactly the width the column got. `truncate` works here where it
+      // did not on the customer's name because the block has a width to clip against.
+      //
+      // The 12rem inside the `max()` is a floor: without it the column shrank to its
+      // header at 1280px (measured, 81px) and read as an ellipsis, which defeats the
+      // column. A percentage resolves to zero while the table measures its minimum, so
+      // the floor is the only part of the minimum the cell contributes; at 1440px with the
+      // sidebar open it costs about 70px of horizontal scroll inside the frame, which the
+      // table already handles, and from 1512px up nothing scrolls. The whole causale
+      // stays reachable as the cell's title.
       meta: { width: '100%' },
       cell: ({ row }) => {
         const causale = description(row.original)
         if (causale === EMPTY) return <span className="text-muted-foreground">{EMPTY}</span>
         return (
-          <span className="block w-0 min-w-full truncate" title={causale}>
+          <span className="block w-0 min-w-[max(100%,12rem)] truncate" title={causale}>
             {causale}
           </span>
         )

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
@@ -49,6 +49,13 @@ function accrualPeriod(row: Invoice): string {
   return formatPeriod(row.competenza_da, row.competenza_a)
 }
 
+/** The causale, or the dash: `''` and `null` are both "nothing here", as everywhere
+ *  else in this table. */
+function description(row: Invoice): string {
+  const causale = row.causale
+  return causale === null || causale === undefined || causale === '' ? EMPTY : causale
+}
+
 export function buildInvoiceColumns(
   options: InvoiceColumnOptions = {},
 ): ColumnDef<DataTableFeatures, Invoice>[] {
@@ -82,6 +89,27 @@ export function buildInvoiceColumns(
     },
     ...cliente,
     {
+      header: 'Descrizione',
+      id: 'descrizione',
+      accessorFn: (row) => description(row),
+      // The one cell in this table that truncates (ORB-130). A causale runs to 200
+      // characters, and a column that widened to fit the longest one would push every
+      // other column off the frame. `truncate` works here where it did not on the
+      // customer's name because the span is a block with a maximum width: in an
+      // auto-layout table that width is what the cell's minimum becomes, so the
+      // ellipsis has something to clip against. The whole text stays reachable as the
+      // cell's title.
+      cell: ({ row }) => {
+        const causale = description(row.original)
+        if (causale === EMPTY) return <span className="text-muted-foreground">{EMPTY}</span>
+        return (
+          <span className="block max-w-[24rem] truncate" title={causale}>
+            {causale}
+          </span>
+        )
+      },
+    },
+    {
       header: 'Tipo',
       id: 'tipo',
       accessorFn: (row) => INVOICE_TYPE_LABELS[row.tipo as keyof typeof INVOICE_TYPE_LABELS],
@@ -89,7 +117,10 @@ export function buildInvoiceColumns(
     {
       header: 'Stato',
       id: 'stato',
-      cell: ({ row }) => <InvoiceStateBadge invoice={row.original} />,
+      // Without the «importata» pill (ORB-130): in a register where most rows came from
+      // the previous system the word explains nothing a reader of the list can act on.
+      // The detail page keeps it, as the reason its XML actions are missing.
+      cell: ({ row }) => <InvoiceStateBadge invoice={row.original} importata={false} />,
     },
     {
       header: 'Data',

--- a/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/columns.tsx
@@ -92,18 +92,22 @@ export function buildInvoiceColumns(
       header: 'Descrizione',
       id: 'descrizione',
       accessorFn: (row) => description(row),
-      // The one cell in this table that truncates (ORB-130). A causale runs to 200
-      // characters, and a column that widened to fit the longest one would push every
-      // other column off the frame. `truncate` works here where it did not on the
-      // customer's name because the span is a block with a maximum width: in an
-      // auto-layout table that width is what the cell's minimum becomes, so the
-      // ellipsis has something to clip against. The whole text stays reachable as the
-      // cell's title.
+      // The one flexible column in this table (ORB-130). A causale runs to 200
+      // characters, and a column sized to its content, or even to a fixed maximum,
+      // pushed the other eight past the frame at 1440px (measured: 24rem left the table
+      // 280px wider than its box). So it is sized the other way round: the header asks
+      // for `100%`, which in an auto-layout table means "whatever the others leave", and
+      // the span is a block of width zero with a minimum of the whole cell, so the cell
+      // contributes nothing to the table's minimum and the text truncates at exactly the
+      // width the column got. `truncate` works here where it did not on the customer's
+      // name because the block has a width to clip against. The whole causale stays
+      // reachable as the cell's title.
+      meta: { width: '100%' },
       cell: ({ row }) => {
         const causale = description(row.original)
         if (causale === EMPTY) return <span className="text-muted-foreground">{EMPTY}</span>
         return (
-          <span className="block max-w-[24rem] truncate" title={causale}>
+          <span className="block w-0 min-w-full truncate" title={causale}>
             {causale}
           </span>
         )

--- a/projects/pigrocrm/apps/web/src/routes/app/fatture/index.test.tsx
+++ b/projects/pigrocrm/apps/web/src/routes/app/fatture/index.test.tsx
@@ -156,6 +156,15 @@ describe('the invoice list', () => {
     expect(screen.getByRole('cell', { name: 'ACME S.r.l.' })).toBeInTheDocument()
   })
 
+  it('says what each invoice is for, right after the customer (ORB-130)', async () => {
+    mockInvoices([invoice({ causale: 'Consulenza agosto', importata_da: 'esterno' })])
+    renderList()
+    const headers = (await screen.findAllByRole('columnheader')).map((h) => h.textContent)
+    expect(headers.indexOf('Descrizione')).toBe(headers.indexOf('Cliente') + 1)
+    expect(screen.getByRole('cell', { name: 'Consulenza agosto' })).toBeInTheDocument()
+    expect(screen.queryByText(/^importata$/i)).toBeNull()
+  })
+
   it('says which period each invoice is about, beside its date (ORB-126)', async () => {
     mockInvoices([
       invoice({


### PR DESCRIPTION
## What this changes

The Fatture list never showed what an invoice is for: the causale is on every row but was printed only as the detail page's subtitle. And the Stato column appended an «importata» pill to every row that came from the previous system, which in Ivan's register is most of them, so the word explained nothing a reader of the list could act on. Ivan asked for both on 2026-09-10 («aggiungi nella tabella anche la descrizione della fattura, rimuovi il tag importata che non ha senso dalla tabella»).

Now a «Descrizione» column sits right after «Cliente» (after «Numero» on the Fatture tab of a customer or a deal, which has no customer column), reading the causale or the em dash. It is the one flexible column in the table: the header asks for `100%`, so it takes whatever the other columns leave, and the text truncates there with the whole causale as the cell's title. The «importata» pill is gone from the table: `InvoiceStateBadge` takes an `importata` option, on by default, and the list turns it off. The detail page keeps the pill, where it is the reason the XML and «Rigenera documenti» actions are missing for an imported invoice.

## How I verified it

- Red then green: seven tests across `columns.test.ts` (position with and without the customer column, the causale and the dash, truncation classes and title, quiet dash, the state cell without «importata»), `InvoiceActions.test.tsx` (the badge without its pill when asked, with it by default) and `fatture/index.test.tsx` (the header after Cliente, the cell, no «importata» in the list). All failing on `origin/main`, passing now.
- The first cut used a 24rem maximum width. Measured on the live page at 1440px: the table came out 280px wider than its frame. The second commit switches to the flexible column; measured again, the table is back at 1078px inside its box and the description gets about 120px at that viewport with the sidebar open.
- `pnpm --filter web test`: 1071 passed, 101 files. `pnpm --filter web lint`, `pnpm --filter web build`, `tsc --noEmit`: clean.
- `bash projects/pigrocrm/apps/web/scripts/e2e.sh` (the Playwright suite, serial, its own Postgres): 39 passed in 1.2m.
- After the independent review (recorded as a comment on this PR): the twelve invoice and table test files 164 passed; eslint, `tsc --noEmit` clean; the page re-measured at 1440px, Descrizione 208px wide, the table about 80px past its frame inside its own scroll.
- Opened http://localhost:5173/app/fatture against a local stack with an issued invoice carrying a 170-character causale, a proforma, and an invoice imported through `POST /api/invoices/import`: the causale reads truncated with the full text on hover, and the imported row shows «Emessa» with no pill. The pair below is that page, before from `origin/main` on 5175 and after from this branch on 5173, same API.

## Anything a reviewer should look at twice

- The description has a floor of 12rem (the review found it shrinking to its header at 1280px without one). At 1440px with the sidebar open that costs about 80px of horizontal scroll inside the table's frame, the «Pagamento» column partly behind it; from 1512px up nothing scrolls and the column grows with the screen. Reclaiming width would mean shortening or dropping another column, which is a separate decision.
- The `w-0 min-w-[max(100%,12rem)]` span: width zero keeps the cell's text out of the table's minimum, the percentage resolves to zero while the table measures itself so only the 12rem counts, and the minimum of 100% makes it fill the width the column was given. Verified by measurement at 1280, 1440 and 1920, not only by reasoning.

## What did not change, on purpose

- The «importata» pill stays on the detail page, where it explains the missing actions. Ivan can ask for it to go there too.
- No filter or sort by description, no API change.

## Screenshots

**1. Fatture list, the «Descrizione» column after Cliente, and «Emessa» without «importata» on the imported row**
![Fatture list, before and after](https://github.com/user-attachments/assets/9168c155-9ba8-4fbe-809d-cd20fb8ece1f)

Linear: ORB-130.
