### PR TITLE
docs(repo): the loop scans the neighbours and keeps the card current

### DIFF
--- a/.claude/skills/linear-content/SKILL.md
+++ b/.claude/skills/linear-content/SKILL.md
@@ -48,10 +48,14 @@ to edit. Where a design choice is already taken, say so and where it is recorded
 reason, so the next person does not reopen a closed question.
 ```
 
-Optional, when they apply: **Evidence** (the reproduction, the measurement, the log
-line), **Blocks** / **Blocked by** (issue ids you have read), **Decision for the
-lead** (the project's lead per `docs/tracker.md`: one question, the options, your
-recommendation first).
+Always, on a card you are about to work: **Adjacent** (the open cards next to this one,
+found as the `linear-ticket` skill says, and what was done about each: linked, narrowed
+around, waited for. When there are none, the sentence that says so, with the calls that
+answered empty and the last Done cards on the same surface, so a reader can tell the
+board was read). Optional, when they apply: **Evidence** (the reproduction, the
+measurement, the log line), **Blocks** / **Blocked by** (issue ids you have read),
+**Decision for the lead** (the project's lead per `docs/tracker.md`: one question, the
+options, your recommendation first).
 
 ## Comments
 
@@ -62,11 +66,20 @@ which kind it is, so a reader can skim the thread.
   Never "working on it".
 - **Found.** `**Cause is different from the title:** ...` The reproduction or measurement,
   and what it changes about the plan.
+- **Scope.** `**Scope, narrowed:** ...` or `**Scope, grown:** ...` What the card now
+  covers that it did not, or no longer covers, and why: a neighbour found late, a file
+  that had to move too, a piece left for its own card (with the id, once filed).
+- **Waiting.** `**Waiting on Lorenzo:** ...` What you are stopped on, from whom, and what
+  you will do when it arrives. One comment when you stop, one when it lifts.
 - **Decision.** `**MCP, decided.** ...` What was chosen, the reason, where it is recorded
   (`DECISIONS.md` row, spec paragraph). If it is the lead's to take: the question, the
   options, your recommendation, and stop.
 - **PR.** `PR: <url> (branch ...)` plus one sentence on what it contains and what is
   still running (review, CI).
+- **Review.** `**Review applied:** ...` How many findings, which changed the code (commit
+  sha), which you left as they were and why. The full record stays on the PR; the card
+  gets the one line that says the PR is not what it was when it opened. The same shape
+  for a CI run that went red (`**CI red:** run ..., <job>, <cause>, fixed in ...`).
 - **Closing.** `**Merged:** <url> (merge commit ...)` or `**In production:** tag ...`
   followed by `Evidence:` and a bulleted list a reader can chase: run ids with the job
   names that went green, test counts, the request you made and what came back, what you

--- a/.claude/skills/linear-content/SKILL.md
+++ b/.claude/skills/linear-content/SKILL.md
@@ -29,7 +29,7 @@ the intended fix, because the fix changes and a title written as a fix ages into
 
 ## The issue body
 
-Four lead words, each a short paragraph or a few bullets. Skip one only when it has
+Five lead words, each a short paragraph or a few bullets. Skip one only when it has
 nothing to say, never because it is inconvenient.
 
 ```markdown
@@ -46,16 +46,18 @@ to edit. Where a design choice is already taken, say so and where it is recorded
 
 **Deliberately not done.** What a reader might expect and will not find, with the
 reason, so the next person does not reopen a closed question.
+
+**Adjacent.** The open cards next to this one, found as the `linear-ticket` skill
+says, and what was done about each: linked, narrowed around, waited for. Or that there
+were none: which area calls answered empty, and the Done cards `query` ranked first for
+the surface, so a reader can tell the board was read.
 ```
 
-Always, on a card you are about to work: **Adjacent** (the open cards next to this one,
-found as the `linear-ticket` skill says, and what was done about each: linked, narrowed
-around, waited for. When there are none, the sentence that says so, with the calls that
-answered empty and the last Done cards on the same surface, so a reader can tell the
-board was read). Optional, when they apply: **Evidence** (the reproduction, the
-measurement, the log line), **Blocks** / **Blocked by** (issue ids you have read),
-**Decision for the lead** (the project's lead per `docs/tracker.md`: one question, the
-options, your recommendation first).
+**Adjacent** is skipped only on a card filed for later, and added when the card is
+picked up (`patch` with `op: "append"`, in the call that moves it). Optional, when they
+apply: **Evidence** (the reproduction, the measurement, the log line), **Blocks** /
+**Blocked by** (issue ids you have read), **Decision for the lead** (the project's lead
+per `docs/tracker.md`: one question, the options, your recommendation first).
 
 ## Comments
 
@@ -79,7 +81,8 @@ which kind it is, so a reader can skim the thread.
 - **Review.** `**Review applied:** ...` How many findings, which changed the code (commit
   sha), which you left as they were and why. The full record stays on the PR; the card
   gets the one line that says the PR is not what it was when it opened. The same shape
-  for a CI run that went red (`**CI red:** run ..., <job>, <cause>, fixed in ...`).
+  for a CI run that went red (`**CI red:** run ..., <job>, <cause>`, written when you
+  see it, with the sha of the fix added to the same comment when you push it).
 - **Closing.** `**Merged:** <url> (merge commit ...)` or `**In production:** tag ...`
   followed by `Evidence:` and a bulleted list a reader can chase: run ids with the job
   names that went green, test counts, the request you made and what came back, what you

--- a/.claude/skills/linear-ticket/SKILL.md
+++ b/.claude/skills/linear-ticket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linear-ticket
-description: Use when filing, finding, moving or closing a Linear issue for this repository (team Orbiters, ORB-N), or posting a project update. The MCP workflow with every field in one call, the state changes at each step, and the API quirks that otherwise cost a wasted call. Triggers on "file this", "move to Done", "update the project", or the Italian «crea ticket», «apri un'issue».
+description: Use when filing, finding, moving or closing a Linear issue for this repository (team Orbiters, ORB-N), or posting a project update, and at the start of any change here, before the first file is touched, to find the card and the cards next to it. The MCP workflow with every field in one call, the neighbour scan, the state changes at each step, and the API quirks that otherwise cost a wasted call. Triggers on "file this", "move to Done", "update the project", on starting a task or a PR, or the Italian «crea ticket», «apri un'issue», «parti da questo ticket».
 ---
 
 # Working the Linear board
@@ -52,6 +52,45 @@ work you may start.
 A new issue is filed only when none exists and the work will outlive this run, and then
 **before** the work starts, never after (`docs/tracker.md`, The loop).
 
+## The neighbours, before the first file changes
+
+Finding the same card is one search. Finding the cards your change can collide with or
+settle is another, and it happens every time, whether the card was found or filed
+(`docs/tracker.md` § The loop). Three reads, each with
+`fields: ["id", "title", "status", "statusType", "labels", "project", "assigneeId"]`:
+
+1. **The area, open states only.** `list_issues` with `team: "Orbiters"`,
+   `label: "<the area:* your change lands in>"` and `state: "started"`, which answers
+   `In Progress` and `In Review` together; then `state: "unstarted"` (`Todo`), then
+   `state: "backlog"`. One `state` per call, so three calls, with `limit` raised past
+   50.
+2. **The surface, by name.** `list_issues` with `query:` one noun of what you are about
+   to touch, one call per noun: the screen («Fatture»), the route (`/api/invoices`), the
+   table (`invoices`), the file's stem (`columns.tsx`). `query` ranks, it does not
+   filter (measured 2026-09-10: `columns.tsx` gave the three invoice-list cards first,
+   then twenty unrelated ones). Read the first handful and stop where the titles stop
+   being about your surface.
+3. **The project**, when the area is the wrong lens (a shared package, `docs/`, a
+   change that spans two apps): `list_issues` with `project:` the id and the three open
+   states.
+
+What comes back is read, not counted:
+
+- **`started` under the other person, on the same surface.** You do not overlap it.
+  Narrow your card to what theirs leaves alone, or wait for theirs, and write which on
+  your card. Never a second PR on the same files, and never a touch on their card beyond
+  a comment (§ above).
+- **`Backlog` or `Todo` that your change would close.** If it is yours to take, take it
+  and do not file a second card; if it is not, `duplicateOf` from yours to theirs, or a
+  comment on theirs saying yours will close it, and leave the rest alone.
+- **A card your change would break, make easier, or has to land after.** `blocks`,
+  `blockedBy`, or `relatedTo` when a reader of either card would want the other. All
+  four relations are arrays on `save_issue`, append-only, and they go in the same call
+  that files or moves your card, never a second one.
+- **Nothing.** Written anyway, as the `**Adjacent.**` lead of the body per the
+  `linear-content` skill, with the calls that answered empty and the last Done cards on
+  the surface. A scan that leaves no trace cannot be told from one that did not happen.
+
 ## Filing: one `save_issue` call
 
 Every field at once; a second call to add the missing ones is the sign the first was
@@ -69,6 +108,7 @@ wrong.
 | `estimate` | the team's points. |
 | `assignee` | never omitted. `"me"` when you will do the work, the person who asked for it when they will. A card filed for later still gets one: an empty assignee reads as free to the other agent. |
 | `state` | `"In Progress"` when you start now, otherwise leave the default. |
+| `relatedTo`, `blocks`, `blockedBy`, `duplicateOf` | what the neighbour scan found (§ above), as arrays of `ORB-N` you have read, in this same call. Append-only: one added by mistake is undone only with `removeRelatedTo`, `removeBlocks`, `removeBlockedBy` or `duplicateOf: null`, so read the id before you write it. |
 
 Label names are case-insensitive workspace-wide and a retired label keeps its name:
 `Chore` resolves to whatever old label owned that name. Use the exact lowercase names
@@ -85,7 +125,8 @@ not learn it from here. What that section leaves to the caller:
 - `In Review` is set by you when the PR opens, with a comment carrying the PR URL. The
   PR links itself to the issue, so seeing the link is not seeing a state change: the
   status automation is a per-team setting and it is off here (PR #33 linked, ORB-80
-  stayed `In Progress`). Move it yourself.
+  stayed `In Progress`). Move it yourself. From there to the merge the card keeps
+  following the PR (§ Commenting): the review, a red run, a reshaped PR.
 - `Done` takes a closing comment shaped as the `linear-content` skill says (`Evidence:`
   with run ids, sha, what you exercised and what came back). No evidence, no `Done`.
 - Won't-do is `Canceled` (one `l`), with the reason.
@@ -98,10 +139,22 @@ history you can read back. Reading the owner first is the only guard.
 
 ## Commenting
 
-`save_comment` with `issueId` (not `issue`) and `body`. When: something changed the
-issue (a reproduction, a measurement, a cause different from the title, a decision that
-is now the project lead's), a PR opened, a step of a plan landed, the closing evidence.
-Not: "working on it". Replies in a thread take `parentId`.
+`save_comment` with `issueId` (not `issue`) and `body`. The card follows the work while
+it happens (`docs/tracker.md` § While you work), so a comment at each of these, in the
+shape the `linear-content` skill gives it:
+
+- something changed the issue: a reproduction, a measurement, a cause different from the
+  title, a decision that is now the project lead's;
+- the work changed shape: a scope dropped or added, a file or a surface you had not
+  planned to touch, a neighbour found late;
+- you are waiting on something outside your hands: what, and from whom;
+- the PR opened; the review's findings and what you did with them; a CI run that went
+  red and why; a push that changed what the PR is;
+- the closing evidence.
+
+Not: "working on it", and not a step a reader could infer from the previous comment.
+Replies in a thread take `parentId`. A card that has read `In Progress` since morning
+with nothing under it is the failure this section exists to prevent.
 
 ## Project updates
 

--- a/.claude/skills/linear-ticket/SKILL.md
+++ b/.claude/skills/linear-ticket/SKILL.md
@@ -55,9 +55,10 @@ A new issue is filed only when none exists and the work will outlive this run, a
 ## The neighbours, before the first file changes
 
 Finding the same card is one search. Finding the cards your change can collide with or
-settle is another, and it happens every time, whether the card was found or filed
-(`docs/tracker.md` § The loop). Three reads, each with
-`fields: ["id", "title", "status", "statusType", "labels", "project", "assigneeId"]`:
+settle is another, and it happens every time, whether the card is found or filed, and
+before the `save_issue` that files or moves it (`docs/tracker.md` § The loop). Three
+reads, each with `fields: ["id", "title", "status", "statusType", "labels", "project",
+"assigneeId", "createdById"]`:
 
 1. **The area, open states only.** `list_issues` with `team: "Orbiters"`,
    `label: "<the area:* your change lands in>"` and `state: "started"`, which answers
@@ -79,17 +80,19 @@ What comes back is read, not counted:
 - **`started` under the other person, on the same surface.** You do not overlap it.
   Narrow your card to what theirs leaves alone, or wait for theirs, and write which on
   your card. Never a second PR on the same files, and never a touch on their card beyond
-  a comment (§ above).
-- **`Backlog` or `Todo` that your change would close.** If it is yours to take, take it
-  and do not file a second card; if it is not, `duplicateOf` from yours to theirs, or a
-  comment on theirs saying yours will close it, and leave the rest alone.
+  a comment (§ Finding before filing).
+- **`Backlog` or `Todo` that your change would close.** If it is yours to take, it is
+  your card: move it, and file nothing new. If it is not, `duplicateOf` from yours to
+  theirs, or a comment on theirs saying yours will close it, and leave the rest alone.
 - **A card your change would break, make easier, or has to land after.** `blocks`,
-  `blockedBy`, or `relatedTo` when a reader of either card would want the other. All
-  four relations are arrays on `save_issue`, append-only, and they go in the same call
-  that files or moves your card, never a second one.
-- **Nothing.** Written anyway, as the `**Adjacent.**` lead of the body per the
-  `linear-content` skill, with the calls that answered empty and the last Done cards on
-  the surface. A scan that leaves no trace cannot be told from one that did not happen.
+  `blockedBy`, or `relatedTo` when a reader of either card would want the other.
+  `blocks`, `blockedBy` and `relatedTo` are arrays on `save_issue`, append-only;
+  `duplicateOf` is one id, and `null` clears it. All four go in the same call that files
+  or moves your card, never a second one.
+- **Nothing.** Written anyway, as the **Adjacent** paragraph of the body per the
+  `linear-content` skill, with the area calls that answered empty and the Done cards
+  `query` ranked first for the surface. A scan that leaves no trace cannot be told from
+  one that did not happen.
 
 ## Filing: one `save_issue` call
 
@@ -108,7 +111,7 @@ wrong.
 | `estimate` | the team's points. |
 | `assignee` | never omitted. `"me"` when you will do the work, the person who asked for it when they will. A card filed for later still gets one: an empty assignee reads as free to the other agent. |
 | `state` | `"In Progress"` when you start now, otherwise leave the default. |
-| `relatedTo`, `blocks`, `blockedBy`, `duplicateOf` | what the neighbour scan found (§ above), as arrays of `ORB-N` you have read, in this same call. Append-only: one added by mistake is undone only with `removeRelatedTo`, `removeBlocks`, `removeBlockedBy` or `duplicateOf: null`, so read the id before you write it. |
+| `relatedTo`, `blocks`, `blockedBy`, `duplicateOf` | what the neighbour scan found (§ The neighbours): the three arrays of `ORB-N` you have read, or the one id for `duplicateOf`, in this same call. The arrays are append-only, so one added by mistake is undone only with `removeRelatedTo`, `removeBlocks` or `removeBlockedBy`; `duplicateOf: null` clears the one id. Read the id before you write it. |
 
 Label names are case-insensitive workspace-wide and a retired label keeps its name:
 `Chore` resolves to whatever old label owned that name. Use the exact lowercase names
@@ -121,7 +124,10 @@ not learn it from here. What that section leaves to the caller:
 
 - `In Progress` goes with `assignee: "me"` in the same call, and only on a card that is
   already yours (§ Finding before filing). On somebody else's card both fields stay as
-  they are.
+  they are. On a card you found rather than filed, the **Adjacent** paragraph and the
+  relations go in that same call; the paragraph as
+  `patch: [{ "op": "append", "text": "\n\n**Adjacent.** ..." }]`, because `description`
+  on an update replaces the whole body.
 - `In Review` is set by you when the PR opens, with a comment carrying the PR URL. The
   PR links itself to the issue, so seeing the link is not seeing a state change: the
   status automation is a per-team setting and it is off here (PR #33 linked, ORB-80
@@ -140,8 +146,8 @@ history you can read back. Reading the owner first is the only guard.
 ## Commenting
 
 `save_comment` with `issueId` (not `issue`) and `body`. The card follows the work while
-it happens (`docs/tracker.md` § While you work), so a comment at each of these, in the
-shape the `linear-content` skill gives it:
+it happens (`docs/tracker.md` § The loop, While you work), so a comment at each of
+these, in the shape the `linear-content` skill gives it:
 
 - something changed the issue: a reproduction, a measurement, a cause different from the
   title, a decision that is now the project lead's;
@@ -153,8 +159,7 @@ shape the `linear-content` skill gives it:
 - the closing evidence.
 
 Not: "working on it", and not a step a reader could infer from the previous comment.
-Replies in a thread take `parentId`. A card that has read `In Progress` since morning
-with nothing under it is the failure this section exists to prevent.
+Replies in a thread take `parentId`.
 
 ## Project updates
 

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -14,22 +14,23 @@ it and a document disagree, the document is right and the skill has a bug.
 
 ## Before the branch exists
 
-1. **A Linear issue exists, is yours, and is `In Progress`.** Find it with `list_issues`
-   or file it with the `linear-ticket` skill. No issue, no branch: the issue is where the
-   reasons live, and a PR written first loses them. Yours means what
-   `docs/tracker.md` § Who owns a card says: assigned to the account this session writes
-   as, or unassigned and filed by it, or labelled `parallel` and unclaimed. A card
-   assigned to the other person is not made yours by opening a PR for it, nor by their
-   having asked you for it, and a PR on their card is worse than no PR: it is their work
-   done twice.
-2. **Its neighbours have been read, and the card says so.** Before the first file
-   changes, the open cards next to this one: same `area:*` in `started`, `unstarted` and
-   `backlog`, and the same screen, route, table or file by name, as the `linear-ticket`
-   skill § The neighbours says. One `In Progress` or `In Review` under the other person
-   on the same files is a PR you do not open: narrow yours around it, or wait, and write
-   which on the card. One in the backlog your change would settle or break is linked
-   (`relatedTo`, `blocks`, `blockedBy`, `duplicateOf`) and named in the body. Nothing
-   found is written as well, as the body's **Adjacent** lead. No scan on the card, no
+1. **A Linear issue exists and is yours.** Find it with `list_issues` or file it with
+   the `linear-ticket` skill. No issue, no branch: the issue is where the reasons live,
+   and a PR written first loses them. Yours means what `docs/tracker.md` § Who owns a
+   card says: assigned to the account this session writes as, or unassigned and filed by
+   it, or labelled `parallel` and unclaimed. A card assigned to the other person is not
+   made yours by opening a PR for it, nor by their having asked you for it, and a PR on
+   their card is worse than no PR: it is their work done twice.
+2. **Its neighbours have been read, and the card is `In Progress` with the result on
+   it.** Before the first file changes, the open cards next to this one: same `area:*`
+   in `started`, `unstarted` and `backlog`, and the same screen, route, table or file by
+   name, as the `linear-ticket` skill § The neighbours says. One `In Progress` or
+   `In Review` under the other person on the same files is a PR you do not open: narrow
+   yours around it, or wait, and write which on the card. One in `Backlog` or `Todo`
+   your change would settle or break is linked (`relatedTo`, `blocks`, `blockedBy`,
+   `duplicateOf`) and named in the body. Nothing found is written as well, as the body's
+   **Adjacent** paragraph. The one `save_issue` that moves the card to `In Progress`
+   with `assignee: "me"` carries the links and that paragraph. No scan on the card, no
    branch.
 3. **The branch is Linear's.** Use the issue's `gitBranchName` (`mariorossi/orb-42-...`),
    which Linear renders for whoever reads the issue rather than for its assignee, so it
@@ -48,14 +49,12 @@ it and a document disagree, the document is right and the skill has a bug.
 
 ## While the work happens
 
-The card follows the work, per `docs/tracker.md` § While you work, and the PR body is
-written from the card at the end, never the card from the PR: a card rebuilt from memory
-is a summary and loses the reasons. A comment, in the `linear-content` shapes, when a
-finding changes the plan, when the scope moves (a neighbour found late, a file that had
-to move too, a piece left for its own card), and when you are waiting on something
-outside your hands. Not one per commit, and none that says "working on it"; but a card
-that has read `In Progress` since the worktree was made, with nothing under it, is the
-other agent's only view of your work, and it shows them nothing.
+The card follows the work, per `docs/tracker.md` § The loop, While you work, and the PR
+body is written from the card at the end, never the card from the PR. A comment, in the
+`linear-content` shapes, when a finding changes the plan, when the scope moves (a
+neighbour found late, a file that had to move too, a piece left for its own card), and
+when you are waiting on something outside your hands. Not one per commit, and none that
+says "working on it".
 
 ## Commits
 
@@ -166,7 +165,8 @@ The last line of the body: `Linear: ORB-N.`
    the PR is no longer what it was when it opened.
 4. **Wait for CI**: `gh pr checks <n> --watch`. The `ci` job is the only status that
    matters; the others may skip by path filter. A red run gets a line on the card too
-   (`**CI red:** run ..., <job>, <cause>, fixed in ...`), before the fix is pushed.
+   (`**CI red:** run ..., <job>, <cause>`) when you see it, and the sha of the fix on
+   the same comment when you push it.
 5. **Merge with a merge commit**, the repository's shape:
    `gh pr merge <n> --merge --delete-branch`. Never squash a two-commit PR whose second
    commit is the review: the history is the record.

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creation
-description: Use when opening, describing or merging a pull request in this monorepo. Enforces the branch, the Conventional Commit title, the body in the repository's own template sections, the review and merge loop, and the hand-off to Linear. Triggers on "open a PR", "submit for review", "review and merge", or the Italian «apri una PR», «fai review e mergia».
+description: Use when starting a change that will end in a pull request, and when opening, describing or merging one in this monorepo. Enforces the card and its neighbours before the branch, the branch, the Conventional Commit title, the body in the repository's own template sections, the review and merge loop, and the Linear card kept current from the first file to the merge. Triggers on starting a task, "open a PR", "submit for review", "review and merge", or the Italian «lavora su questo ticket», «apri una PR», «fai review e mergia».
 ---
 
 # Opening a pull request here
@@ -22,7 +22,16 @@ it and a document disagree, the document is right and the skill has a bug.
    assigned to the other person is not made yours by opening a PR for it, nor by their
    having asked you for it, and a PR on their card is worse than no PR: it is their work
    done twice.
-2. **The branch is Linear's.** Use the issue's `gitBranchName` (`mariorossi/orb-42-...`),
+2. **Its neighbours have been read, and the card says so.** Before the first file
+   changes, the open cards next to this one: same `area:*` in `started`, `unstarted` and
+   `backlog`, and the same screen, route, table or file by name, as the `linear-ticket`
+   skill § The neighbours says. One `In Progress` or `In Review` under the other person
+   on the same files is a PR you do not open: narrow yours around it, or wait, and write
+   which on the card. One in the backlog your change would settle or break is linked
+   (`relatedTo`, `blocks`, `blockedBy`, `duplicateOf`) and named in the body. Nothing
+   found is written as well, as the body's **Adjacent** lead. No scan on the card, no
+   branch.
+3. **The branch is Linear's.** Use the issue's `gitBranchName` (`mariorossi/orb-42-...`),
    which Linear renders for whoever reads the issue rather than for its assignee, so it
    tells you nothing about ownership and is only the name to use once step 1 holds. In a
    git worktree of its own, never on `main` and never in the shared checkout:
@@ -35,7 +44,18 @@ it and a document disagree, the document is right and the skill has a bug.
    ```
 
    Other sessions write to the same index; a worktree is what keeps your commit yours.
-3. **Read the project's `AGENTS.md`** (`projects/<name>/AGENTS.md`) before its source.
+4. **Read the project's `AGENTS.md`** (`projects/<name>/AGENTS.md`) before its source.
+
+## While the work happens
+
+The card follows the work, per `docs/tracker.md` § While you work, and the PR body is
+written from the card at the end, never the card from the PR: a card rebuilt from memory
+is a summary and loses the reasons. A comment, in the `linear-content` shapes, when a
+finding changes the plan, when the scope moves (a neighbour found late, a file that had
+to move too, a piece left for its own card), and when you are waiting on something
+outside your hands. Not one per commit, and none that says "working on it"; but a card
+that has read `In Progress` since the worktree was made, with nothing under it, is the
+other agent's only view of your work, and it shows them nothing.
 
 ## Commits
 
@@ -140,16 +160,21 @@ The last line of the body: `Linear: ORB-N.`
    context, and to rank findings by severity with a concrete fix each). Do not review your
    own diff and call it a review.
 3. **Apply the findings in a second commit**, push, and record the review on the PR as
-   a comment: each finding, what you did with it, and what you left as is and why.
+   a comment: each finding, what you did with it, and what you left as is and why. Then
+   one line on the card (`**Review applied:** ...`, the `linear-content` shape): the
+   count, the sha, what stayed as it was. The card is where the other agent reads that
+   the PR is no longer what it was when it opened.
 4. **Wait for CI**: `gh pr checks <n> --watch`. The `ci` job is the only status that
-   matters; the others may skip by path filter.
+   matters; the others may skip by path filter. A red run gets a line on the card too
+   (`**CI red:** run ..., <job>, <cause>, fixed in ...`), before the fix is pushed.
 5. **Merge with a merge commit**, the repository's shape:
    `gh pr merge <n> --merge --delete-branch`. Never squash a two-commit PR whose second
    commit is the review: the history is the record.
 6. **Clean up**: `git worktree remove ../<repo>-orb<N>`, `git worktree prune`.
 7. **Close on Linear only with evidence**: run ids, commit sha, the test counts, what
    you opened and saw. Preview deploys on the green trunk run; **production moves only
-   on a tag** (`docs/design/DECISIONS.md`, 2026-09-09) and only when asked.
+   on a tag** (`docs/design/DECISIONS.md`, 2026-09-09) and only when asked, and when it
+   does, the card gets its `**In production:**` comment with the tag and what answered.
 
 ## What never goes in a PR
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,17 @@ tested on a branch and is proven on the trunk instead.
 - An issue carries exactly one `type` label and exactly one `area:*` label, both from
   enforced groups, so Linear drops a second one silently. Priority and effort are
   Linear's native fields and are never labels.
+- **The board is read before the first file changes, and the card is written while
+  the work happens.** Before starting: the card for the thing itself, and the open cards
+  next to it (same `area:*` in `started`, `unstarted` and `backlog`; same screen, route,
+  table or file by name), so a neighbour in progress under the other person is not done
+  twice and a neighbour in the backlog is linked rather than rediscovered. What the scan
+  found, or that it found nothing, goes on the card first. While working: the card never
+  lags the work; a comment at every turn a reader could not infer (a finding, a change of
+  scope, a wait), `In Review` the moment the PR opens, one line for the review and for a
+  red run, and `Done` only with the evidence. A card that has read `In Progress` all day
+  with nothing under it is the other agent's only view of your work (`docs/tracker.md`
+  § The loop).
 - `In Review` is a status on the team, and it is where an issue sits while its PR
   is open on GitHub.
 - **A project update is written whenever something changed that the issue list

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,13 +217,13 @@ tested on a branch and is proven on the trunk instead.
   the work happens.** Before starting: the card for the thing itself, and the open cards
   next to it (same `area:*` in `started`, `unstarted` and `backlog`; same screen, route,
   table or file by name), so a neighbour in progress under the other person is not done
-  twice and a neighbour in the backlog is linked rather than rediscovered. What the scan
-  found, or that it found nothing, goes on the card first. While working: the card never
-  lags the work; a comment at every turn a reader could not infer (a finding, a change of
-  scope, a wait), `In Review` the moment the PR opens, one line for the review and for a
-  red run, and `Done` only with the evidence. A card that has read `In Progress` all day
-  with nothing under it is the other agent's only view of your work (`docs/tracker.md`
-  § The loop).
+  twice and a neighbour in `Backlog` or `Todo` is linked rather than rediscovered. What
+  the scan found, or that it found nothing, goes on the card first, in the same call
+  that moves it. While working: the card never lags the work; a comment at every turn a
+  reader could not infer (a finding, a change of scope, a wait), `In Review` the moment
+  the PR opens, one line for the review and for a red run, and `Done` only with the
+  evidence. A card that has read `In Progress` all day with nothing under it is the
+  other agent's only view of your work (`docs/tracker.md` § The loop).
 - `In Review` is a status on the team, and it is where an issue sits while its PR
   is open on GitHub.
 - **A project update is written whenever something changed that the issue list

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,14 @@ a product and is permanent; a **project** is a release with an end, closed when 
 ships; a **project milestone** is an outcome inside a release; an **issue** is one
 agent run, one PR. Every issue carries exactly one `type` label and exactly one `area:*`
 label, both from enforced groups, and priority and effort as Linear's own fields, never
-labels. Move the issue to
+labels. Before the first file changes, read the open cards next to yours (same area,
+same screen or table) and link or narrow around them; while you work, keep your card
+current with a comment at every turn a reader could not infer. Move the issue to
 `In Review` while its PR is open on GitHub, and leave a project status update whenever
-something changed that the issue list alone does not show. The GitHub integration is
-requested and pending on this org, so nothing closes itself yet: move the card by hand
-and put the evidence in a comment. Full conventions are in `docs/tracker.md`.
+something changed that the issue list alone does not show. Linear's GitHub app links a
+PR to its card, and the team's status automation is off, so nothing moves a state for
+you: move the card by hand and put the evidence in a comment. Full conventions are in
+`docs/tracker.md`.
 
 ## Commits
 

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -120,21 +120,44 @@ that is yours you use, an issue that is somebody else's you leave. If nothing ex
 and the work will outlive this run, file one before you start rather than after: an
 issue written afterwards is a summary, and it loses the reasons.
 
+**Then its neighbours, before the first file changes.** The same card is one search;
+the cards your change can collide with or settle are another, and it happens every
+time, whether the card was found or filed. Neighbours are the open cards in the same
+`area:*`, and the ones whose title or body names the same screen, route, table or file.
+One that is `In Progress` or `In Review` under the other person is work you do not
+overlap: narrow yours to what theirs leaves alone, or wait for it, and say which on your
+card. One in `Backlog` or `Todo` that your change would close, break, make easier or
+has to land after is linked to yours (`relatedTo`, `blocks`, `blockedBy`,
+`duplicateOf`, all on `save_issue`) and named in the body, so it is not rediscovered
+from scratch by the next reader. What the scan found goes on your card before the work
+starts, and "nothing adjacent" is written too: a scan that leaves no trace cannot be
+told from a scan that did not happen.
+
 **When you start.** Check the card is yours (§ Who owns a card): assigned to you,
 unassigned and filed by you, or labelled `parallel`. If it is somebody else's, leave it
 alone, comment if you have something to add, and pick another. If it is yours, move it
 to `In Progress` and set `assignee` to yourself in the same call, so the other agent can
 see it is taken.
 
-**While you work.** A comment when you learn something that changes the issue: a
-reproduction, a measurement, a cause that turned out to be different from the title, a
-decision that is now the project's lead's. Comments are cheap and they are what makes an
-issue readable in a month.
+**While you work.** The card follows the work while it happens; it is never rebuilt
+from memory at the end, because a card written afterwards is a summary and loses the
+reasons. A comment when you learn something that changes the issue: a reproduction, a
+measurement, a cause that turned out to be different from the title, a decision that is
+now the project's lead's. A comment when the work changes shape: a scope dropped or
+added, a surface or a file you had not expected to touch, a neighbour you found late. A
+comment when you stop on something outside your hands, saying what you are waiting for
+and from whom, so a reader does not have to find you to know. Comments are cheap and
+they are what makes an issue readable in a month, and a card that has read `In Progress`
+for a day with nothing under it tells the other agent nothing when they are deciding
+whether to touch the same files.
 
 **When your PR is open.** Move the issue to `In Review`, the status for an issue whose
-PR is open on GitHub. Until the GitHub integration is approved on this org (see
-Commits and issues below), nothing moves it there for you, so do this by hand when you
-open the PR.
+PR is open on GitHub, and comment the PR URL on it. The PR links itself to the card
+within seconds; the state does not move, because the team's status automation is off
+(§ Commits and issues), so do this by hand when you open the PR. From here to the merge
+the card keeps following the PR: the review's findings and what you did with them, a CI
+run that went red and why, a push that changed what the PR is. One line each is enough,
+and silence is not.
 
 **When you finish.** `Done` means verified on the surface the issue is about, and the
 comment that closes it says how. A green CI check closes a CI issue. A deploy issue
@@ -243,6 +266,14 @@ paragraph plus the two skills that repeat it can drop the manual step, with the 
   `cursor`, so an unbounded one answers with a slice of a board already past ORB-58 that
   reads like the whole of it. Narrow server-side first (`state: "Todo"`, then
   `state: "Backlog"`) and raise `limit`.
+- `list_issues` takes one `state` per call, and a state **type** is a valid value:
+  `state: "started"` answers `In Progress` and `In Review` together, `"unstarted"` is
+  `Todo`, `"backlog"` is `Backlog` (measured 2026-09-10). Three calls cover every open
+  card; combined with `label`, they are the neighbour scan of § The loop.
+- `list_issues` with `query` ranks, it does not filter: `query: "columns.tsx"` answered
+  the three invoice-list cards first and then twenty unrelated ones with a next page
+  (measured 2026-09-10). Read the first handful and stop where the titles stop being
+  about your surface; a count of what came back means nothing.
 - Initiatives cannot be created from the MCP surface at all. `save_project` can attach
   an existing initiative with `addInitiatives`, but there is no `save_initiative`.
   Initiatives are created by hand in the Linear UI; automation only creates projects and

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -114,24 +114,27 @@ means everywhere below, and it is not necessarily the person who is talking to y
 
 ## The loop
 
-**Before starting work.** Search the board for the thing you are about to do. Read who
-owns what comes back, since a card that exists is not automatically available: an issue
-that is yours you use, an issue that is somebody else's you leave. If nothing exists,
-and the work will outlive this run, file one before you start rather than after: an
-issue written afterwards is a summary, and it loses the reasons.
+**Before starting work.** Search the board for the thing you are about to do, and for
+its neighbours (next paragraph), before the first file changes. Read who owns what comes
+back, since a card that exists is not automatically available: an issue that is yours
+you use, an issue that is somebody else's you leave. If nothing exists, and the work will
+outlive this run, file one before you start rather than after: an issue written
+afterwards is a summary, and it loses the reasons.
 
-**Then its neighbours, before the first file changes.** The same card is one search;
-the cards your change can collide with or settle are another, and it happens every
-time, whether the card was found or filed. Neighbours are the open cards in the same
-`area:*`, and the ones whose title or body names the same screen, route, table or file.
-One that is `In Progress` or `In Review` under the other person is work you do not
-overlap: narrow yours to what theirs leaves alone, or wait for it, and say which on your
-card. One in `Backlog` or `Todo` that your change would close, break, make easier or
-has to land after is linked to yours (`relatedTo`, `blocks`, `blockedBy`,
-`duplicateOf`, all on `save_issue`) and named in the body, so it is not rediscovered
-from scratch by the next reader. What the scan found goes on your card before the work
-starts, and "nothing adjacent" is written too: a scan that leaves no trace cannot be
-told from a scan that did not happen.
+**Its neighbours.** The same card is one search; the cards your change can collide with
+or settle are another, and it happens every time, whether the card is found or filed.
+Neighbours are the open cards in the same `area:*`, and the ones whose title or body
+names the same screen, route, table or file. One that is `In Progress` or `In Review`
+under the other person, on the same surface, is work you do not overlap: narrow yours
+to what theirs leaves alone, or wait for it, and say which on your card. One in
+`Backlog` or `Todo` that your change would close is your card, if it is yours to take
+(§ Who owns a card), and nothing new is filed; one that is not yours, or that your
+change would break, make easier or has to land after, is linked to yours (`relatedTo`,
+`blocks`, `blockedBy`, `duplicateOf` on `save_issue`) and named in the body, so it is
+not rediscovered from scratch by the next reader. The scan comes before the `save_issue`
+that files your card or moves it to `In Progress`, so its links and its **Adjacent**
+paragraph land in that call and not a second one. "Nothing adjacent" is written too: a
+scan that leaves no trace cannot be told from a scan that did not happen.
 
 **When you start.** Check the card is yours (§ Who owns a card): assigned to you,
 unassigned and filed by you, or labelled `parallel`. If it is somebody else's, leave it
@@ -139,17 +142,16 @@ alone, comment if you have something to add, and pick another. If it is yours, m
 to `In Progress` and set `assignee` to yourself in the same call, so the other agent can
 see it is taken.
 
-**While you work.** The card follows the work while it happens; it is never rebuilt
-from memory at the end, because a card written afterwards is a summary and loses the
-reasons. A comment when you learn something that changes the issue: a reproduction, a
-measurement, a cause that turned out to be different from the title, a decision that is
-now the project's lead's. A comment when the work changes shape: a scope dropped or
-added, a surface or a file you had not expected to touch, a neighbour you found late. A
-comment when you stop on something outside your hands, saying what you are waiting for
-and from whom, so a reader does not have to find you to know. Comments are cheap and
-they are what makes an issue readable in a month, and a card that has read `In Progress`
-for a day with nothing under it tells the other agent nothing when they are deciding
-whether to touch the same files.
+**While you work.** The card follows the work while it happens, never rebuilt from
+memory at the end. A comment when you learn something that changes the issue: a
+reproduction, a measurement, a cause that turned out to be different from the title, a
+decision that is now the project's lead's. A comment when the work changes shape: a
+scope dropped or added, a surface or a file you had not expected to touch, a neighbour
+you found late. A comment when you stop on something outside your hands, saying what you
+are waiting for and from whom, so a reader does not have to find you to know. Comments
+are cheap and they are what makes an issue readable in a month, and a card that has read
+`In Progress` for a day with nothing under it tells the other agent nothing when they
+are deciding whether to touch the same files.
 
 **When your PR is open.** Move the issue to `In Review`, the status for an issue whose
 PR is open on GitHub, and comment the PR URL on it. The PR links itself to the card


### PR DESCRIPTION
## What this changes

Before this PR the tracker loop asked an agent for one search, for the card it was about to work, and for a comment only when a finding changed the issue. Nothing asked about the cards next to it, so a change could land on top of one the other person had `In Progress` on the same files, or rediscover a backlog card from scratch; and a card could read `In Progress` from the first commit to the PR with nothing under it. Now `docs/tracker.md` § The loop has a second search, for the open cards in the same `area:*` and on the same surface by name, whose result is written on the card before work starts (links included, and "nothing adjacent" written too), and the card is kept current while the work happens: a comment at every turn a reader could not infer, and one line each for the review, a red run and a reshaped PR between `In Review` and the merge.

The three skills carry the two rules to the moment they apply. `linear-ticket` gets the calls of the neighbour scan (three `state` calls per area, `query` per noun of the surface, the project when the area is the wrong lens), what to do with each kind of neighbour, and the relation fields in the filing table. `linear-content` gets the **Adjacent** lead of the body and the **Scope**, **Waiting** and **Review** comment shapes. `pr-creation` gets the scan as a step before the branch, a section on the card during the work, and the card lines in the loop after `gh pr create`. `AGENTS.md` gets one bullet so a session that opens no skill still meets the rule, and `CONTRIBUTING.md` one sentence. Two measured API details go in `docs/tracker.md`: a state type (`started`) is a valid `state` filter and answers `In Progress` and `In Review` together, and `query` ranks rather than filters.

## How I verified it

- The two API claims were measured against the board on 2026-09-10 with the Linear MCP: `list_issues` with `state: "started"` returned ORB-130 (`In Progress`) and ORB-129 (`In Review`) and nothing else; `label: "area:repo"` with `state: "unstarted"` returned empty; `query: "columns.tsx"` returned ORB-130, ORB-126 and ORB-98 first and then twenty unrelated cards with a next page.
- The rules were run on this very card: ORB-131 carries an **Adjacent** lead (nothing open in `area:repo`; ORB-14, ORB-42, ORB-58, ORB-80 named as the last four changes to the contract), a **Scope, grown** comment for the `CONTRIBUTING.md` sentence found late, and will carry the PR, review and closing comments.
- `uv run pytest -q projects/pigrocrm/packages/core/tests/test_no_real_identity_in_the_repository.py`: 6 passed. `orbiters-identity-scan` is not on this machine's PATH, so that preflight tier did not run here.
- Zero em dashes in the added lines (counted on the diff). Prose only, no code path changes; CI's `ci` job is the only check that applies.

## Anything a reviewer should look at twice

- `docs/tracker.md` § The loop, the new "Then its neighbours" paragraph: it is the contract the skills restate, so if its wording and a skill's disagree the skill is the bug. I tried to keep every skill sentence traceable to it.
- The `**Adjacent.**` lead is written as "always, on a card you are about to work", not optional. That is deliberate: a scan that leaves no trace cannot be told from one that did not happen. If that reads as noise on a one-line chore card, the place to relax it is the contract, not the skill.
- The "While you work" cadence adds three comment kinds (Scope, Waiting, Review). The risk is a chattier board; the guard in the text is "not a step a reader could infer from the previous comment", and the Review line is one line with the record staying on the PR.

## What did not change, on purpose

The ownership rules of ORB-58 (a neighbour under the other person is left alone exactly as before; the scan only makes sure it is seen), and the label and status vocabulary: the neighbour scan is a reading discipline, and Linear's relations already record its result. Two stale sentences were reworded in passing because their paragraphs changed anyway: the loop's PR step and `CONTRIBUTING.md` § Tracker still said the GitHub integration was pending approval, which ORB-80 corrected elsewhere. Recorded on ORB-131.

## Screenshots

Nothing a person could see changed: six Markdown files, no UI. No pair to capture.

Linear: ORB-131.
