### PR TITLE
docs(repo): the tracker lists the board's eight projects and the ten area labels

### DIFF
--- a/.claude/skills/linear-ticket/SKILL.md
+++ b/.claude/skills/linear-ticket/SKILL.md
@@ -106,7 +106,7 @@ wrong.
 | `milestone` | the milestone id from `list_milestones(project)`, unless the issue genuinely belongs to no body of work. It is accepted and not echoed back: trust `list_milestones` progress, not the response. |
 | `title` | the observed problem, not the fix: "the invoice page shows the numbers but never the document", not "add a PDF preview". |
 | `description` | per the `linear-content` skill. Real newlines, never `\n` escapes. |
-| `addLabels` | exactly two: one from the `type` group (`fix`, `feature`, `refactor`, `chore`, `docs`, `test`, `ci`, `design`, `security`, `spike`) and one from `Area` (`area:web`, `area:api`, `area:core`, `area:mcp`, `area:infra`, `area:ci`, `area:website`, `area:brand`, `area:repo`). Both are groups: a second label from the same group is silently dropped. Use `addLabels`, never `labels`: `labels` replaces the whole set. |
+| `addLabels` | exactly two: one from the `type` group (`fix`, `feature`, `refactor`, `chore`, `docs`, `test`, `ci`, `design`, `security`, `spike`) and one from `Area` (`area:web`, `area:api`, `area:core`, `area:mcp`, `area:hub`, `area:infra`, `area:ci`, `area:website`, `area:brand`, `area:repo`). Both are groups: a second label from the same group is silently dropped. Use `addLabels`, never `labels`: `labels` replaces the whole set. |
 | `priority` | 1 Urgent, 2 High, 3 Medium, 4 Low. A field, never a label. |
 | `estimate` | the team's points. |
 | `assignee` | never omitted. `"me"` when you will do the work, the person who asked for it when they will. A card filed for later still gets one: an empty assignee reads as free to the other agent. |

--- a/.claude/skills/linear-ticket/SKILL.md
+++ b/.claude/skills/linear-ticket/SKILL.md
@@ -102,7 +102,7 @@ wrong.
 | Field | Value |
 |---|---|
 | `team` | `"Orbiters"` |
-| `project` | **the project id**, from `list_projects`. Project names carry a version suffix (`PigroCRM v1 - first deploy from CI, with green gates`) and change; a lookup by the old name fails with "Could not find project". |
+| `project` | **the project id**, from `list_projects`, or omitted when the issue is repository-wide and fits no open project (`docs/tracker.md` § Where things are). Project names carry a version suffix (`PigroCRM v1 - first deploy from CI, with green gates`) and change; a lookup by the old name fails with "Could not find project". |
 | `milestone` | the milestone id from `list_milestones(project)`, unless the issue genuinely belongs to no body of work. It is accepted and not echoed back: trust `list_milestones` progress, not the response. |
 | `title` | the observed problem, not the fix: "the invoice page shows the numbers but never the document", not "add a PDF preview". |
 | `description` | per the `linear-content` skill. Real newlines, never `\n` escapes. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,7 @@ tested on a branch and is proven on the trunk instead.
   of the convention, from what a title says to which labels are legal, is in
   `docs/tracker.md`.
 - **Every project always carries a lead and both members.** A project created
-  without a lead and without both members is incomplete.
+  without a lead or without both members is incomplete.
 - **The assignee is a claim, and a card that is not yours stays untouched.** Both of
   us run agents against the same board, so the only thing keeping two of them off
   the same work is that field: you may work a card assigned to the account your

--- a/docs/adding-a-project.md
+++ b/docs/adding-a-project.md
@@ -296,10 +296,13 @@ because a copy drifts, which is exactly what an earlier version of this section 
 (ORB-45). What a new monorepo project needs is an initiative of its own, named as the
 directory reads to people (`PigroCRM`, not `pigrocrm`) and created by hand in the Linear
 UI since the MCP surface cannot create one, and a first project under it with a scope
-that can actually close, a lead and both members: the initiative is the permanent
+that can actually close, a lead and both members (the members in the UI too, since
+`save_project` has no field for them), plus its row in the project table of
+`docs/tracker.md` § Where things are in the same change: the initiative is the permanent
 container, the project is the release. Repository-wide work that belongs to no product
-(CI cost, the licence, this documentation) goes under the `Monorepo` initiative, which
-is why `Monorepo hygiene v1` exists and sits under no `projects/<name>/`. The `Area`
+(CI cost, the licence, this documentation) goes under the `Monorepo` initiative; it went
+into `Monorepo hygiene v1`, which sat under no `projects/<name>/` and is closed, and
+where such an issue goes now is that same section of the tracker page. The `Area`
 group is shared by everyone: if the new project needs an `area:*` child the board does
 not have, add it under the group rather than inventing a parallel scheme, and record it
 in `docs/tracker.md` in the same change.

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -20,29 +20,49 @@ are not part of this repo's flow.
 | Effort | Linear's own estimate field. Never a label |
 | Statuses | `Backlog`, `Todo`, `In Progress`, `In Review`, `Done`, `Canceled` |
 | Type labels | group **type**, exactly one, Linear enforces it because it is a group: `feature`, `fix`, `refactor`, `test`, `chore`, `ci`, `docs`, `design`, `security`, `spike` |
-| Area labels | group **Area**, exactly one, Linear enforces it because it is a group: `area:api`, `area:brand`, `area:ci`, `area:core`, `area:infra`, `area:mcp`, `area:repo`, `area:web`, `area:website` |
+| Area labels | group **Area**, exactly one, Linear enforces it because it is a group: `area:api`, `area:brand`, `area:ci`, `area:core`, `area:hub`, `area:infra`, `area:mcp`, `area:repo`, `area:web`, `area:website` |
 | Assignee | who owns the card and will do the work. A claim, not a hint: see § Who owns a card |
 | Other flat labels | `flagship` for headline work, `parallel` for an issue that collides with nothing, in the files or between us, so whoever is free may pick it up whoever filed it, as long as nobody has claimed it yet |
 
 The two lists above are the board's, checked against `list_issue_labels` with
-`includeGroups: true` on 2026-09-09, and the board is the authority: an earlier version of
+`includeGroups: true` on 2026-09-10, and the board is the authority: an earlier version of
 this page named `Bug` and `core`, and an issue filed with those names failed with "Could
-not find labels" (ORB-33). Five of the type labels carry a description on the board, and
+not find labels" (ORB-33); a later one listed nine area labels for a day after `area:hub`
+had made them ten (ORB-76). Five of the type labels carry a description on the board, and
 it is the one to apply: `fix` is something that does not do what it says it does;
 `feature` is new behaviour a user or an agent can observe; `refactor` is existing behaviour
 made better with no new capability; `chore` is maintenance with no change in behaviour;
 `docs` is documentation that stands on its own. `test`, `ci`, `design`, `security` and
 `spike` mean what their names say.
 
-The four current projects, each with a lead and both of us as members:
+The projects on the board, read with `list_projects` on 2026-09-10. This table is a
+snapshot and the board is the authority: `list_projects` with `team: "Orbiters"`, which
+answers completed projects too, is what to trust when the two disagree, and the change
+that opens or closes a project updates this table in the same PR.
 
-- `Website v1 - the public site, live and correct on a phone`. Lead: Lorenzo.
-- `Hub v0 - signups and the company flow, deployed`. Lead: Ivan.
-- `PigroCRM v1 - first deploy from CI, with green gates`. Lead: Ivan.
-- `Monorepo hygiene v1 - CI cost, licence and the English rule`. Lead: Lorenzo.
+| Initiative | Project | Lead | State on 2026-09-10 |
+|---|---|---|---|
+| `PigroCRM` | `PigroCRM v1 - first deploy from CI, with green gates` | Ivan | In Progress |
+| `Hub` | `Hub v0 - signups and the company flow, deployed` | Ivan | In Progress |
+| `Hub` | `Hub v1 - the wizards look like the site` | Lorenzo | In Progress |
+| `Website` | `Website v1 - the public site, live and correct on a phone` | Lorenzo | In Progress |
+| `Website` | `Website v2 - the new landing takes the front door` | Lorenzo | In Progress |
+| `Monorepo` | `Deploy and access hygiene v1` | Lorenzo | In Progress |
+| `Monorepo` | `Indexing and SEO v1 - what a crawler sees` | Lorenzo | In Progress |
+| `Monorepo` | `Monorepo hygiene v1 - CI cost, licence and the English rule` | Lorenzo | Completed, 2026-09-10 |
+
+`Monorepo hygiene v1` was where repository-wide work that belongs to no product went
+(CI cost, the licence, this page). It is closed, and nothing has replaced it: a
+repository-wide issue that fits neither open `Monorepo` project is filed with no
+project, which is what ORB-131 and ORB-136 did, until somebody opens a
+`Monorepo hygiene v2` with a scope it can reach.
 
 Every project always carries a lead and both members, Lorenzo and Ivan, no matter who
-leads it. A project created without a lead and without both members is incomplete.
+leads it. A project created without a lead and without both members is incomplete, and
+four of the eight above are: `Hub v1`, `Website v2`, `Deploy and access hygiene v1` and
+`Indexing and SEO v1` carry Lorenzo alone as of 2026-09-10. The MCP surface cannot repair
+that, since `save_project` takes a `lead` and has no member field (§ API details), so the
+second member is added by hand in the Linear UI, at creation.
 
 This replaces the old rule that gave every monorepo project (`projects/pigrocrm`,
 `projects/website`) its own permanent Linear project. Initiatives are the permanent
@@ -280,3 +300,7 @@ paragraph plus the two skills that repeat it can drop the manual step, with the 
   an existing initiative with `addInitiatives`, but there is no `save_initiative`.
   Initiatives are created by hand in the Linear UI; automation only creates projects and
   issues underneath them.
+- Project members cannot be set from the MCP surface either. `save_project` takes `lead`
+  and has no member field, and `list_projects` with `includeMembers: true` only reads
+  them, so the rule that every project carries both members (§ Where things are) is kept
+  by hand in the Linear UI, and read back with that call.

--- a/docs/tracker.md
+++ b/docs/tracker.md
@@ -27,8 +27,8 @@ are not part of this repo's flow.
 The two lists above are the board's, checked against `list_issue_labels` with
 `includeGroups: true` on 2026-09-10, and the board is the authority: an earlier version of
 this page named `Bug` and `core`, and an issue filed with those names failed with "Could
-not find labels" (ORB-33); a later one listed nine area labels for a day after `area:hub`
-had made them ten (ORB-76). Five of the type labels carry a description on the board, and
+not find labels" (ORB-33); a later one still listed nine area labels after `area:hub` had
+made them ten (ORB-76). Five of the type labels carry a description on the board, and
 it is the one to apply: `fix` is something that does not do what it says it does;
 `feature` is new behaviour a user or an agent can observe; `refactor` is existing behaviour
 made better with no new capability; `chore` is maintenance with no change in behaviour;
@@ -37,8 +37,9 @@ made better with no new capability; `chore` is maintenance with no change in beh
 
 The projects on the board, read with `list_projects` on 2026-09-10. This table is a
 snapshot and the board is the authority: `list_projects` with `team: "Orbiters"`, which
-answers completed projects too, is what to trust when the two disagree, and the change
-that opens or closes a project updates this table in the same PR.
+answers completed projects too, is what to trust when the two disagree. Opening or closing
+a project is a board action with no PR of its own, so whoever does it adds or updates the
+row here, in the PR that ships the release or in one of its own.
 
 | Initiative | Project | Lead | State on 2026-09-10 |
 |---|---|---|---|
@@ -53,16 +54,17 @@ that opens or closes a project updates this table in the same PR.
 
 `Monorepo hygiene v1` was where repository-wide work that belongs to no product went
 (CI cost, the licence, this page). It is closed, and nothing has replaced it: a
-repository-wide issue that fits neither open `Monorepo` project is filed with no
-project, which is what ORB-131 and ORB-136 did, until somebody opens a
-`Monorepo hygiene v2` with a scope it can reach.
+repository-wide issue that fits no open `Monorepo` project is filed with no project,
+which is what ORB-131 and ORB-136 did, until somebody opens a `Monorepo hygiene v2` with
+a scope it can reach.
 
 Every project always carries a lead and both members, Lorenzo and Ivan, no matter who
-leads it. A project created without a lead and without both members is incomplete, and
+leads it. A project created without a lead or without both members is incomplete, and
 four of the eight above are: `Hub v1`, `Website v2`, `Deploy and access hygiene v1` and
 `Indexing and SEO v1` carry Lorenzo alone as of 2026-09-10. The MCP surface cannot repair
 that, since `save_project` takes a `lead` and has no member field (§ API details), so the
-second member is added by hand in the Linear UI, at creation.
+second member is added by hand in the Linear UI, at creation, and on those four under
+ORB-137.
 
 This replaces the old rule that gave every monorepo project (`projects/pigrocrm`,
 `projects/website`) its own permanent Linear project. Initiatives are the permanent
@@ -199,9 +201,10 @@ would mislead a reader is worse.
 - A **title that states the observed problem**, not the intended fix: "the backend gate
   installs neither pandoc nor typst" rather than "add pandoc to CI". The fix is often
   not the one you first thought of, and a title written as a fix ages into a lie.
-- **Project**, its **milestone** (unless the issue genuinely belongs to no body of
-  work), one **area:\*** label, one **type** label, a **priority**, an **estimate**, and
-  an **assignee**. `save_issue` takes all of this in the same call, so an issue that is
+- **Project**, when one fits (a repository-wide issue may have none, § Where things
+  are), its **milestone** (unless the issue genuinely belongs to no body of work), one
+  **area:\*** label, one **type** label, a **priority**, an **estimate**, and an
+  **assignee**. `save_issue` takes all of this in the same call, so an issue that is
   missing one of them is a mistake, not the accident of a skipped second call. The
   assignee is yourself when you will do the work, the person who asked for it when they
   will, and never empty: an unowned card is one the other agent will take.


### PR DESCRIPTION
## What this changes

`docs/tracker.md` § Where things are said «The four current projects, each with a lead and both of us as members» and listed `Website v1`, `Hub v0`, `PigroCRM v1` and `Monorepo hygiene v1`. The board has eight projects today and `Monorepo hygiene v1` has been `Completed` since 2026-09-10, so an agent reading the page to pick a project for a card was reading a list that was wrong in both directions.

Now the section carries a table of what `list_projects` answered on 2026-09-10, by initiative, with lead and state: eight rows, one of them `Completed, 2026-09-10`. It says the board is the authority when the two drift and that the change opening or closing a project updates the table in the same PR. A paragraph under it says where repository-wide work goes now that `Monorepo hygiene v1` is closed: nowhere, until a `Monorepo hygiene v2` exists, which is what ORB-131 and ORB-136 did.

Two more things in the same section were stale the same way, so I fixed them in the same change. The Area row listed nine labels and the board has ten: `area:hub` exists since 2026-09-09, ORB-76 asked for that line and closed with the label checked and the document untouched. The row names it now, and so does the `addLabels` row of the `linear-ticket` skill, which had the same nine. And the membership rule («every project always carries a lead and both members») is false for the four projects opened after the list was written, which carry Lorenzo alone. The rule stays and now says which four and why they cannot be repaired from an agent session: `save_project` takes a `lead` and has no member field, which also gets a bullet under § API details.

## How I verified it

- `list_projects` with `team: "Orbiters"`, `includeMembers: true`, `fields: [name, status, lead, members, initiatives, completedAt]` on 2026-09-10: eight projects, leads, initiatives and states as in the table; `Monorepo hygiene v1` with `completedAt: 2026-09-10T09:20:53Z`; `Hub v1`, `Website v2`, `Deploy and access hygiene v1` and `Indexing and SEO v1` with one member each. A second call without `includeArchived` returned the same eight, so the page does not tell the reader to pass it.
- `list_issue_labels` with `includeGroups: true`: ten children under `Area`, `area:hub` included, and the ten type labels as the Type row already had them.
- `save_project` schema read from the MCP surface: `lead` present, no member field.
- `uv run pytest -q projects/pigrocrm/packages/core/tests/test_no_real_identity_in_the_repository.py`: 7 passed, the one preflight check that runs on every diff and is installed on this machine (`orbiters-identity-scan` is not on this box).

## Anything a reviewer should look at twice

The table is a dated snapshot, and the old bullet list was one too; the new sentence that the change opening or closing a project updates the table is what stops it going stale a third time, and it is a rule with no check behind it. The alternative was to drop the list and keep only the `list_projects` pointer, which I did not do because a reader without an MCP session (a reviewer on GitHub) still wants the names.

The four incomplete projects are named as incomplete rather than fixed. The MCP surface cannot add a member, so that is a UI action for whoever opens Linear next; nothing on the board was changed for it.

## Screenshots

Nothing a person can see changed: two Markdown files, no UI.

Linear: ORB-136.
