### PR TITLE
feat(web): every column of the economic charts says its figure

### DIFF
--- a/projects/pigrocrm/apps/web/src/features/dashboard/EconomicTab.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/EconomicTab.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { EconomicTab } from './EconomicTab'
+import type { CashMonth } from './queries'
 import { api } from '@/lib/api'
 
 vi.mock('@/lib/api', async (importOriginal) => {
@@ -45,7 +46,16 @@ function failed(error: unknown, status: number) {
   return { error, response: new Response(null, { status }) } as never
 }
 
-function month(mese: number, incassato = '0.00', da_incassare = '0.00', bozze = '0.00', costi = '0.00') {
+/** Typed as the wire shape so a field added to `CashMonth` fails here rather than
+ *  rendering something nobody asserted on (ORB-139: the two `pila_*` heights). The
+ *  heights are illustrative, not sums: the chart prints them, it never checks them. */
+function month(
+  mese: number,
+  incassato = '0.00',
+  da_incassare = '0.00',
+  bozze = '0.00',
+  costi = '0.00',
+): CashMonth {
   return {
     anno: 2026,
     mese,
@@ -53,6 +63,8 @@ function month(mese: number, incassato = '0.00', da_incassare = '0.00', bozze = 
     da_incassare,
     bozze,
     costi,
+    pila_andamento: incassato,
+    pila_proiezione: incassato,
     quote_andamento: { incassato: incassato === '0.00' ? 0 : 1, costi: costi === '0.00' ? 0 : 0.1 },
     quote_proiezione: {
       incassato: incassato === '0.00' ? 0 : 0.6,

--- a/projects/pigrocrm/apps/web/src/features/dashboard/MonthlyBars.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/MonthlyBars.test.tsx
@@ -3,7 +3,7 @@
  * value, the tallest, and only when it filled more than a third of the plot: most months
  * said nothing and the one figure shown read as the column's total when it was one
  * segment's. Now every segment tall enough to hold the text says its value, a column too
- * short for a label says it above, and a stacked column says its total above.
+ * short for a label says it above, and a stacked column says its height as money above.
  */
 import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
@@ -14,7 +14,7 @@ function month(
   mese: number,
   amounts: Partial<Record<'incassato' | 'da_incassare' | 'bozze' | 'costi', string>>,
   shares: Record<string, number>,
-  totals: { andamento?: string; proiezione?: string } = {},
+  pila: { andamento?: string; proiezione?: string } = {},
 ): CashMonth {
   return {
     anno: 2026,
@@ -23,15 +23,19 @@ function month(
     da_incassare: amounts.da_incassare ?? '0.00',
     bozze: amounts.bozze ?? '0.00',
     costi: amounts.costi ?? '0.00',
-    totale_andamento: totals.andamento ?? amounts.incassato ?? '0.00',
-    totale_proiezione: totals.proiezione ?? amounts.incassato ?? '0.00',
+    pila_andamento: pila.andamento ?? amounts.incassato ?? '0.00',
+    pila_proiezione: pila.proiezione ?? amounts.incassato ?? '0.00',
     quote_andamento: shares,
     quote_proiezione: shares,
-  } as CashMonth
+  }
 }
 
 const ZERO = { incassato: 0, da_incassare: 0, bozze: 0, costi: 0 }
-const EMPTY = Array.from({ length: 9 }, (_, i) => month(i + 4, {}, ZERO))
+
+/** `count` empty months starting at `from`, to fill the row beside the one under test. */
+function empties(from: number, count: number): CashMonth[] {
+  return Array.from({ length: count }, (_, i) => month(from + i, {}, ZERO))
+}
 
 function column(mese: number) {
   return screen.getByTestId(`column-${mese}`)
@@ -62,7 +66,7 @@ describe('MonthlyBars', () => {
     expect(within(gennaio).getByText('2.000,00 €')).toBeInTheDocument()
   })
 
-  it('says the total above a stacked column, so the figure on top is the whole month', () => {
+  it("says the stack's height as money above a stacked column, so the figure on top is the whole bar", () => {
     render(
       <MonthlyBars
         title="Proiezione"
@@ -73,28 +77,76 @@ describe('MonthlyBars', () => {
             { ...ZERO, incassato: 0.3, da_incassare: 0.4, bozze: 0.2 },
             { proiezione: '22784.03' },
           ),
-          ...EMPTY.slice(0, 2),
+          ...empties(10, 2),
         ]}
         series={['incassato', 'da_incassare', 'bozze', 'costi']}
         shares="quote_proiezione"
       />,
     )
     const agosto = column(8)
-    expect(within(agosto).getByTestId('column-total')).toHaveTextContent('22.784,03 €')
+    expect(within(agosto).getByTestId('lifted-value')).toHaveTextContent('22.784,03 €')
   })
 
-  it('prints no total above a column with one segment: its value already says it', () => {
+  /** August in the screenshot that opened ORB-139: a tall revenue segment and a sliver
+   *  of cost too short for its own label. The lifted figure still says the whole bar. */
+  it('says the height above a stack whose second segment is a sliver', () => {
     render(
       <MonthlyBars
         title="Andamento"
-        months={[month(6, { incassato: '7740.72' }, { ...ZERO, incassato: 1 }), ...EMPTY.slice(0, 2)]}
+        months={[
+          month(
+            8,
+            { incassato: '7813.91', costi: '320.00' },
+            { ...ZERO, incassato: 0.96, costi: 0.04 },
+            { andamento: '8133.91' },
+          ),
+          ...empties(10, 2),
+        ]}
+        series={['incassato', 'costi']}
+        shares="quote_andamento"
+      />,
+    )
+    const agosto = column(8)
+    expect(within(agosto).getByTestId('lifted-value')).toHaveTextContent('8.133,91 €')
+    expect(within(agosto).getByText('7.813,91 €')).toBeInTheDocument()
+    expect(within(agosto).getAllByTestId('segment')).toHaveLength(2)
+  })
+
+  /** An API one deploy behind the web sends no `pila_*`: the chart says nothing above
+   *  the stack rather than `NaN €`, and the segments keep their own figures. */
+  it('prints nothing above a stacked column when the payload has no height for it', () => {
+    const senza = month(
+      8,
+      { incassato: '7813.91', da_incassare: '9970.12' },
+      { ...ZERO, incassato: 0.4, da_incassare: 0.5 },
+    ) as Partial<CashMonth>
+    delete senza.pila_proiezione
+    render(
+      <MonthlyBars
+        title="Proiezione"
+        months={[senza as CashMonth, ...empties(10, 2)]}
+        series={['incassato', 'da_incassare', 'bozze', 'costi']}
+        shares="quote_proiezione"
+      />,
+    )
+    const agosto = column(8)
+    expect(within(agosto).queryByTestId('lifted-value')).toBeNull()
+    expect(within(agosto).queryByText(/NaN/)).toBeNull()
+    expect(within(agosto).getByText('9.970,12 €')).toBeInTheDocument()
+  })
+
+  it('prints no figure above a column with one segment: its value already says it', () => {
+    render(
+      <MonthlyBars
+        title="Andamento"
+        months={[month(6, { incassato: '7740.72' }, { ...ZERO, incassato: 1 }), ...empties(10, 2)]}
         series={['incassato', 'costi']}
         shares="quote_andamento"
       />,
     )
     const giugno = column(6)
     expect(within(giugno).getByText('7.740,72 €')).toBeInTheDocument()
-    expect(within(giugno).queryByTestId('column-total')).toBeNull()
+    expect(within(giugno).queryByTestId('lifted-value')).toBeNull()
   })
 
   /** feb and apr in the screenshot that opened ORB-139: a column of a few pixels cannot
@@ -106,14 +158,14 @@ describe('MonthlyBars', () => {
         months={[
           month(2, { incassato: '1000.00' }, { ...ZERO, incassato: 0.05 }),
           month(6, { incassato: '20000.00' }, { ...ZERO, incassato: 1 }),
-          ...EMPTY.slice(0, 1),
+          ...empties(10, 1),
         ]}
         series={['incassato', 'costi']}
         shares="quote_andamento"
       />,
     )
     const febbraio = column(2)
-    expect(within(febbraio).getByTestId('column-total')).toHaveTextContent('1.000,00 €')
+    expect(within(febbraio).getByTestId('lifted-value')).toHaveTextContent('1.000,00 €')
     // Inside the segment there is no room, so no second copy of the figure sits there.
     expect(within(febbraio).getByTestId('segment')).not.toHaveTextContent('1.000,00 €')
   })
@@ -122,12 +174,12 @@ describe('MonthlyBars', () => {
     render(
       <MonthlyBars
         title="Andamento"
-        months={[month(6, { incassato: '20000.00' }, { ...ZERO, incassato: 1 }), ...EMPTY.slice(0, 2)]}
+        months={[month(6, { incassato: '20000.00' }, { ...ZERO, incassato: 1 }), ...empties(10, 2)]}
         series={['incassato', 'costi']}
         shares="quote_andamento"
       />,
     )
-    expect(within(column(4)).queryByTestId('column-total')).toBeNull()
-    expect(within(column(4)).queryByTestId('segment')).toBeNull()
+    expect(within(column(10)).queryByTestId('lifted-value')).toBeNull()
+    expect(within(column(10)).queryByTestId('segment')).toBeNull()
   })
 })

--- a/projects/pigrocrm/apps/web/src/features/dashboard/MonthlyBars.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/MonthlyBars.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * The figures on the columns (ORB-139). Until now one segment per column carried a
+ * value, the tallest, and only when it filled more than a third of the plot: most months
+ * said nothing and the one figure shown read as the column's total when it was one
+ * segment's. Now every segment tall enough to hold the text says its value, a column too
+ * short for a label says it above, and a stacked column says its total above.
+ */
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { MonthlyBars } from './MonthlyBars'
+import type { CashMonth } from './queries'
+
+function month(
+  mese: number,
+  amounts: Partial<Record<'incassato' | 'da_incassare' | 'bozze' | 'costi', string>>,
+  shares: Record<string, number>,
+  totals: { andamento?: string; proiezione?: string } = {},
+): CashMonth {
+  return {
+    anno: 2026,
+    mese,
+    incassato: amounts.incassato ?? '0.00',
+    da_incassare: amounts.da_incassare ?? '0.00',
+    bozze: amounts.bozze ?? '0.00',
+    costi: amounts.costi ?? '0.00',
+    totale_andamento: totals.andamento ?? amounts.incassato ?? '0.00',
+    totale_proiezione: totals.proiezione ?? amounts.incassato ?? '0.00',
+    quote_andamento: shares,
+    quote_proiezione: shares,
+  } as CashMonth
+}
+
+const ZERO = { incassato: 0, da_incassare: 0, bozze: 0, costi: 0 }
+const EMPTY = Array.from({ length: 9 }, (_, i) => month(i + 4, {}, ZERO))
+
+function column(mese: number) {
+  return screen.getByTestId(`column-${mese}`)
+}
+
+describe('MonthlyBars', () => {
+  it('labels every segment tall enough to hold its value, not only the tallest', () => {
+    render(
+      <MonthlyBars
+        title="Proiezione"
+        months={[
+          month(
+            1,
+            { incassato: '4000.00', da_incassare: '3000.00', bozze: '2000.00' },
+            { ...ZERO, incassato: 0.4, da_incassare: 0.3, bozze: 0.2 },
+            { proiezione: '9000.00' },
+          ),
+          month(2, {}, ZERO),
+          month(3, {}, ZERO),
+        ]}
+        series={['incassato', 'da_incassare', 'bozze', 'costi']}
+        shares="quote_proiezione"
+      />,
+    )
+    const gennaio = column(1)
+    expect(within(gennaio).getByText('4.000,00 €')).toBeInTheDocument()
+    expect(within(gennaio).getByText('3.000,00 €')).toBeInTheDocument()
+    expect(within(gennaio).getByText('2.000,00 €')).toBeInTheDocument()
+  })
+
+  it('says the total above a stacked column, so the figure on top is the whole month', () => {
+    render(
+      <MonthlyBars
+        title="Proiezione"
+        months={[
+          month(
+            8,
+            { incassato: '7813.91', da_incassare: '9970.12', bozze: '5000.00' },
+            { ...ZERO, incassato: 0.3, da_incassare: 0.4, bozze: 0.2 },
+            { proiezione: '22784.03' },
+          ),
+          ...EMPTY.slice(0, 2),
+        ]}
+        series={['incassato', 'da_incassare', 'bozze', 'costi']}
+        shares="quote_proiezione"
+      />,
+    )
+    const agosto = column(8)
+    expect(within(agosto).getByTestId('column-total')).toHaveTextContent('22.784,03 €')
+  })
+
+  it('prints no total above a column with one segment: its value already says it', () => {
+    render(
+      <MonthlyBars
+        title="Andamento"
+        months={[month(6, { incassato: '7740.72' }, { ...ZERO, incassato: 1 }), ...EMPTY.slice(0, 2)]}
+        series={['incassato', 'costi']}
+        shares="quote_andamento"
+      />,
+    )
+    const giugno = column(6)
+    expect(within(giugno).getByText('7.740,72 €')).toBeInTheDocument()
+    expect(within(giugno).queryByTestId('column-total')).toBeNull()
+  })
+
+  /** feb and apr in the screenshot that opened ORB-139: a column of a few pixels cannot
+   *  hold a label, so its value goes above it rather than nowhere. */
+  it('lifts the value above a column too short to hold it', () => {
+    render(
+      <MonthlyBars
+        title="Andamento"
+        months={[
+          month(2, { incassato: '1000.00' }, { ...ZERO, incassato: 0.05 }),
+          month(6, { incassato: '20000.00' }, { ...ZERO, incassato: 1 }),
+          ...EMPTY.slice(0, 1),
+        ]}
+        series={['incassato', 'costi']}
+        shares="quote_andamento"
+      />,
+    )
+    const febbraio = column(2)
+    expect(within(febbraio).getByTestId('column-total')).toHaveTextContent('1.000,00 €')
+    // Inside the segment there is no room, so no second copy of the figure sits there.
+    expect(within(febbraio).getByTestId('segment')).not.toHaveTextContent('1.000,00 €')
+  })
+
+  it('says nothing above an empty month', () => {
+    render(
+      <MonthlyBars
+        title="Andamento"
+        months={[month(6, { incassato: '20000.00' }, { ...ZERO, incassato: 1 }), ...EMPTY.slice(0, 2)]}
+        series={['incassato', 'costi']}
+        shares="quote_andamento"
+      />,
+    )
+    expect(within(column(4)).queryByTestId('column-total')).toBeNull()
+    expect(within(column(4)).queryByTestId('segment')).toBeNull()
+  })
+})

--- a/projects/pigrocrm/apps/web/src/features/dashboard/MonthlyBars.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/MonthlyBars.tsx
@@ -20,10 +20,13 @@ import type { CashMonth } from './queries'
  *
  * The figures on the columns (ORB-139). Every segment tall enough to hold the text says
  * its own value inside; a column too short for a label says its value above itself
- * rather than nowhere; a stacked column says its total above, so the figure on top of a
- * month is the whole month and not one segment mistaken for it. The totals come from the
- * server (`totale_andamento`, `totale_proiezione`): a sum is a figure, and no figure is
- * born in the browser.
+ * rather than nowhere; a stacked column says its height as money above, so the figure on
+ * top of a month is the bar a reader measures and not one segment mistaken for it. That
+ * height comes from the server (`pila_andamento`, `pila_proiezione`), costs included
+ * since the bar includes them: a sum is a figure, and no figure is born in the browser.
+ * A payload without it, an API a deploy behind the web, prints nothing above rather than
+ * `NaN €`. Below 72px of column the labels hide instead of clipping (a container query):
+ * a cut-off amount is a wrong amount, and the tooltip and the table keep the full one.
  */
 
 const MONTHS = ['gen', 'feb', 'mar', 'apr', 'mag', 'giu', 'lug', 'ago', 'set', 'ott', 'nov', 'dic']
@@ -31,9 +34,10 @@ const PLOT_HEIGHT = 180
 /** The room a 10px label with its padding needs: below this a segment stays mute, and a
  *  column made only of mute segments lifts its value above itself instead. */
 const LABEL_HEIGHT = 16
-/** Reserved above the plot for the lifted values and the totals, so a full-height column
- *  does not push its own figure out of the card. */
-const HEADROOM = 16
+/** Reserved above the plot for the lifted value: its fixed 16px slot, the 2px flex gap
+ *  under it, and the 2px gaps between up to four stacked segments, so a full-height
+ *  column carries its figure without growing past the plot and dropping its baseline. */
+const HEADROOM = 24
 
 function isZero(value: string): boolean {
   return /^-?0(?:\.0+)?$/.test(value)
@@ -51,7 +55,7 @@ export function MonthlyBars({
   shares: 'quote_andamento' | 'quote_proiezione'
 }) {
   const empty = months.every((month) => series.every((key) => isZero(month[key])))
-  const totals = shares === 'quote_andamento' ? 'totale_andamento' : 'totale_proiezione'
+  const heights = shares === 'quote_andamento' ? 'pila_andamento' : 'pila_proiezione'
 
   return (
     <figure className="border bg-card p-4" aria-labelledby={`${shares}-title`}>
@@ -93,12 +97,16 @@ export function MonthlyBars({
                 height: Math.max(2, segment.share * PLOT_HEIGHT),
               }))
             const labelled = segments.filter((segment) => segment.height >= LABEL_HEIGHT)
-            // Above the column: the total when the month stacks more than one segment,
-            // the lone value when its only segment is too short to carry it. A month with
-            // one segment tall enough says its figure once, inside.
+            // Above the column: the stack's height as money when the month stacks more
+            // than one segment, the lone value when its only segment is too short to carry
+            // it. A month with one segment tall enough says its figure once, inside. An
+            // older payload carries no `pila_*`: then nothing, never `NaN €`.
+            const pila: string | undefined = month[heights]
             const above =
               segments.length > 1
-                ? money(month[totals])
+                ? pila === undefined
+                  ? null
+                  : money(pila)
                 : segments.length === 1 && labelled.length === 0
                   ? money(segments[0]!.value)
                   : null
@@ -106,12 +114,12 @@ export function MonthlyBars({
               <div
                 key={month.mese}
                 data-testid={`column-${month.mese}`}
-                className="flex h-full flex-col justify-end gap-0.5"
+                className="@container flex h-full min-h-0 flex-col justify-end gap-0.5"
               >
                 {above !== null && (
                   <span
-                    data-testid="column-total"
-                    className="mb-0.5 truncate text-center text-[10px] font-medium text-muted-foreground"
+                    data-testid="lifted-value"
+                    className="hidden h-4 text-center text-[10px] leading-4 font-medium text-muted-foreground @min-[72px]:block"
                   >
                     {above}
                   </span>
@@ -130,7 +138,7 @@ export function MonthlyBars({
                   >
                     {segment.height >= LABEL_HEIGHT && (
                       <span
-                        className="absolute inset-x-0 top-1 truncate px-1 text-center text-[10px] font-medium"
+                        className="absolute inset-x-0 top-1 hidden px-1 text-center text-[10px] font-medium @min-[72px]:block"
                         style={{
                           color:
                             segment.key === 'da_incassare'

--- a/projects/pigrocrm/apps/web/src/features/dashboard/MonthlyBars.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/MonthlyBars.tsx
@@ -15,12 +15,25 @@ import type { CashMonth } from './queries'
  * Series colours are the tile palette, not a validated categorical set: Prussian Blue
  * and Royal Gold sit outside the lightness band a chart palette would want, and the
  * dataviz validator says so. The brand wins here, and the secondary encodings carry
- * identity where colour alone would not -- legend, direct label on the tallest
- * segment of a column, the 2px gaps and the table view.
+ * identity where colour alone would not -- legend, direct labels, the 2px gaps and the
+ * table view.
+ *
+ * The figures on the columns (ORB-139). Every segment tall enough to hold the text says
+ * its own value inside; a column too short for a label says its value above itself
+ * rather than nowhere; a stacked column says its total above, so the figure on top of a
+ * month is the whole month and not one segment mistaken for it. The totals come from the
+ * server (`totale_andamento`, `totale_proiezione`): a sum is a figure, and no figure is
+ * born in the browser.
  */
 
 const MONTHS = ['gen', 'feb', 'mar', 'apr', 'mag', 'giu', 'lug', 'ago', 'set', 'ott', 'nov', 'dic']
 const PLOT_HEIGHT = 180
+/** The room a 10px label with its padding needs: below this a segment stays mute, and a
+ *  column made only of mute segments lifts its value above itself instead. */
+const LABEL_HEIGHT = 16
+/** Reserved above the plot for the lifted values and the totals, so a full-height column
+ *  does not push its own figure out of the card. */
+const HEADROOM = 16
 
 function isZero(value: string): boolean {
   return /^-?0(?:\.0+)?$/.test(value)
@@ -38,6 +51,7 @@ export function MonthlyBars({
   shares: 'quote_andamento' | 'quote_proiezione'
 }) {
   const empty = months.every((month) => series.every((key) => isZero(month[key])))
+  const totals = shares === 'quote_andamento' ? 'totale_andamento' : 'totale_proiezione'
 
   return (
     <figure className="border bg-card p-4" aria-labelledby={`${shares}-title`}>
@@ -65,20 +79,43 @@ export function MonthlyBars({
         <div
           aria-hidden="true"
           className="mt-4 grid grid-cols-12 items-end gap-2"
-          style={{ height: PLOT_HEIGHT }}
+          style={{ height: PLOT_HEIGHT + HEADROOM }}
         >
           {months.map((month) => {
             // Stacked from the baseline up, in series order; a 2px surface gap between
-            // segments, none below the first.
+            // segments, none below the first. Heights are geometry from the server's
+            // shares; whether a segment can carry its label is a question about pixels.
             const segments = series
               .map((key) => ({ key, share: month[shares][key] ?? 0, value: month[key] }))
               .filter((segment) => segment.share > 0)
-            const tallest = segments.reduce(
-              (best, segment) => (segment.share > best.share ? segment : best),
-              segments[0] ?? { key: series[0]!, share: 0, value: '0.00' },
-            )
+              .map((segment) => ({
+                ...segment,
+                height: Math.max(2, segment.share * PLOT_HEIGHT),
+              }))
+            const labelled = segments.filter((segment) => segment.height >= LABEL_HEIGHT)
+            // Above the column: the total when the month stacks more than one segment,
+            // the lone value when its only segment is too short to carry it. A month with
+            // one segment tall enough says its figure once, inside.
+            const above =
+              segments.length > 1
+                ? money(month[totals])
+                : segments.length === 1 && labelled.length === 0
+                  ? money(segments[0]!.value)
+                  : null
             return (
-              <div key={month.mese} className="flex h-full flex-col justify-end gap-0.5">
+              <div
+                key={month.mese}
+                data-testid={`column-${month.mese}`}
+                className="flex h-full flex-col justify-end gap-0.5"
+              >
+                {above !== null && (
+                  <span
+                    data-testid="column-total"
+                    className="mb-0.5 truncate text-center text-[10px] font-medium text-muted-foreground"
+                  >
+                    {above}
+                  </span>
+                )}
                 {[...segments].reverse().map((segment) => (
                   <div
                     key={segment.key}
@@ -87,11 +124,11 @@ export function MonthlyBars({
                     title={`${SERIES[segment.key].label}: ${money(segment.value)}`}
                     className="relative w-full"
                     style={{
-                      height: `${Math.max(2, segment.share * PLOT_HEIGHT)}px`,
+                      height: `${segment.height}px`,
                       backgroundColor: SERIES[segment.key].color,
                     }}
                   >
-                    {segment === tallest && segment.share > 0.35 && (
+                    {segment.height >= LABEL_HEIGHT && (
                       <span
                         className="absolute inset-x-0 top-1 truncate px-1 text-center text-[10px] font-medium"
                         style={{

--- a/projects/pigrocrm/apps/web/src/lib/api-types.ts
+++ b/projects/pigrocrm/apps/web/src/lib/api-types.ts
@@ -2967,7 +2967,10 @@ export interface components {
          *
          *     `quote` are the same four amounts as a share of the tallest month of their chart, in
          *     [0, 1], computed here: the browser scales a bar with them and never turns an amount
-         *     string into a number (apps/web/src/test/no-browser-arithmetic.test.ts).
+         *     string into a number (apps/web/src/test/no-browser-arithmetic.test.ts). `totale_*`
+         *     are the two column totals the charts print above a stacked month (ORB-139), summed
+         *     here for the same reason: what the cash chart stacks (`incassato + costi`) and what
+         *     the projection stacks (all four).
          */
         CashMonth: {
             /** Anno */
@@ -2982,6 +2985,10 @@ export interface components {
             bozze: string;
             /** Costi */
             costi: string;
+            /** Totale Andamento */
+            totale_andamento: string;
+            /** Totale Proiezione */
+            totale_proiezione: string;
             /** Quote Andamento */
             quote_andamento: {
                 [key: string]: number;
@@ -22091,7 +22098,7 @@ export interface operations {
         parameters: {
             query: {
                 anno: number;
-                /** @description In quale mese cade il denaro di ogni documento: 'competenza' (il periodo di competenza dichiarato sulla fattura o sulla proforma, con la data del documento per chi non lo dichiara; predefinito) oppure 'incasso' (la data di incasso per le fatture pagate, la scadenza per quelle da incassare, la data del documento per bozze e proforma). La stima fiscale resta sempre sull'incassato dell'anno. */
+                /** @description In quale mese cade il denaro di ogni documento: 'competenza' (il periodo di competenza dichiarato sulla fattura o sulla proforma, con la data del documento per chi non lo dichiara; predefinito) oppure 'incasso' (la data di incasso per le fatture pagate, la scadenza per quelle da incassare, la data del documento, o di creazione, per bozze e proforma). La stima fiscale resta sempre sull'incassato dell'anno. */
                 base?: "competenza" | "incasso";
             };
             header?: never;

--- a/projects/pigrocrm/apps/web/src/lib/api-types.ts
+++ b/projects/pigrocrm/apps/web/src/lib/api-types.ts
@@ -2967,10 +2967,13 @@ export interface components {
          *
          *     `quote` are the same four amounts as a share of the tallest month of their chart, in
          *     [0, 1], computed here: the browser scales a bar with them and never turns an amount
-         *     string into a number (apps/web/src/test/no-browser-arithmetic.test.ts). `totale_*`
-         *     are the two column totals the charts print above a stacked month (ORB-139), summed
-         *     here for the same reason: what the cash chart stacks (`incassato + costi`) and what
-         *     the projection stacks (all four).
+         *     string into a number (apps/web/src/test/no-browser-arithmetic.test.ts). `pila_*` are
+         *     the heights of the two stacked columns as money (ORB-139), summed here for the same
+         *     reason: what the cash chart stacks (`incassato + costi`) and what the projection
+         *     stacks (all four). A column's height, not an income: the costs are inside it, which
+         *     is why the field is not called a total and `proiettato` on `CashOverview` excludes
+         *     them. The chart prints it above a stacked month, where the figure has to match the
+         *     bar a reader measures.
          */
         CashMonth: {
             /** Anno */
@@ -2985,10 +2988,16 @@ export interface components {
             bozze: string;
             /** Costi */
             costi: string;
-            /** Totale Andamento */
-            totale_andamento: string;
-            /** Totale Proiezione */
-            totale_proiezione: string;
+            /**
+             * Pila Andamento
+             * @description Altezza della colonna dell'andamento come importo: incassato + costi passivi. Non e' un ricavo: i costi sono dentro.
+             */
+            pila_andamento: string;
+            /**
+             * Pila Proiezione
+             * @description Altezza della colonna della proiezione come importo: incassato + da incassare + bozze/proforma + costi passivi. Non e' un ricavo: i costi sono dentro.
+             */
+            pila_proiezione: string;
             /** Quote Andamento */
             quote_andamento: {
                 [key: string]: number;

--- a/projects/pigrocrm/packages/core/src/pigrocrm/core/analytics/schemas.py
+++ b/projects/pigrocrm/packages/core/src/pigrocrm/core/analytics/schemas.py
@@ -230,10 +230,13 @@ class CashMonth(BaseModel):
 
     `quote` are the same four amounts as a share of the tallest month of their chart, in
     [0, 1], computed here: the browser scales a bar with them and never turns an amount
-    string into a number (apps/web/src/test/no-browser-arithmetic.test.ts). `totale_*`
-    are the two column totals the charts print above a stacked month (ORB-139), summed
-    here for the same reason: what the cash chart stacks (`incassato + costi`) and what
-    the projection stacks (all four)."""
+    string into a number (apps/web/src/test/no-browser-arithmetic.test.ts). `pila_*` are
+    the heights of the two stacked columns as money (ORB-139), summed here for the same
+    reason: what the cash chart stacks (`incassato + costi`) and what the projection
+    stacks (all four). A column's height, not an income: the costs are inside it, which
+    is why the field is not called a total and `proiettato` on `CashOverview` excludes
+    them. The chart prints it above a stacked month, where the figure has to match the
+    bar a reader measures."""
 
     anno: int
     mese: int
@@ -241,8 +244,22 @@ class CashMonth(BaseModel):
     da_incassare: Decimal = Field(max_digits=12, decimal_places=2)
     bozze: Decimal = Field(max_digits=12, decimal_places=2)
     costi: Decimal = Field(max_digits=12, decimal_places=2)
-    totale_andamento: Decimal = Field(max_digits=12, decimal_places=2)
-    totale_proiezione: Decimal = Field(max_digits=12, decimal_places=2)
+    pila_andamento: Decimal = Field(
+        max_digits=12,
+        decimal_places=2,
+        description=(
+            "Altezza della colonna dell'andamento come importo: incassato + costi passivi. "
+            "Non e' un ricavo: i costi sono dentro."
+        ),
+    )
+    pila_proiezione: Decimal = Field(
+        max_digits=12,
+        decimal_places=2,
+        description=(
+            "Altezza della colonna della proiezione come importo: incassato + da incassare + "
+            "bozze/proforma + costi passivi. Non e' un ricavo: i costi sono dentro."
+        ),
+    )
     quote_andamento: dict[str, float]
     quote_proiezione: dict[str, float]
 

--- a/projects/pigrocrm/packages/core/src/pigrocrm/core/analytics/schemas.py
+++ b/projects/pigrocrm/packages/core/src/pigrocrm/core/analytics/schemas.py
@@ -230,7 +230,10 @@ class CashMonth(BaseModel):
 
     `quote` are the same four amounts as a share of the tallest month of their chart, in
     [0, 1], computed here: the browser scales a bar with them and never turns an amount
-    string into a number (apps/web/src/test/no-browser-arithmetic.test.ts)."""
+    string into a number (apps/web/src/test/no-browser-arithmetic.test.ts). `totale_*`
+    are the two column totals the charts print above a stacked month (ORB-139), summed
+    here for the same reason: what the cash chart stacks (`incassato + costi`) and what
+    the projection stacks (all four)."""
 
     anno: int
     mese: int
@@ -238,6 +241,8 @@ class CashMonth(BaseModel):
     da_incassare: Decimal = Field(max_digits=12, decimal_places=2)
     bozze: Decimal = Field(max_digits=12, decimal_places=2)
     costi: Decimal = Field(max_digits=12, decimal_places=2)
+    totale_andamento: Decimal = Field(max_digits=12, decimal_places=2)
+    totale_proiezione: Decimal = Field(max_digits=12, decimal_places=2)
     quote_andamento: dict[str, float]
     quote_proiezione: dict[str, float]
 

--- a/projects/pigrocrm/packages/core/src/pigrocrm/core/analytics/service.py
+++ b/projects/pigrocrm/packages/core/src/pigrocrm/core/analytics/service.py
@@ -436,8 +436,8 @@ class AnalyticsService:
                 da_incassare=da_incassare.get(m, zero),
                 bozze=bozze.get(m, zero),
                 costi=costi.get(m, zero),
-                totale_andamento=round_money(incassato.get(m, zero) + costi.get(m, zero)),
-                totale_proiezione=round_money(
+                pila_andamento=round_money(incassato.get(m, zero) + costi.get(m, zero)),
+                pila_proiezione=round_money(
                     incassato.get(m, zero)
                     + da_incassare.get(m, zero)
                     + bozze.get(m, zero)

--- a/projects/pigrocrm/packages/core/src/pigrocrm/core/analytics/service.py
+++ b/projects/pigrocrm/packages/core/src/pigrocrm/core/analytics/service.py
@@ -436,6 +436,13 @@ class AnalyticsService:
                 da_incassare=da_incassare.get(m, zero),
                 bozze=bozze.get(m, zero),
                 costi=costi.get(m, zero),
+                totale_andamento=round_money(incassato.get(m, zero) + costi.get(m, zero)),
+                totale_proiezione=round_money(
+                    incassato.get(m, zero)
+                    + da_incassare.get(m, zero)
+                    + bozze.get(m, zero)
+                    + costi.get(m, zero)
+                ),
                 quote_andamento={
                     "incassato": share(incassato.get(m, zero), stack_andamento),
                     "costi": share(costi.get(m, zero), stack_andamento),

--- a/projects/pigrocrm/packages/core/tests/test_analytics_cash.py
+++ b/projects/pigrocrm/packages/core/tests/test_analytics_cash.py
@@ -72,6 +72,13 @@ def test_the_year_adds_up_month_by_month_and_costs_are_not_revenue(
     # Shares of the tallest stack: both present, and the stack adds up to the whole.
     assert month.quote_andamento["incassato"] > 0 and month.quote_andamento["costi"] > 0
     assert abs(month.quote_andamento["incassato"] + month.quote_andamento["costi"] - 1.0) < 1e-9
+    # The column totals the chart prints above a stacked month (ORB-139): summed here,
+    # once, because the browser never turns an amount into a number.
+    assert month.totale_andamento == month.incassato + Decimal("120.00")
+    assert month.totale_proiezione == month.incassato + Decimal("120.00")
+    empty = next(m for m in overview.mesi if m.mese != OGGI.month)
+    assert empty.totale_andamento == Decimal("0.00")
+    assert empty.totale_proiezione == Decimal("0.00")
     assert sum(m.incassato for m in overview.mesi) == overview.incassato
     assert overview.proiettato == overview.incassato  # nothing pending, nothing drafted
     assert overview.lordo_effettivo == overview.incassato - Decimal("120.00")
@@ -89,6 +96,11 @@ def test_an_issued_unpaid_invoice_is_projected_not_collected(
     assert overview.incassato == Decimal("0.00")
     assert overview.da_incassare == Decimal(str(totale))
     assert overview.proiettato == Decimal(str(totale))
+    # Owed money is projected, not collected: it is in the projection's column total
+    # and not in the cash chart's.
+    month = next(m for m in overview.mesi if m.da_incassare > Decimal("0.00"))
+    assert month.totale_proiezione == Decimal(str(totale))
+    assert month.totale_andamento == Decimal("0.00")
 
 
 def test_a_draft_counts_as_a_draft_and_a_paid_invoice_never_twice(

--- a/projects/pigrocrm/packages/core/tests/test_analytics_cash.py
+++ b/projects/pigrocrm/packages/core/tests/test_analytics_cash.py
@@ -72,13 +72,14 @@ def test_the_year_adds_up_month_by_month_and_costs_are_not_revenue(
     # Shares of the tallest stack: both present, and the stack adds up to the whole.
     assert month.quote_andamento["incassato"] > 0 and month.quote_andamento["costi"] > 0
     assert abs(month.quote_andamento["incassato"] + month.quote_andamento["costi"] - 1.0) < 1e-9
-    # The column totals the chart prints above a stacked month (ORB-139): summed here,
-    # once, because the browser never turns an amount into a number.
-    assert month.totale_andamento == month.incassato + Decimal("120.00")
-    assert month.totale_proiezione == month.incassato + Decimal("120.00")
+    # The height of each stacked column as money (ORB-139), summed here, once, because
+    # the browser never turns an amount into a number. Costs are inside it, which is why
+    # it is a `pila` and not a total: the chart prints it above the bar a reader measures.
+    assert month.pila_andamento == month.incassato + Decimal("120.00")
+    assert month.pila_proiezione == month.incassato + Decimal("120.00")
     empty = next(m for m in overview.mesi if m.mese != OGGI.month)
-    assert empty.totale_andamento == Decimal("0.00")
-    assert empty.totale_proiezione == Decimal("0.00")
+    assert empty.pila_andamento == Decimal("0.00")
+    assert empty.pila_proiezione == Decimal("0.00")
     assert sum(m.incassato for m in overview.mesi) == overview.incassato
     assert overview.proiettato == overview.incassato  # nothing pending, nothing drafted
     assert overview.lordo_effettivo == overview.incassato - Decimal("120.00")
@@ -99,8 +100,8 @@ def test_an_issued_unpaid_invoice_is_projected_not_collected(
     # Owed money is projected, not collected: it is in the projection's column total
     # and not in the cash chart's.
     month = next(m for m in overview.mesi if m.da_incassare > Decimal("0.00"))
-    assert month.totale_proiezione == Decimal(str(totale))
-    assert month.totale_andamento == Decimal("0.00")
+    assert month.pila_proiezione == Decimal(str(totale))
+    assert month.pila_andamento == Decimal("0.00")
 
 
 def test_a_draft_counts_as_a_draft_and_a_paid_invoice_never_twice(
@@ -110,6 +111,11 @@ def test_a_draft_counts_as_a_draft_and_a_paid_invoice_never_twice(
     assert overview.bozze > Decimal("0.00")
     assert overview.incassato == Decimal("0.00")
     assert overview.da_incassare == Decimal("0.00")
+    # A draft is in the projection's stack and not in the cash chart's: the two heights
+    # differ by exactly the two projection-only series.
+    month = next(m for m in overview.mesi if m.bozze > Decimal("0.00"))
+    assert month.pila_proiezione == month.bozze
+    assert month.pila_andamento == Decimal("0.00")
 
 
 def test_a_proforma_is_projected_in_the_month_of_its_own_date(


### PR DESCRIPTION
## What this changes

The two economic charts of the dashboard labelled one segment per column, the tallest, and only when it filled more than a third of the plot. On Ivan's 2026 data «Andamento economico» left February and April mute, «Proiezione economica» labelled two months out of nine, and the «9.970,12 €» on August was the gold «Da incassare» segment alone, which a reader takes for the month's total. Ivan asked on 2026-09-10, with a screenshot: «fai sì che il valore economico si veda sempre dentro alle colonne».

Now every segment tall enough to hold the text says its own value inside. A column too short for a label says its value above itself, small and muted, rather than nowhere. A column that stacks more than one segment says its total above, so the figure on top of a month is the whole month. The plot keeps a strip of headroom for those figures.

The figure above a stacked column is the height of the bar as money, and it comes from the server: `CashMonth` gains `pila_andamento` (incassato + costi) and `pila_proiezione` (all four series), summed once in `AnalyticsService.cash_overview` beside the shares, because a sum is a figure and no figure is born in the browser (criterion 14, `no-browser-arithmetic.test.ts`). They are named for what they are, a bar's height with the costs inside, not a total an assistant on the MCP would read as an income.

## How I verified it

- Red then green. Core: `test_analytics_cash.py` asserts the two heights on a month with a paid invoice and a cost, on an empty month, and on a month whose only money is owed (in the projection's height, not the cash chart's); both failed with `AttributeError` on `origin/main`. Web: `MonthlyBars.test.tsx`, five tests (every tall segment labelled, the bar's height above a stacked column, nothing above a single tall segment, the value lifted above a short column and not repeated inside, nothing above an empty month); all five failed on `origin/main`.
- `pnpm --filter web test`: 1087 passed, 102 files. `tsc --noEmit`, eslint, `pnpm --filter web build`: clean. `no-browser-arithmetic.test.ts` passes: the chart still does no arithmetic on amounts.
- `test_analytics_api.py`, `test_dashboard_api.py`, `test_analytics_cash.py`, `test_dashboard_commercial.py`: 90 passed. ruff, ruff format, mypy: clean.
- `uv run pytest -q -n 3 --dist loadfile -m "not slow and not planner" projects/pigrocrm`: 4190 passed.
- `bash projects/pigrocrm/apps/web/scripts/e2e.sh` (the Playwright suite, serial, its own Postgres): 39 passed in 1.3m.
- After the independent review (recorded as a comment on this PR): the dashboard and criterion-14 test files 102 passed, the whole web suite 1089 passed; the page re-measured at 1440 and 1024: the tallest column ends on the plot's bottom edge, no label is clipped, none is shown where it would not fit.
- `pnpm --filter web generate:api` with the API up: the only change in `api-types.ts` is the two fields and their descriptions.
- Opened http://localhost:5173/app/?tab=economica against a local stack with seven imported invoices spread over the year (six paid, one owed), a September proforma and an August cost. Before: nine figures across the two charts. After: sixteen, one per column plus a total above the two stacked Augusts; February's «1.450,00 €» sits above its short bar.

## Anything a reviewer should look at twice

- The stacked August total in the projection reads 18.104,03 €, which includes the 320,00 € cost stacked on top of the revenue, since that is what the column stacks. Whether costs belong in that stack is the open question Ivan raised about the projection («non sono convinto») and is not decided here.
- A segment shorter than 16px carries no label (the 320 € cost sliver above August): its figure is in the tooltip and in the table view, and the column's total above already contains it.
- Labels are 10px in a twelfth of the plot's width; at 1440px «18.104,03 €» fits with room to spare. Below 72px of column (about 1280px of viewport) they hide rather than clip, and the tooltip and the table carry the figures.

## What did not change, on purpose

- What each chart stacks, the default «per competenza» reading, the series colours, the tooltips and the table view. The projection's content is a separate decision pending Ivan's answer.

## API changes

- `GET /api/analytics/panoramica`: every element of `cassa.mesi` gains `pila_andamento` and `pila_proiezione` (decimal strings, the stacked bar's height as money, costs inside). No status code changes. `pnpm --filter web generate:api` was run with the API up on `localhost:8000`; `projects/pigrocrm/apps/web/src/lib/api-types.ts` matches.

## MCP surface

- No tool added or renamed. `get_economic_dashboard` returns the same `CashMonth` rows, so its output carries the two new keys.

## Screenshots

**1. The economic tab, both charts: a figure on every column, the bar's height above a stacked month, the short February labelled above its bar**
![Economic charts, before and after](https://github.com/user-attachments/assets/8ba08fd7-1a68-45d1-a6a6-c6d8d5f20106)

Linear: ORB-139.
