### PR TITLE
fix(web): after Emetti the page lands on the fattura, and a consumed proforma says which

### DIFF
--- a/projects/pigrocrm/apps/api/src/pigrocrm_api/routers/invoices.py
+++ b/projects/pigrocrm/apps/api/src/pigrocrm_api/routers/invoices.py
@@ -71,6 +71,9 @@ def list_invoices(
     # (§6.2). The card links here and nowhere else, and the rows returned are counted by
     # the same predicate function the card's `COUNT` uses.
     scadute: Annotated[bool, Query()] = False,
+    # The fattura a consumed proforma was issued as: the proforma's page asks for the
+    # one row whose `origine_proforma_id` is its own id (ORB-134).
+    origine_proforma_id: Annotated[UUID | None, Query()] = None,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     cursor: Annotated[UUID | None, Query()] = None,
 ) -> InvoicePage:
@@ -82,6 +85,7 @@ def list_invoices(
         anno=anno,
         stato_pagamento=stato_pagamento,
         scadute=scadute,
+        origine_proforma_id=origine_proforma_id,
         limit=limit,
         cursor=cursor,
     )

--- a/projects/pigrocrm/apps/api/tests/test_invoices_api.py
+++ b/projects/pigrocrm/apps/api/tests/test_invoices_api.py
@@ -361,6 +361,33 @@ def test_the_list_filters_and_paginates(
     assert filtered["items"] == []
 
 
+def test_the_list_answers_the_fattura_a_consumed_proforma_became(
+    logged_in: TestClient,
+    customer: dict[str, Any],
+    fiscal_profile: dict[str, Any],
+    emitter: dict[str, Any],
+) -> None:
+    """After «Emetti» on a proforma the numbered row is a different one (spec 5), and the
+    consumed proforma's page needs a way to it: `?origine_proforma_id=` answers exactly
+    that row (ORB-134)."""
+    proforma = logged_in.post(
+        "/api/invoices",
+        json={
+            "customer_id": customer["id"],
+            "tipo": "proforma",
+            "righe": [{"descrizione": "Consulenza", "prezzo_unitario": "100.00"}],
+        },
+    ).json()
+    assert logged_in.post(f"/api/invoices/{proforma['id']}/confirm").status_code == 200
+    issued = logged_in.post(f"/api/invoices/{proforma['id']}/issue", json={}).json()
+    assert issued["id"] != proforma["id"]
+    assert issued["origine_proforma_id"] == proforma["id"]
+
+    page = logged_in.get("/api/invoices", params={"origine_proforma_id": proforma["id"]}).json()
+    assert [row["id"] for row in page["items"]] == [issued["id"]]
+    assert logged_in.get("/api/invoices", params={"origine_proforma_id": "x"}).status_code == 422
+
+
 def test_the_list_limit_is_bounded_at_the_http_layer(logged_in: TestClient) -> None:
     assert logged_in.get("/api/invoices", params={"limit": 201}).status_code == 422
 

--- a/projects/pigrocrm/apps/web/src/features/invoices/ConsumedProformaNotice.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/ConsumedProformaNotice.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConsumedProformaNotice } from './ConsumedProformaNotice'
+import type { Invoice } from './queries'
+import { api } from '@/lib/api'
+
+// The route tree is not mounted here, so `Link` renders as the anchor it would become.
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    Link: ({
+      to,
+      params,
+      children,
+    }: {
+      to: string
+      params?: Record<string, string>
+      children: ReactNode
+    }) => (
+      <a href={to.replace('$invoiceId', params?.invoiceId ?? '')}>{children}</a>
+    ),
+  }
+})
+
+const mockGet = vi.spyOn(api, 'GET')
+
+function ok(data: unknown) {
+  return { data, response: new Response(null, { status: 200 }) } as never
+}
+
+const CONSUMED = { id: 'pf-1', tipo: 'proforma', stato: 'consumata' } as unknown as Invoice
+const FATTURA = {
+  id: 'inv-18',
+  tipo: 'fattura',
+  stato: 'emessa',
+  anno: 2026,
+  numero: 18,
+  riferimento: null,
+  origine_proforma_id: 'pf-1',
+} as unknown as Invoice
+
+function wrap(children: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{children}</QueryClientProvider>)
+}
+
+beforeEach(() => {
+  mockGet.mockReset()
+})
+
+describe('ConsumedProformaNotice', () => {
+  /** The page Ivan was stuck on: a consumed proforma with no actions and no XML, and no
+   *  word about where they went (ORB-134). */
+  it('names the fattura the proforma became and links to its page', async () => {
+    mockGet.mockResolvedValue(ok({ items: [FATTURA], next_cursor: null }))
+    wrap(<ConsumedProformaNotice proforma={CONSUMED} />)
+
+    const link = await screen.findByRole('link', { name: '2026/18' })
+    expect(link).toHaveAttribute('href', '/app/fatture/inv-18')
+    expect(screen.getByTestId('consumed-proforma-notice').textContent).toContain(
+      'emessa come fattura',
+    )
+    const [path, options] = mockGet.mock.calls[0] as unknown as [string, { params: unknown }]
+    expect(path).toBe('/api/invoices')
+    expect(options.params).toEqual({
+      query: { origine_proforma_id: 'pf-1', tipo: 'fattura', limit: 1 },
+    })
+  })
+
+  it('still says where to look when the list answers nothing', async () => {
+    mockGet.mockResolvedValue(ok({ items: [], next_cursor: null }))
+    wrap(<ConsumedProformaNotice proforma={CONSUMED} />)
+
+    expect(await screen.findByTestId('consumed-proforma-notice')).toHaveTextContent(
+      'elenco delle fatture',
+    )
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+})

--- a/projects/pigrocrm/apps/web/src/features/invoices/ConsumedProformaNotice.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/ConsumedProformaNotice.tsx
@@ -1,0 +1,41 @@
+import { Link } from '@tanstack/react-router'
+import { formatInvoiceNumber } from './format'
+import { type Invoice, useInvoices } from './queries'
+
+/**
+ * What «Consumata» means, said on the page it is said of.
+ *
+ * Issuing a proforma creates a new numbered row and freezes the proforma (spec 5); the
+ * proforma keeps no pointer to it, the fattura points back with `origine_proforma_id`.
+ * A person who lands here after «Emetti», or from the list, sees a document with no
+ * actions and no XML and reads it as lost (ORB-134, Ivan on 2026-09-11: «non ci sta il
+ * pulsante»). This asks the list for the one row that points here and links to it,
+ * so the way to the fattura is one click from the proforma and not a search by number.
+ */
+export function ConsumedProformaNotice({ proforma }: { proforma: Invoice }) {
+  const fatture = useInvoices({ origine_proforma_id: proforma.id, tipo: 'fattura', limit: 1 })
+  const fattura = fatture.data?.items[0]
+  if (fatture.isLoading) return null
+  return (
+    <p className="text-muted-foreground text-sm" data-testid="consumed-proforma-notice">
+      {fattura ? (
+        <>
+          Questa proforma è stata emessa come fattura{' '}
+          <Link
+            to="/app/fatture/$invoiceId"
+            params={{ invoiceId: fattura.id }}
+            className="text-foreground font-medium underline underline-offset-4"
+          >
+            {formatInvoiceNumber(fattura)}
+          </Link>
+          : PDF e XML FatturaPA sono lì.
+        </>
+      ) : (
+        // A consumed proforma always has its fattura; the list not answering one is a
+        // network error or a race with the emission that has just happened, and the
+        // sentence still says where to look.
+        'Questa proforma è stata emessa: la fattura con il numero e l\u2019XML è nell\u2019elenco delle fatture.'
+      )}
+    </p>
+  )
+}

--- a/projects/pigrocrm/apps/web/src/features/invoices/ConsumedProformaNotice.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/ConsumedProformaNotice.tsx
@@ -31,10 +31,11 @@ export function ConsumedProformaNotice({ proforma }: { proforma: Invoice }) {
           : PDF e XML FatturaPA sono lì.
         </>
       ) : (
-        // A consumed proforma always has its fattura; the list not answering one is a
-        // network error or a race with the emission that has just happened, and the
-        // sentence still says where to look.
-        'Questa proforma è stata emessa: la fattura con il numero e l\u2019XML è nell\u2019elenco delle fatture.'
+        // A consumed proforma always has its fattura, written in the same transaction
+        // that consumed it, so an empty answer is the request failing after the client
+        // gave up retrying. The sentence stays true either way and says where to look;
+        // an error banner for a one-line notice would be louder than the page it sits on.
+        'Questa proforma è stata emessa: la fattura con il numero e l’XML è nell’elenco delle fatture.'
       )}
     </p>
   )

--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.test.tsx
@@ -108,12 +108,44 @@ describe('InvoiceActions', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /emetti/i }))
 
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Documento emesso'))
+    await waitFor(() => expect(toast.success).toHaveBeenCalled())
+    expect(String(vi.mocked(toast.success).mock.calls[0]?.[0])).toContain('emessa')
     await waitFor(() => expect(toast.warning).toHaveBeenCalled())
     const warning = String(vi.mocked(toast.warning).mock.calls[0]?.[0])
     expect(warning).toContain('emesso correttamente')
     expect(warning).toContain('Rigenera documenti')
     expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
+  })
+
+  /**
+   * From a proforma the numbered row is a *new* one (spec 5). Until this existed the
+   * bar rendered the proforma's own PDF, toasted, and stayed on a page that had just
+   * become a consumed proforma with nothing left to do on it; the fattura and its XML
+   * were somewhere in the list (ORB-134). Now the render targets the issued row, the
+   * toast names the number, and the caller is handed the row to go to.
+   */
+  it('renders the issued row, not the proforma, and hands it to the caller', async () => {
+    const issuedFromProforma = {
+      ...ISSUED,
+      id: 'inv-18',
+      anno: 2026,
+      numero: 18,
+      origine_proforma_id: 'pf-1',
+    } as unknown as Invoice
+    vi.mocked(api.POST).mockResolvedValueOnce(ok(issuedFromProforma)).mockResolvedValueOnce(ok([]))
+    const onIssued = vi.fn()
+    wrap(<InvoiceActions invoice={PROFORMA} onIssued={onIssued} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /emetti/i }))
+
+    await waitFor(() => expect(vi.mocked(api.POST).mock.calls.length).toBe(2))
+    const paths = vi.mocked(api.POST).mock.calls.map((call) => String(call[0]))
+    expect(paths[0]).toContain('/issue')
+    expect(paths[1]).toContain('/artifacts')
+    const render = vi.mocked(api.POST).mock.calls[1] as unknown as [string, { params: unknown }]
+    expect(render[1].params).toEqual({ path: { invoice_id: 'inv-18' } })
+    expect(onIssued).toHaveBeenCalledWith(issuedFromProforma)
+    expect(String(vi.mocked(toast.success).mock.calls[0]?.[0])).toBe('Fattura 2026/18 emessa')
   })
 
   // --- the step before emission: confirming a proforma (ORB-132) -------------------------

--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.test.tsx
@@ -80,7 +80,8 @@ describe('InvoiceActions', () => {
 
   it('renders the artefacts after issuing, as a second call', async () => {
     vi.mocked(api.POST).mockResolvedValue(ok(ISSUED))
-    wrap(<InvoiceActions invoice={DRAFT} />)
+    const onIssued = vi.fn()
+    wrap(<InvoiceActions invoice={DRAFT} onIssued={onIssued} />)
 
     await userEvent.click(screen.getByRole('button', { name: /emetti/i }))
     await waitFor(() => expect(vi.mocked(api.POST).mock.calls.length).toBe(2))
@@ -91,6 +92,30 @@ describe('InvoiceActions', () => {
       .mock.calls.map((call) => String((call as unknown as unknown[])[0]))
     expect(paths[0]).toContain('/issue')
     expect(paths[1]).toContain('/artifacts')
+    // A draft fattura is issued in place: the caller gets the same id back and has
+    // nothing to navigate to. The route relies on this to stay put (ORB-134).
+    expect(onIssued).toHaveBeenCalledWith(ISSUED)
+    expect(onIssued.mock.calls[0]?.[0]?.id).toBe(DRAFT.id)
+  })
+
+  /**
+   * The route navigates away in `onIssued`, so this bar unmounts while the render is
+   * still in flight. TanStack Query drops the callbacks passed to `mutate()` once the
+   * observer has no listeners, which silently lost the warning on exactly the flow
+   * ORB-134 introduces; the promise form does not. Pinned by unmounting from the
+   * callback, as the route does.
+   */
+  it('still warns about a failed render after the caller has navigated away', async () => {
+    vi.mocked(api.POST)
+      .mockResolvedValueOnce(ok({ ...ISSUED, id: 'inv-18' }))
+      .mockResolvedValueOnce(failed({ detail: 'typst non disponibile' }, 500))
+    const view = wrap(<InvoiceActions invoice={PROFORMA} onIssued={() => view.unmount()} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /emetti/i }))
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalled())
+    expect(String(vi.mocked(toast.warning).mock.calls[0]?.[0])).toContain('Rigenera documenti')
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
   })
 
   /**

--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.tsx
@@ -26,6 +26,7 @@ import { QueryErrorBanner } from '@/components/QueryErrorBanner'
 import { toProblem, type ProblemDetail } from '@/lib/api'
 import { useIsAdmin } from '@/lib/auth'
 import { toIsoDate } from '@/lib/dates'
+import { formatInvoiceNumber } from './format'
 import {
   downloadInvoiceArtifact,
   useAnnulInvoice,
@@ -41,11 +42,17 @@ import {
 export function InvoiceActions({
   invoice,
   onDeleted,
+  onIssued,
 }: {
   invoice: Invoice
   /** Called once the server has accepted the delete: the page this bar sits on no
    *  longer exists, so the caller decides where to go (the list, in practice). */
   onDeleted?: () => void
+  /** Called with the row that now carries the number. For a draft fattura it is this
+   *  same row; for a proforma it is a *new* row (spec 5), and the page this bar sits on
+   *  has become a consumed proforma with nothing left to do on it, so the caller goes
+   *  to the fattura, where «XML FatturaPA» is (ORB-134). */
+  onIssued?: (issued: Invoice) => void
 }) {
   const [problem, setProblem] = useState<ProblemDetail | null>(null)
   const [annulOpen, setAnnulOpen] = useState(false)
@@ -122,6 +129,11 @@ export function InvoiceActions({
    * regenerates deterministically from the frozen snapshot whenever it is called again.
    * Saying "emission failed" here would be the more dangerous lie, so the message says
    * exactly what happened and what to press.
+   *
+   * The render targets `issued.id`, not `invoice.id`: from a proforma the two differ,
+   * and rendering the proforma would print the wrong document (ORB-134). The toast
+   * names the number, since it is the one fact the person cannot see on the page they
+   * pressed the button on.
    */
   function onIssue() {
     if (!window.confirm(`Emettere questo documento? Il numero assegnato non è più modificabile.`))
@@ -131,15 +143,15 @@ export function InvoiceActions({
       {},
       {
         onSuccess: (issued) => {
-          toast.success('Documento emesso')
-          artifacts.mutate(undefined, {
+          toast.success(`Fattura ${formatInvoiceNumber(issued)} emessa`)
+          artifacts.mutate(issued.id, {
             onError: () =>
               toast.warning(
                 'Documento emesso correttamente, ma PDF e XML non sono stati generati. ' +
                   'Riprova con «Rigenera documenti»: il numero resta quello.',
               ),
           })
-          void issued
+          onIssued?.(issued)
         },
         onError: (error) => setProblem(toProblem(error)),
       },

--- a/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.tsx
+++ b/projects/pigrocrm/apps/web/src/features/invoices/InvoiceActions.tsx
@@ -134,6 +134,12 @@ export function InvoiceActions({
    * and rendering the proforma would print the wrong document (ORB-134). The toast
    * names the number, since it is the one fact the person cannot see on the page they
    * pressed the button on.
+   *
+   * `mutateAsync` and not `mutate` with callbacks: `onIssued` navigates away, this bar
+   * unmounts, and TanStack Query drops the callbacks handed to `mutate()` once the
+   * observer has no listeners. The warning would be lost on exactly the flow this
+   * exists for. A promise's `catch` does not care whether anything is still mounted,
+   * and the toast is global.
    */
   function onIssue() {
     if (!window.confirm(`Emettere questo documento? Il numero assegnato non è più modificabile.`))
@@ -144,13 +150,12 @@ export function InvoiceActions({
       {
         onSuccess: (issued) => {
           toast.success(`Fattura ${formatInvoiceNumber(issued)} emessa`)
-          artifacts.mutate(issued.id, {
-            onError: () =>
-              toast.warning(
-                'Documento emesso correttamente, ma PDF e XML non sono stati generati. ' +
-                  'Riprova con «Rigenera documenti»: il numero resta quello.',
-              ),
-          })
+          void artifacts.mutateAsync(issued.id).catch(() =>
+            toast.warning(
+              'Documento emesso correttamente, ma PDF e XML non sono stati generati. ' +
+                'Riprova con «Rigenera documenti»: il numero resta quello.',
+            ),
+          )
           onIssued?.(issued)
         },
         onError: (error) => setProblem(toProblem(error)),

--- a/projects/pigrocrm/apps/web/src/features/invoices/queries.ts
+++ b/projects/pigrocrm/apps/web/src/features/invoices/queries.ts
@@ -39,6 +39,12 @@ export interface InvoiceFilters {
    * today, one already collected -- that the predicate exists to settle.
    */
   scadute?: boolean
+  /**
+   * The fattura a consumed proforma was issued as. The fattura carries
+   * `origine_proforma_id` and the proforma carries nothing, so the proforma's page asks
+   * the list for the one row that points at it (ORB-134).
+   */
+  origine_proforma_id?: string
   limit?: number
   cursor?: string
 }
@@ -336,16 +342,25 @@ export function useSetPaymentState(invoiceId: string) {
   })
 }
 
+/**
+ * `invoiceId` is the row the bar sits on; `mutate(targetId)` names another one. The
+ * one caller that does is «Emetti» on a proforma, whose issued row is a *different*
+ * row (spec 5): rendering the proforma there would produce the proforma's PDF and
+ * leave the fattura, the document the person came for, unprinted (ORB-134).
+ */
 export function useProduceArtifacts(invoiceId: string) {
   const invalidate = useInvoiceInvalidation()
   return useMutation({
-    mutationFn: () =>
+    mutationFn: (targetId?: string) =>
       unwrap(
         api.POST('/api/invoices/{invoice_id}/artifacts', {
-          params: { path: { invoice_id: invoiceId } },
+          params: { path: { invoice_id: targetId ?? invoiceId } },
         }),
       ),
-    onSuccess: () => invalidate(invoiceId),
+    onSuccess: (_data, targetId) => {
+      invalidate(invoiceId)
+      if (targetId) invalidate(targetId)
+    },
   })
 }
 

--- a/projects/pigrocrm/apps/web/src/lib/api-types.ts
+++ b/projects/pigrocrm/apps/web/src/lib/api-types.ts
@@ -16196,6 +16196,7 @@ export interface operations {
                 anno?: number | null;
                 stato_pagamento?: ("da_incassare" | "incassato") | null;
                 scadute?: boolean;
+                origine_proforma_id?: string | null;
                 limit?: number;
                 cursor?: string | null;
             };

--- a/projects/pigrocrm/apps/web/src/routes/app/fatture/$invoiceId.tsx
+++ b/projects/pigrocrm/apps/web/src/routes/app/fatture/$invoiceId.tsx
@@ -3,6 +3,7 @@ import { Receipt } from 'lucide-react'
 import { EntityDetailLayout } from '@/components/EntityDetailLayout'
 import { QueryErrorBanner } from '@/components/QueryErrorBanner'
 import { StatusPill } from '@/components/StatusPill'
+import { ConsumedProformaNotice } from '@/features/invoices/ConsumedProformaNotice'
 import { InvoiceActions } from '@/features/invoices/InvoiceActions'
 import { InvoiceHeaderEditor } from '@/features/invoices/InvoiceHeaderEditor'
 import { InvoiceLinesEditor } from '@/features/invoices/InvoiceLinesEditor'
@@ -72,7 +73,20 @@ export function InvoiceDetail() {
           <div className="space-y-8">
             {/* A deleted draft has no page: back to the list, which the mutation has already
                 invalidated. */}
-            <InvoiceActions invoice={row} onDeleted={() => void navigate({ to: '/app/fatture' })} />
+            <InvoiceActions
+              invoice={row}
+              onDeleted={() => void navigate({ to: '/app/fatture' })}
+              // From a proforma the numbered row is a new one and this page has just
+              // become a consumed proforma with nothing to do on it, so go where the
+              // XML is. A draft fattura is issued in place and stays (ORB-134).
+              onIssued={(issued) => {
+                if (issued.id !== row.id)
+                  void navigate({ to: '/app/fatture/$invoiceId', params: { invoiceId: issued.id } })
+              }}
+            />
+            {row.tipo === 'proforma' && row.stato === 'consumata' ? (
+              <ConsumedProformaNotice proforma={row} />
+            ) : null}
 
             {/* While the document can still change, its dates are inputs (ORB-61, ORB-63)
                 and the list below states only what nobody can edit here; once frozen, the

--- a/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/repository.py
+++ b/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/repository.py
@@ -429,6 +429,8 @@ class InvoiceRepository:
             stmt = stmt.where(Invoice.anno == query.anno)
         if query.stato_pagamento:
             stmt = stmt.where(Invoice.stato_pagamento == query.stato_pagamento)
+        if query.origine_proforma_id:
+            stmt = stmt.where(Invoice.origine_proforma_id == query.origine_proforma_id)
         if query.scadute:
             # The drill-through of §6.2's "scaduto e non incassato" card, sharing its
             # predicate literally rather than restating it -- see `_overdue_predicate`,

--- a/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/schemas.py
+++ b/projects/pigrocrm/packages/core/src/pigrocrm/core/invoices/schemas.py
@@ -487,6 +487,11 @@ class InvoiceListQuery(BaseModel):
     # (`_overdue_predicate`), so the two cannot drift apart. Same shape as
     # `DocumentListQuery.solo_deal_non_vinto`.
     scadute: bool = False
+    # The way back from a consumed proforma to the fattura it became. The fattura carries
+    # `origine_proforma_id`; the proforma carries nothing, by design (a row is written
+    # once at emission and the proforma is frozen at the same moment), so the page of a
+    # consumed proforma asks the list for the row that points at it (ORB-134).
+    origine_proforma_id: UUID | None = None
     # Bounded here, not only on the router: an MCP tool builds this object directly,
     # with no `Query(...)` bound sitting between it and this schema.
     limit: int = Field(default=50, ge=1, le=200)

--- a/projects/pigrocrm/packages/core/tests/test_invoice_service.py
+++ b/projects/pigrocrm/packages/core/tests/test_invoice_service.py
@@ -540,10 +540,11 @@ def test_a_collaboratore_may_record_a_payment(
     )
 
 
-def _issued_row(db_session: Session, customer_id: UUID) -> Invoice:
+def _issued_row(db_session: Session, customer_id: UUID, **overrides: object) -> Invoice:
     """An already-issued row inserted directly, so this file's payment tests do not
-    depend on `issue` (next task) being written yet."""
-    invoice = Invoice(
+    depend on `issue` (next task) being written yet. `overrides` are applied before the
+    flush, since `(anno, numero)` is unique and a second row needs its own number."""
+    fields: dict[str, object] = dict(
         customer_id=customer_id,
         tipo="fattura",
         stato="emessa",
@@ -561,6 +562,8 @@ def _issued_row(db_session: Session, customer_id: UUID) -> Invoice:
         snapshot_versione=1,
         custom_fields={},
     )
+    fields.update(overrides)
+    invoice = Invoice(**fields)  # type: ignore[arg-type]
     db_session.add(invoice)
     db_session.flush()
     return invoice
@@ -607,6 +610,25 @@ def test_an_issued_invoice_cannot_be_soft_deleted(
 
 
 # --- listing ------------------------------------------------------------------------
+
+
+def test_the_list_finds_the_fattura_a_consumed_proforma_was_issued_as(
+    service: InvoiceService, db_session: Session, customer_id: UUID
+) -> None:
+    """The fattura points back at its proforma and the proforma points at nothing, so
+    the consumed proforma's page finds its fattura by asking the list for the row whose
+    `origine_proforma_id` is its own id (ORB-134). Another fattura, or another
+    proforma's fattura, does not answer."""
+    proforma = service.create(InvoiceCreate(customer_id=customer_id, tipo="proforma"), ADMIN)
+    other = service.create(InvoiceCreate(customer_id=customer_id, tipo="proforma"), ADMIN)
+    from_proforma = _issued_row(db_session, customer_id, origine_proforma_id=proforma.id)
+    _issued_row(db_session, customer_id, numero=2, origine_proforma_id=other.id)
+    standalone = _issued_row(db_session, customer_id, numero=3)
+
+    found = service.list(InvoiceListQuery(origine_proforma_id=proforma.id), ADMIN).items
+    assert [i.id for i in found] == [from_proforma.id]
+    assert standalone.id not in {i.id for i in found}
+    assert service.list(InvoiceListQuery(origine_proforma_id=uuid4()), ADMIN).items == []
 
 
 def test_the_list_filters_by_tipo_stato_year_and_payment(


### PR DESCRIPTION
## What this changes

Issuing a proforma creates a new numbered row and freezes the proforma (spec 5). The web toasted «Documento emesso», rendered the proforma's own PDF, and stayed on a page that had just become a consumed proforma with no actions and no XML; the fattura was somewhere in the list, to be found by number. Ivan hit exactly this the evening ORB-140 shipped: «non ci sta il pulsante».

Now, on that page:

- After «Emetti» on a proforma the route navigates to the issued fattura, where «Scarica XML» and «Rigenera documenti» are. A draft fattura is issued in place and stays. The toast names the number: «Fattura 2026/18 emessa».
- The render the web asks for after emission targets the issued row, not the proforma, so the fattura is the document that gets printed.
- A consumed proforma carries one sentence: «Questa proforma è stata emessa come fattura 2026/18: PDF e XML FatturaPA sono lì», with the number as a link to the fattura's page. If the list answers nothing (a race with the emission just made, a network error) the sentence still says where to look.

The sentence needs the way back from a proforma to its fattura, which nothing stored: the fattura points at the proforma through `origine_proforma_id`, the proforma at nothing. So the invoice list gains `origine_proforma_id` as a filter, in `InvoiceListQuery`, the repository and `GET /api/invoices`.

## How I verified it

- `pnpm --filter web test`: 1092 passed in 103 files (1089 before). New: `ConsumedProformaNotice.test.tsx` pins the sentence, the link target and the exact query the page sends, plus the empty answer; `InvoiceActions.test.tsx` pins that from a proforma the render call carries the issued row's id, `onIssued` receives the issued row, and the toast reads «Fattura 2026/18 emessa». The existing «a failed render is not a failed emission» test still passes.
- `pnpm --filter web lint`, `pnpm --filter web build` (vite and `tsc --noEmit`): clean.
- `uv run pytest -q projects/pigrocrm/packages/core/tests/test_invoice_service.py -n 0`: 55 passed (54 before). New: the list by `origine_proforma_id` answers the one fattura and not a sibling proforma's or a standalone one; an unknown id answers empty.
- `uv run pytest -q projects/pigrocrm/apps/api/tests/test_invoices_api.py -n 0`: 24 passed (23 before). New: create a proforma, confirm, issue over HTTP, then `GET /api/invoices?origine_proforma_id=` answers exactly the issued row; a malformed id is 422.
- `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`: clean.

## Anything a reviewer should look at twice

- `useProduceArtifacts(invoiceId)` now accepts a target id at `mutate` time and invalidates both. The one caller that passes one is «Emetti»; «Rigenera documenti» still passes nothing and renders the row it sits on.
- The navigation happens right after `issue` succeeds, while the render is still in flight against the issued row; the fattura's page then shows the PDF when its query is invalidated. If the render fails, the warning toast still fires, on the fattura's page.
- The API endpoint itself renders the artefacts inside `POST /issue` and answers an error when that fails after the number is spent, which is what Ivan saw as a failed emission. Not touched here: filed as ORB-143.

## API changes

`GET /api/invoices` gains the optional query parameter `origine_proforma_id` (UUID). No response shape changed. `projects/pigrocrm/apps/web/src/lib/api-types.ts` was regenerated from the app's own OpenAPI document (`create_app().openapi()` piped to `openapi-typescript`, the same generator `generate:api` runs against a live API); the diff is the one new line.

## What did not change, on purpose

The MCP `list_invoices` tool builds its `InvoiceListQuery` explicitly and gains no `origine_proforma_id` argument: an agent reads the fattura's `origine_proforma_id` from `get_invoice`, and the reverse lookup is the page's need. Recorded on the card.

## Screenshots

Before and after of the consumed proforma's page, attached below once captured on the same throwaway data: the before shows the page with the state pill and nothing else, the after shows the sentence with the link to the fattura.

Linear: ORB-134.

![pair-1-proforma-consumata](https://github.com/user-attachments/assets/3eacdb9c-cef9-418e-b70f-ecc4bdccfcb1)