### PR TITLE
style(website): the landing hero sits just under the header

### DIFF
--- a/projects/website/src/landing.css
+++ b/projects/website/src/landing.css
@@ -153,9 +153,11 @@ footer .quiet-link:hover {
   color: var(--landing-cta-ink);
 }
 
-/* --- Hero: the field behind, one box in front. */
+/* --- Hero: the field behind, one box in front. A short step down from the header,
+   and no padding of its own below: the first `.section`'s padding is the gap to
+   "Come funziona", the same beat as between every other pair of sections. */
 .hero {
-  padding-block: clamp(3rem, 9vw, 8rem);
+  padding-block: clamp(1rem, 2.5vw, 2rem) 0;
 }
 
 /* --- The field: the same one the community page on `/` has. Fixed, behind everything


### PR DESCRIPTION
## What this changes

On `/pigrocrm` the hero box floated in too much air: 128px between the header and the box at 1440px, and 240px between the box and "Come funziona", because the hero's own padding, `clamp(3rem, 9vw, 8rem)` on both sides, added itself to the first section's padding. Everywhere else on the page two sections are 7rem apart. I changed the one rule in `projects/website/src/landing.css`: the hero keeps a short step below the header, `clamp(1rem, 2.5vw, 2rem)`, and no padding of its own below, so the first section's padding is the gap to "Come funziona", the same beat as between every other pair of sections. At 1440px the box now starts 32px under the header and "Come funziona" follows 112px after it.

**Adjacent.** No open card touches `landing.css` or the hero. ORB-71 and ORB-72 (Backlog, Lorenzo) will move this page to `/` and retire the community page; they do not change this rule. The community page on `/` has its own stylesheet and is untouched.

## How I verified it

In the branch worktree, `pnpm --filter website lint` (clean), `pnpm --filter website test` (11 files, 205 tests passed) and `pnpm --filter website test:e2e` (49 passed in 12.0s). I opened `/pigrocrm` on the dev server at 1440×900 and at 1000×620 and measured the rectangles with `getBoundingClientRect`: header to box 128px → 32px and box to the "Come funziona" kicker 240px → 112px at 1440px; 90px → 25px and 170px → 80px at 1000px.

## Anything a reviewer should look at twice

The bottom padding is 0 rather than a smaller clamp, on purpose: any value there stacks on the section's padding and breaks the 7rem rhythm the rest of the page keeps. If the box should breathe more than the sections do, the place to say so is a hero-only rule with a comment, not a second clamp.

## Screenshots

**1. The landing hero at 1440×900, before and after**
![The landing hero at 1440×900, before and after](https://github.com/user-attachments/assets/271bf2ce-4f8f-448a-8794-efe619006041)

Linear: ORB-144.
