### PR TITLE
style(website): room under the hero, larger type, four short voices

### DIFF
--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -144,9 +144,10 @@
         </div>
       </section>
 
-      <!-- The four voices: people who are in Orbiters and what each says about it, one
-        sentence each (Ivan, 2026-09-11). Real names, no placeholder left: a tile here is
-        a person who agreed to be quoted, and the test counts four of them. -->
+      <!-- The four voices: two talents and two companies, one short sentence each about
+        the platform (Ivan, 2026-09-11, ORB-145 then ORB-146). Real names, no placeholder
+        left: a tile here is a person who agreed to be quoted, and the role line says
+        which side of the marketplace they speak from; the test counts four. -->
       <section class="band dark" aria-labelledby="worked-with">
         <div class="wrap section">
           <p class="kicker" id="worked-with" data-reveal>Hanno lavorato con noi</p>
@@ -156,50 +157,38 @@
           <div class="grid-2 voices">
             <figure class="testimonial" data-reveal style="--d: 0.25s">
               <blockquote>
-                <p>
-                  «Un progetto proposto da chi conosce il mio lavoro vale più di cento candidature:
-                  qui arrivano così.»
-                </p>
+                <p>«Il progetto giusto mi è arrivato da chi conosceva già il mio lavoro.»</p>
               </blockquote>
               <figcaption class="who">
                 <span class="avatar" aria-hidden="true">IS</span>
-                <span><strong>Ivan Sala</strong><br /><span class="role">Fractional CTO</span></span>
+                <span><strong>Ivan Sala</strong><br /><span class="role">Fractional CTO · talento</span></span>
               </figcaption>
             </figure>
             <figure class="testimonial" data-reveal style="--d: 0.4s">
               <blockquote>
-                <p>
-                  «Offerta, contratto e fattura in una sera, senza aprire tre strumenti diversi: il
-                  tempo che avanza lo passo a fare il CTO.»
-                </p>
+                <p>«Offerta, contratto e fattura in una sera. Il resto del tempo lo passo a lavorare.»</p>
               </blockquote>
               <figcaption class="who">
                 <span class="avatar" aria-hidden="true">LF</span>
-                <span><strong>Lorenzo Fiore</strong><br /><span class="role">Fractional CTO</span></span>
+                <span><strong>Lorenzo Fiore</strong><br /><span class="role">Fractional CTO · talento</span></span>
               </figcaption>
             </figure>
             <figure class="testimonial" data-reveal style="--d: 0.55s">
               <blockquote>
-                <p>
-                  «Cercavo un backend developer e ho avuto due nomi giusti in una settimana, senza
-                  leggere cinquanta CV.»
-                </p>
+                <p>«Cercavo un backend developer. In una settimana avevo due nomi giusti.»</p>
               </blockquote>
               <figcaption class="who">
                 <span class="avatar" aria-hidden="true">LF</span>
-                <span><strong>Luca Franzesi</strong><br /><span class="role">Head of Software Solution</span></span>
+                <span><strong>Luca Franzesi</strong><br /><span class="role">Head of Software Solution · azienda</span></span>
               </figcaption>
             </figure>
             <figure class="testimonial" data-reveal style="--d: 0.7s">
               <blockquote>
-                <p>
-                  «Quando un cliente ha chiesto più di quanto avevamo pattuito, c'era qualcuno che
-                  quella telefonata l'aveva già fatta.»
-                </p>
+                <p>«Persone già selezionate da chi fa il loro mestiere. Niente CV da filtrare.»</p>
               </blockquote>
               <figcaption class="who">
                 <span class="avatar" aria-hidden="true">AC</span>
-                <span><strong>Andrea Ciceri</strong><br /><span class="role">Lead Infrastructure Engineer</span></span>
+                <span><strong>Andrea Ciceri</strong><br /><span class="role">Lead Infrastructure Engineer · azienda</span></span>
               </figcaption>
             </figure>
           </div>

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -149,11 +149,12 @@ describe('index.html', () => {
     const tiles = page.match(/<figure class="testimonial"[^>]*>/g) ?? []
     expect(tiles).toHaveLength(4)
     expect(page).not.toContain('data-placeholder')
+    // Two talents and two companies, the role line saying which (ORB-146).
     for (const [name, role] of [
-      ['Ivan Sala', 'Fractional CTO'],
-      ['Lorenzo Fiore', 'Fractional CTO'],
-      ['Luca Franzesi', 'Head of Software Solution'],
-      ['Andrea Ciceri', 'Lead Infrastructure Engineer'],
+      ['Ivan Sala', 'Fractional CTO · talento'],
+      ['Lorenzo Fiore', 'Fractional CTO · talento'],
+      ['Luca Franzesi', 'Head of Software Solution · azienda'],
+      ['Andrea Ciceri', 'Lead Infrastructure Engineer · azienda'],
     ]) {
       expect(page).toMatch(new RegExp(`<strong>${name}</strong><br /><span class="role">${role}</span>`))
     }

--- a/projects/website/src/landing-style.test.ts
+++ b/projects/website/src/landing-style.test.ts
@@ -141,7 +141,7 @@ describe('the landing shares the product system', () => {
     it('does not let the testimonial\'s role size reach the title', () => {
       // `.role` was the testimonial caption's class before it was the title's word;
       // the small size stays on the caption.
-      expect(rule('.who .role')).toMatch(/font-size:\s*0\.875rem/)
+      expect(rule('.who .role')).toMatch(/font-size:\s*1rem/)
       expect(css).not.toMatch(/\n\.role\s*\{/)
     })
   })

--- a/projects/website/src/landing.css
+++ b/projects/website/src/landing.css
@@ -163,10 +163,11 @@ footer .quiet-link:hover {
 }
 
 /* --- Hero: the field behind, one box in front. A short step down from the header,
-   and no padding of its own below: the first `.section`'s padding is the gap to
-   "Come funziona", the same beat as between every other pair of sections. */
+   and a full beat below: since ORB-145 the next section is an opaque band, so this
+   padding is the only room between the box and it, and the field shows through there
+   (ORB-146; ORB-144 had set it to 0 when the section below still carried the gap). */
 .hero {
-  padding-block: clamp(1rem, 2.5vw, 2rem) 0;
+  padding-block: clamp(1rem, 2.5vw, 2rem) clamp(3rem, 6vw, 5rem);
 }
 
 /* --- The field: the same one the community page on `/` has. Fixed, behind everything
@@ -208,20 +209,20 @@ footer .quiet-link:hover {
 
 /* --- Type: fluid, one family. */
 h1 {
-  font-size: clamp(2.2rem, 2.6vw + 1.5rem, 3.5rem);
+  font-size: clamp(2.2rem, 3vw + 1.4rem, 4.4rem);
   font-weight: 500;
   line-height: 1.08;
   letter-spacing: -0.02em;
 }
 
 h2 {
-  font-size: clamp(1.5rem, 1.3vw + 1.05rem, 2.1rem);
+  font-size: clamp(1.75rem, 1.5vw + 1.2rem, 2.6rem);
   font-weight: 500;
   line-height: 1.2;
 }
 
 h3 {
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   font-weight: 500;
   line-height: 1.3;
   margin-bottom: 0.5rem;
@@ -229,17 +230,17 @@ h3 {
 
 p,
 li {
-  font-size: clamp(1rem, 0.3vw + 0.95rem, 1.125rem);
+  font-size: clamp(1.0625rem, 0.35vw + 1rem, 1.25rem);
   color: var(--landing-ink-quiet);
 }
 
 .lead {
-  font-size: clamp(1.1rem, 0.5vw + 1rem, 1.3rem);
+  font-size: clamp(1.2rem, 0.6vw + 1.05rem, 1.5rem);
   color: var(--landing-ink);
 }
 
 .fine {
-  font-size: 0.9375rem;
+  font-size: 1.0625rem;
 }
 
 /* A sentence, not a label: one tile and a few words in sentence case, where the
@@ -304,10 +305,10 @@ li {
   gap: 0.5rem;
   background-color: var(--landing-cta);
   color: var(--landing-cta-ink);
-  font-size: 1.0625rem;
+  font-size: 1.2rem;
   font-weight: 500;
   text-decoration: none;
-  padding: 0.9rem 1.5rem;
+  padding: 1rem 1.75rem;
   border-width: 2px;
   border-color: var(--landing-cta);
 }
@@ -396,7 +397,7 @@ li {
 }
 
 .testimonial blockquote p {
-  font-size: clamp(1.05rem, 0.4vw + 0.95rem, 1.2rem);
+  font-size: clamp(1.2rem, 0.5vw + 1.05rem, 1.45rem);
   color: var(--landing-ink);
 }
 
@@ -404,7 +405,7 @@ li {
   display: flex;
   align-items: center;
   gap: 0.8rem;
-  font-size: 0.9375rem;
+  font-size: 1.0625rem;
   color: var(--landing-ink-quiet);
 }
 
@@ -414,7 +415,7 @@ li {
 }
 
 .who .role {
-  font-size: 0.875rem;
+  font-size: 1rem;
 }
 
 /* The initial, on a tile the colour of the accent: the one saturated thing a card
@@ -424,8 +425,8 @@ li {
   align-items: center;
   justify-content: center;
   flex: none;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 3rem;
+  height: 3rem;
   background-color: var(--landing-cta);
   color: var(--landing-cta-ink);
   font-weight: 500;
@@ -475,7 +476,7 @@ li {
 
 /* The deck's kicker: capitals, tracked, in the accent; gold on the ink. */
 .deck .kicker {
-  font-size: 0.8125rem;
+  font-size: 0.9375rem;
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -494,7 +495,7 @@ li {
 
 /* The statement under the kicker: the deck's `.statement`, at the page's scale. */
 .statement {
-  font-size: clamp(1.9rem, 2vw + 1.2rem, 3rem);
+  font-size: clamp(2.1rem, 2.4vw + 1.3rem, 3.75rem);
   font-weight: 500;
   line-height: 1.1;
   letter-spacing: -0.02em;
@@ -519,7 +520,7 @@ li {
   height: auto;
   background-color: transparent;
   color: var(--landing-gold);
-  font-size: clamp(2.6rem, 3vw + 1.5rem, 4.5rem);
+  font-size: clamp(3rem, 3.5vw + 1.6rem, 5.25rem);
   font-weight: 500;
   letter-spacing: -0.03em;
   line-height: 1;


### PR DESCRIPTION
## What this changes

Ivan reviewed the landing on preview right after #56 and found three things. The hero box and the first dark band touched: #55 had set the hero's bottom padding to 0 because the section below carried the gap, then #56 turned that section into an opaque band and the gap went. The hero now has a full beat below (`clamp(3rem, 6vw, 5rem)`) and the field shows between the box and the band again. The type was too small everywhere: the whole scale is one step up (body 17–20px, lead up to 24px, h1 up to 70px, statement up to 60px, kicker 15px, buttons 19px, quotes up to 23px, fine print 17px); the h1's floor at 360px is unchanged so the typewriter's longest word still fits. The four voices are now two talents (Ivan Sala, Lorenzo Fiore) and two companies (Luca Franzesi, Andrea Ciceri), one short sentence each, with «talento» or «azienda» on the role line.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 11 files / 205 tests, `pnpm --filter website test:e2e` 49 passed in 11.6s (the typewriter layout tests at 360, 390, 430 and 1280 included). Screenshots of `/` at 1440 and 390 with reduced motion, read before attaching.

## Anything a reviewer should look at twice

`.who .role` was pinned at 0.875rem by `landing-style.test.ts` ("does not let the testimonial's role size reach the title"): the pin moves to 1rem, the point of that test (the caption's size never reaching the h1) holds. The `.avatar` tile grows from 2.5 to 3rem with the type.

## Screenshots

**1. The landing at 1440, before (main after #56) and after**
![The landing before and after the review](https://github.com/user-attachments/assets/83e2fa50-6073-437d-b9e1-a27c8b4c4026)

Linear: ORB-146.
