### PR TITLE
style(website): two voices change hands, centred guide band, gold hover

### DIFF
--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -166,11 +166,11 @@
             </figure>
             <figure class="testimonial" data-reveal style="--d: 0.4s">
               <blockquote>
-                <p>«Offerta, contratto e fattura in una sera. Il resto del tempo lo passo a lavorare.»</p>
+                <p>«Persone già selezionate da chi fa il loro mestiere. Niente CV da filtrare.»</p>
               </blockquote>
               <figcaption class="who">
                 <span class="avatar" aria-hidden="true">LF</span>
-                <span><strong>Lorenzo Fiore</strong><br /><span class="role">Fractional CTO · talento</span></span>
+                <span><strong>Lorenzo Fiore</strong><br /><span class="role">Fractional CTO · azienda</span></span>
               </figcaption>
             </figure>
             <figure class="testimonial" data-reveal style="--d: 0.55s">
@@ -184,11 +184,11 @@
             </figure>
             <figure class="testimonial" data-reveal style="--d: 0.7s">
               <blockquote>
-                <p>«Persone già selezionate da chi fa il loro mestiere. Niente CV da filtrare.»</p>
+                <p>«Offerta, contratto e fattura in una sera. Il resto del tempo lo passo a lavorare.»</p>
               </blockquote>
               <figcaption class="who">
                 <span class="avatar" aria-hidden="true">AC</span>
-                <span><strong>Andrea Ciceri</strong><br /><span class="role">Lead Infrastructure Engineer · azienda</span></span>
+                <span><strong>Andrea Ciceri</strong><br /><span class="role">Lead Infrastructure Engineer · talento</span></span>
               </figcaption>
             </figure>
           </div>
@@ -240,7 +240,7 @@
         the CRM as the largest of them, and it should absorb this block when it lands.
         No size or page count in this copy on purpose, since the file lives in another
         project and a number here would have nothing holding it true. -->
-      <section class="band dark" aria-labelledby="guida">
+      <section class="band dark centred" aria-labelledby="guida">
         <div class="wrap section">
           <p class="kicker" id="guida" data-reveal>La guida, il secondo perk</p>
           <h2 class="statement" data-reveal style="--d: 0.1s">I primi passi <span class="accent">da freelance.</span></h2>

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -152,9 +152,9 @@ describe('index.html', () => {
     // Two talents and two companies, the role line saying which (ORB-146).
     for (const [name, role] of [
       ['Ivan Sala', 'Fractional CTO · talento'],
-      ['Lorenzo Fiore', 'Fractional CTO · talento'],
+      ['Lorenzo Fiore', 'Fractional CTO · azienda'],
       ['Luca Franzesi', 'Head of Software Solution · azienda'],
-      ['Andrea Ciceri', 'Lead Infrastructure Engineer · azienda'],
+      ['Andrea Ciceri', 'Lead Infrastructure Engineer · talento'],
     ]) {
       expect(page).toMatch(new RegExp(`<strong>${name}</strong><br /><span class="role">${role}</span>`))
     }

--- a/projects/website/src/landing.css
+++ b/projects/website/src/landing.css
@@ -474,6 +474,29 @@ li {
   color: var(--landing-quiet-on-ink);
 }
 
+/* On the ink the hover cannot be the ink: the button would vanish into the band. It
+   goes gold, with the ink for its label, the deck's second accent (ORB-147). */
+.band.dark .cta:hover {
+  background-color: var(--landing-gold);
+  border-color: var(--landing-gold);
+  color: var(--landing-ink);
+}
+
+/* A centred band, the way the deck centres a call to action: everything on the axis,
+   the measures kept but placed in the middle (ORB-147, the guide). */
+.band.centred .section {
+  text-align: center;
+}
+
+.band.centred .statement,
+.band.centred .measure {
+  margin-inline: auto;
+}
+
+.band.centred .actions {
+  justify-content: center;
+}
+
 /* The deck's kicker: capitals, tracked, in the accent; gold on the ink. */
 .deck .kicker {
   font-size: 0.9375rem;


### PR DESCRIPTION
## What this changes

Ivan's second pass on the landing on preview. Two voices change hands: Lorenzo Fiore now says «Persone già selezionate da chi fa il loro mestiere. Niente CV da filtrare.» and Andrea Ciceri «Offerta, contratto e fattura in una sera. Il resto del tempo lo passo a lavorare.». The role line follows the voice (Lorenzo · azienda, Andrea · talento), so the section still reads as two talents and two companies. The guide band is centred: kicker, statement, lead, button and fine print on the axis, the way the deck centres a call to action. And the CTA's hover on a dark band turned the button the ink, the same colour as the band, so the label vanished: on the ink the hover is now gold with the ink for its label.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 11 files / 205 tests, `pnpm --filter website test:e2e` 49 passed in 11.9s. Screenshots of the guide band at rest and with the pointer on the button (gold, ink label, readable), and of the four voices, read before attaching.

## Anything a reviewer should look at twice

The role labels moved with the quotes. Ivan asked for the quotes to change hands; a talent saying «niente CV da filtrare» would read as the wrong side, so the label follows the voice and the 2+2 balance is kept. If the labels were meant to stay, it is two strings in `index.html` and two in `landing-pages.test.ts`.

## Screenshots

**1. The landing at 1440, before (main after #57) and after**
![The landing before and after](https://github.com/user-attachments/assets/595c44a2-7aa8-4c54-aa57-8b751a454018)

Linear: ORB-147.
