### PR TITLE
style(website): the guide band's button gets room above and below

### DIFF
--- a/projects/website/src/landing.css
+++ b/projects/website/src/landing.css
@@ -497,6 +497,13 @@ li {
   justify-content: center;
 }
 
+/* Inside a box the grid gap spaces the blocks; in a band the actions paragraph is a
+   child of the section and nothing gives it room, so the button sat against the lead
+   above and the fine print below (ORB-148). A beat above, half a beat below. */
+.band .section > .actions {
+  margin-block: 2.25rem 1.25rem;
+}
+
 /* The deck's kicker: capitals, tracked, in the accent; gold on the ink. */
 .deck .kicker {
   font-size: 0.9375rem;


### PR DESCRIPTION
## What this changes

On the guide band the button sat against the lead above and the fine print below («è troppo attaccato sopra e sotto»). Inside a `.box` the grid gap spaces the blocks; in a band the actions paragraph is a child of the section and nothing gave it room. One rule: `.band .section > .actions` gets `margin-block: 2.25rem 1.25rem`.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 11 files / 205 tests, `pnpm --filter website test:e2e` 49 passed. Screenshot of the guide band at 1440, read before attaching.

## Screenshots

**1. The guide band at 1440, before and after**
![The guide band before and after](https://github.com/user-attachments/assets/c7986357-da86-4cc7-8b9d-6bd7f7ff25f5)

Linear: ORB-148.
