### PR TITLE
style(website): the landing a touch wider, its type a step larger

### DIFF
--- a/projects/website/src/landing.css
+++ b/projects/website/src/landing.css
@@ -69,7 +69,8 @@ body {
 }
 
 .wrap {
-  max-width: 72rem;
+  /* 84rem since ORB-149: a touch wider, the deck's proportions on a wide screen. */
+  max-width: 84rem;
   margin-inline: auto;
   padding-inline: clamp(1.25rem, 5vw, 3rem);
 }
@@ -79,7 +80,7 @@ body {
 }
 
 .measure {
-  max-width: 62ch;
+  max-width: 68ch;
   /* The policy pages make this a grid: one implicit column, a gap between the blocks.
      An implicit track is `min-width: auto`, so it never gets narrower than its widest
      unbreakable child, and the Gmail scope URLs in privacy.html are wider than a
@@ -196,7 +197,7 @@ footer .quiet-link:hover {
 }
 
 .measure-tight {
-  max-width: 24ch;
+  max-width: 26ch;
 }
 
 .card {
@@ -209,20 +210,20 @@ footer .quiet-link:hover {
 
 /* --- Type: fluid, one family. */
 h1 {
-  font-size: clamp(2.2rem, 3vw + 1.4rem, 4.4rem);
+  font-size: clamp(2.2rem, 3.4vw + 1.4rem, 5rem);
   font-weight: 500;
   line-height: 1.08;
   letter-spacing: -0.02em;
 }
 
 h2 {
-  font-size: clamp(1.75rem, 1.5vw + 1.2rem, 2.6rem);
+  font-size: clamp(1.75rem, 1.7vw + 1.2rem, 3rem);
   font-weight: 500;
   line-height: 1.2;
 }
 
 h3 {
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   font-weight: 500;
   line-height: 1.3;
   margin-bottom: 0.5rem;
@@ -230,17 +231,17 @@ h3 {
 
 p,
 li {
-  font-size: clamp(1.0625rem, 0.35vw + 1rem, 1.25rem);
+  font-size: clamp(1.0625rem, 0.45vw + 1rem, 1.375rem);
   color: var(--landing-ink-quiet);
 }
 
 .lead {
-  font-size: clamp(1.2rem, 0.6vw + 1.05rem, 1.5rem);
+  font-size: clamp(1.2rem, 0.75vw + 1.05rem, 1.7rem);
   color: var(--landing-ink);
 }
 
 .fine {
-  font-size: 1.0625rem;
+  font-size: 1.125rem;
 }
 
 /* A sentence, not a label: one tile and a few words in sentence case, where the
@@ -305,10 +306,10 @@ li {
   gap: 0.5rem;
   background-color: var(--landing-cta);
   color: var(--landing-cta-ink);
-  font-size: 1.2rem;
+  font-size: 1.3rem;
   font-weight: 500;
   text-decoration: none;
-  padding: 1rem 1.75rem;
+  padding: 1.05rem 1.9rem;
   border-width: 2px;
   border-color: var(--landing-cta);
 }
@@ -397,7 +398,7 @@ li {
 }
 
 .testimonial blockquote p {
-  font-size: clamp(1.2rem, 0.5vw + 1.05rem, 1.45rem);
+  font-size: clamp(1.2rem, 0.65vw + 1.05rem, 1.65rem);
   color: var(--landing-ink);
 }
 
@@ -506,7 +507,7 @@ li {
 
 /* The deck's kicker: capitals, tracked, in the accent; gold on the ink. */
 .deck .kicker {
-  font-size: 0.9375rem;
+  font-size: 1.0625rem;
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -525,7 +526,7 @@ li {
 
 /* The statement under the kicker: the deck's `.statement`, at the page's scale. */
 .statement {
-  font-size: clamp(2.1rem, 2.4vw + 1.3rem, 3.75rem);
+  font-size: clamp(2.1rem, 2.8vw + 1.3rem, 4.5rem);
   font-weight: 500;
   line-height: 1.1;
   letter-spacing: -0.02em;
@@ -550,7 +551,7 @@ li {
   height: auto;
   background-color: transparent;
   color: var(--landing-gold);
-  font-size: clamp(3rem, 3.5vw + 1.6rem, 5.25rem);
+  font-size: clamp(3rem, 4vw + 1.6rem, 6rem);
   font-weight: 500;
   letter-spacing: -0.03em;
   line-height: 1;


### PR DESCRIPTION
## What this changes

Ivan asked for the landing to widen a touch and its type to grow, to recall the deck. The content column (`.wrap`) goes from 72rem to 84rem and the two measures follow (62→68ch, 24→26ch). Every fluid size gains at the wide end while its floor at phone width stays: h1 to 5rem, statement to 4.5rem, h2 to 3rem, lead to 1.7rem, body to 1.375rem, quotes to 1.65rem, the 01/02/03 step numbers to 6rem; the kicker, h3, fine print and the buttons go up one notch each. The policy pages share `.wrap` and `.measure`, so they widen by the same amount and their type follows.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 11 files / 205 tests, `pnpm --filter website test:e2e` 49 passed, including the typewriter layout tests at 360, 390, 430 and 1280 and the phone-width no-sideways-scroll tests. Screenshots at 1440 (full page) and 1920 (top), read before attaching.

## Anything a reviewer should look at twice

The floors are untouched on purpose: the h1 at 360px is still 2.2rem, which is what keeps «Fractional CTO,» on one line in the hero. The gain is all in the slopes and the caps, so a laptop reads larger and a phone reads the same.

## Screenshots

**1. The landing at 1440, before (main after #58) and after**
![The landing before and after](https://github.com/user-attachments/assets/66f922f0-0e8a-45b5-a728-364781c8f54e)

Linear: ORB-149.
