### PR TITLE
style(website): the hero lead is the deck's one line

### DIFF
--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -50,12 +50,7 @@
           <div class="box">
             <p class="kicker">Orbiters</p>
             <h1 class="measure-tight"><span class="sr-only">Developer, AI engineer, CTO,</span><span aria-hidden="true"><span class="role" data-roles="Developer|AI engineer|CTO|Fractional CTO|Tech lead|Freelance">Developer</span>,</span><br />ma non da soli.</h1>
-            <p class="lead measure">
-              La community di chi fa software in proprio: developer, AI engineer, CTO e fractional
-              CTO. L'abbiamo costruita noi, che lo facciamo da anni. Progetti che arrivano da
-              aziende vere, persone che ci sono passate, e gli strumenti che ci siamo costruiti per
-              fatturare e farci pagare. Tu porti quello che sai fare: al resto pensiamo insieme.
-            </p>
+            <p class="lead measure">La community di chi fa software in proprio in Italia.</p>
             <p class="actions">
               <a class="cta" href="/hub/freelance">Entra come talento</a>
               <a class="cta secondary" href="/hub/aziende">Cerchi persone?</a>

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -113,9 +113,10 @@ describe('index.html', () => {
     const perk = page.indexOf('PigroCRM, il perk')
     expect(claim).toBeGreaterThan(0)
     expect(perk).toBeGreaterThan(claim)
-    // The lead names the reader in the words of docs/design/positioning.md (ORB-24).
+    // The hero lead is the one line the pitch deck's cover uses (Ivan, ORB-150); the
+    // roles by name moved to the description and the steps, checked further down.
     expect(page.replace(/\s+/g, ' ')).toContain(
-      'La community di chi fa software in proprio: developer, AI engineer, CTO e fractional CTO.',
+      '<p class="lead measure">La community di chi fa software in proprio in Italia.</p>',
     )
     expect(page).toContain('Gratis per chi è in community.')
   })


### PR DESCRIPTION
## What this changes

Ivan liked the long hero lead but wants the hero to carry the one line the pitch deck's cover uses: «La community di chi fa software in proprio in Italia.». The four-sentence lead goes; the roles by name (developer, AI engineer, CTO, fractional CTO) stay in the meta description and in the steps, which is where `landing-pages.test.ts` still finds them. The test that pinned the old lead now pins the new line.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 11 files / 205 tests, `pnpm --filter website test:e2e` 49 passed (the typewriter layout tests measure the lead's top, so they exercised the new one). Screenshot of the hero at 1440, read before attaching.

## Screenshots

**1. The hero, before (1920, main) and after (1440, this branch)**
![The hero before and after](https://github.com/user-attachments/assets/accaeded-5d14-476b-ab9d-0f7cbc2e00c3)

Linear: ORB-150.
