### PR TITLE
style(website): the hero fills the first screen

### DIFF
--- a/projects/website/src/landing.css
+++ b/projects/website/src/landing.css
@@ -169,6 +169,26 @@ footer .quiet-link:hover {
    (ORB-146; ORB-144 had set it to 0 when the section below still carried the gap). */
 .hero {
   padding-block: clamp(1rem, 2.5vw, 2rem) clamp(3rem, 6vw, 5rem);
+  /* The first screen is the box on the field (ORB-152): the hero is at least the
+     viewport minus the header, the box grows to fill it and centres its rows, so the
+     first dark band starts under the fold instead of peeking in beneath the box.
+     `svh` is the small viewport, the one a phone's browser chrome leaves; `vh` is the
+     fallback where it is unknown. Never a cap: taller content still grows the box. */
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 5.5rem);
+  min-height: calc(100svh - 5.5rem);
+}
+
+.hero .wrap {
+  display: flex;
+  flex: 1;
+  width: 100%;
+}
+
+.hero .box {
+  flex: 1;
+  align-content: center;
 }
 
 /* --- The field: the same one the community page on `/` has. Fixed, behind everything


### PR DESCRIPTION
## What this changes

On a ~1000px laptop window the hero box ended two thirds of the way down and the first dark band peeked in beneath it. The hero is now at least the viewport minus the header (`100svh`, `vh` fallback), the box grows to fill it (`flex: 1`) and centres its rows (`align-content: center` on the grid), so the first screen is the box on the field and the band starts under the fold. Nothing is capped: on a phone, where the content is taller than the screen, the box grows as before.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 11 files / 205 tests, `pnpm --filter website test:e2e` 49 passed (the typewriter layout tests measure the hero's tops at four widths, and the cookie-notice geometry test reads the hero box; both green). On the preview at 1000×650 the box's bottom is above the fold and the band's top below it; the same at 1440×900. Screenshots at 1000, 1440 and 390, read before attaching.

## Screenshots

**1. The hero: before (1920, main) and after (1440, this branch)**
![The hero before and after](https://github.com/user-attachments/assets/98f3f2c8-6107-42e7-b0e1-4b09001aecab)

Linear: ORB-152.
