### PR TITLE
feat(hub): the wizard says why to finish when sent for the guide

### DIFF
--- a/projects/hub/apps/web/src/pages/FreelancerWizard.test.tsx
+++ b/projects/hub/apps/web/src/pages/FreelancerWizard.test.tsx
@@ -9,7 +9,7 @@ import {
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { FREELANCER_STEPS, FreelancerWizard } from './FreelancerWizard'
+import { FREELANCER_STEPS, FreelancerWizard, readPerk } from './FreelancerWizard'
 
 /** The wizard mounted on its own little router, so `navigate` has somewhere to go. */
 function mount(path = '/freelance?utm_source=linkedin') {
@@ -61,7 +61,31 @@ describe('the freelancer steps', () => {
   })
 })
 
+describe('readPerk', () => {
+  it('reads the guide off the URL the landing\'s button carries, and nothing else', () => {
+    expect(readPerk('?perk=guida')).toBe('guida')
+    expect(readPerk('?utm_source=linkedin&perk=guida')).toBe('guida')
+    expect(readPerk('?perk=crm')).toBeNull()
+    expect(readPerk('')).toBeNull()
+  })
+})
+
 describe('FreelancerWizard', () => {
+  it('says why to finish when the URL says the person came for the guide (ORB-154)', async () => {
+    mount('/freelance?perk=guida')
+    const note = await screen.findByRole('note', { name: 'Perché completare l’iscrizione' })
+    expect(note).toHaveTextContent('Completa l’iscrizione per scaricare la guida per diventare un freelance tech.')
+    expect(note).toHaveTextContent('lo trovi nella tua area appena sei dentro')
+    // The wizard itself is untouched: same heading, same first question.
+    expect(screen.getByRole('heading', { level: 1, name: 'Entra in Orbiters' })).toBeInTheDocument()
+  })
+
+  it('shows no such note to whoever arrives without the key', async () => {
+    mount()
+    await screen.findByRole('heading', { level: 1, name: 'Entra in Orbiters' })
+    expect(screen.queryByRole('note')).not.toBeInTheDocument()
+  })
+
   it('walks the eight questions, posts the multipart body with the UTM and lands on grazie', async () => {
     const user = userEvent.setup({ applyAccept: false })
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(

--- a/projects/hub/apps/web/src/pages/FreelancerWizard.tsx
+++ b/projects/hub/apps/web/src/pages/FreelancerWizard.tsx
@@ -182,11 +182,40 @@ export const FREELANCER_STEPS: Step<FreelancerApplication>[] = [
   },
 ]
 
+/** The perk the URL says the person came for, if any: `?perk=guida` is what the
+ *  landing's «Entra e scaricala» button carries (ORB-154), so the wizard can say why it
+ *  is worth finishing. Anything else is nobody's business and reads as no perk. */
+export function readPerk(search: string): 'guida' | null {
+  return new URLSearchParams(search).get('perk') === 'guida' ? 'guida' : null
+}
+
+/** One line above the wizard for whoever came for the guide: what finishing buys them,
+ *  and where the file will be. The site's own shapes -- an ink line, a stepped shadow,
+ *  the gold the deck uses for its second accent -- inside the panel, over the progress
+ *  bar, so it reads as part of this page and not as a notice dropped on it. */
+function GuideBanner() {
+  return (
+    <aside
+      role="note"
+      aria-label="Perché completare l’iscrizione"
+      className="mx-auto mb-8 w-full max-w-2xl border-(length:--landing-border-width) bg-(--color-royal-gold) px-4 py-3 text-(--landing-ink) shadow-sm"
+    >
+      <p className="font-medium">
+        Completa l’iscrizione per scaricare la guida per diventare un freelance tech.
+      </p>
+      <p className="mt-1 text-sm">
+        È un PDF: lo trovi nella tua area appena sei dentro. Gratis, come PigroCRM.
+      </p>
+    </aside>
+  )
+}
+
 export function FreelancerWizard() {
   const navigate = useNavigate()
   // The URL's own query string, from the router rather than `window`: the attribution
   // is whatever this page was opened with.
   const searchStr = useLocation({ select: (location) => location.searchStr })
+  const perk = readPerk(searchStr)
   const [value, setValue] = useState<FreelancerApplication>(EMPTY)
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<{ message: string; step?: string } | null>(null)
@@ -209,15 +238,18 @@ export function FreelancerWizard() {
   }
 
   return (
-    <Wizard
-      title="Entra in Orbiters"
-      steps={FREELANCER_STEPS}
-      value={value}
-      set={(patch) => setValue((current) => ({ ...current, ...patch }))}
-      onSubmit={() => void submit()}
-      submitting={submitting}
-      submitError={submitError}
-      submitLabel="Invia la candidatura"
-    />
+    <>
+      {perk === 'guida' && <GuideBanner />}
+      <Wizard
+        title="Entra in Orbiters"
+        steps={FREELANCER_STEPS}
+        value={value}
+        set={(patch) => setValue((current) => ({ ...current, ...patch }))}
+        onSubmit={() => void submit()}
+        submitting={submitting}
+        submitError={submitError}
+        submitLabel="Invia la candidatura"
+      />
+    </>
   )
 }

--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -248,7 +248,7 @@
             richieste che arrivano a tutti. Si legge in venti minuti.
           </p>
           <p class="actions" data-reveal style="--d: 0.4s">
-            <a class="cta" href="/hub/freelance">Entra e scaricala</a>
+            <a class="cta" href="/hub/freelance?perk=guida">Entra e scaricala</a>
           </p>
           <p class="fine measure" data-reveal style="--d: 0.5s">
             PDF, la scarichi dalla tua area appena sei dentro. Gratis, come PigroCRM.


### PR DESCRIPTION
## What this changes

Ivan asked for the landing's guide button to tell the wizard why the person came, so the wizard can say what finishing buys them. «Entra e scaricala» (the second perk band on `/`) now links `/hub/freelance?perk=guida`. `FreelancerWizard` reads that one key off the URL (`readPerk`, exported and tested) and, when it is there, renders a note above the wizard: «Completa l’iscrizione per scaricare la guida per diventare un freelance tech.» with «È un PDF: lo trovi nella tua area appena sei dentro. Gratis, come PigroCRM.» underneath. Without the key nothing changes. The note is an `<aside role="note">` with an accessible name, drawn in the site's own shapes (the `.site` tokens: 2px ink line, stepped shadow) on the deck's gold, inside the panel above the progress bar. Nothing is stored: the key is read at render and never sent to the API (the UTM reader is untouched).

## How I verified it

Hub web, in the branch worktree: `pnpm --filter hub lint` clean, `pnpm --filter hub test` 15 files / 64 tests (two new: the note appears with `?perk=guida` and the wizard's heading is still there; no note without the key; `readPerk` accepts only `guida`), `pnpm --filter hub build` green. Website: `pnpm --filter website lint` clean, `pnpm --filter website test` 206 tests, `pnpm --filter website test:e2e` 51 passed (the link check resolves `/hub/freelance?perk=guida` as the hub's, query dropped). On the hub preview `/hub/freelance` renders no note and `/hub/freelance?perk=guida` renders it, read off the DOM and by screenshot.

## Anything a reviewer should look at twice

The key is `perk=guida`, chosen so a second perk can reuse the shape (`?perk=crm`) without a second parameter; today only `guida` is recognised and anything else reads as no perk. The thanks page after submit does not carry the key: the note already says where the file is, and the thanks page links the member area for everyone.

## Screenshots

**1. `/hub/freelance` at 1440: before (no key) and after (`?perk=guida`)**
![The freelancer wizard with and without the guide note](https://github.com/user-attachments/assets/4bdfe1db-bb1c-457b-a2ac-1b31843c6199)

Linear: ORB-154.
