### PR TITLE
feat(hub): the admin area counts the guide's downloads

### DIFF
--- a/projects/hub/apps/api/src/orbiters_api/routers/admin.py
+++ b/projects/hub/apps/api/src/orbiters_api/routers/admin.py
@@ -21,6 +21,7 @@ from orbiters_core.comments import CommentService
 from orbiters_core.companies import CompanyService
 from orbiters_core.freelancers import FreelancerService
 from orbiters_core.models import NAME_MAX_LENGTH
+from orbiters_core.perks import PerkService
 from orbiters_core.schemas import (
     CommentCreate,
     CommentRead,
@@ -28,6 +29,7 @@ from orbiters_core.schemas import (
     CompanyRead,
     FreelancerList,
     FreelancerRead,
+    GuideStats,
     SignupList,
     StatusChange,
 )
@@ -196,6 +198,14 @@ def move_company(
     _: AdminDep, session: SessionDep, company_id: UUID, change: StatusChange
 ) -> CompanyRead:
     return CompanyService(session).set_status(company_id, change)
+
+
+@router.get("/perks/guida", response_model=GuideStats)
+def guide_stats(_: AdminDep, session: SessionDep) -> GuideStats:
+    """How the guide is doing (ORB-156): every download, the distinct members behind
+    them, the last week, and the latest ones by name. Read-only; the rows are written by
+    `GET /me/guida` and by nothing else."""
+    return PerkService(session).guide_stats()
 
 
 @router.get("/signups", response_model=SignupList)

--- a/projects/hub/apps/api/src/orbiters_api/routers/members.py
+++ b/projects/hub/apps/api/src/orbiters_api/routers/members.py
@@ -32,7 +32,7 @@ from orbiters_api.ratelimit import spend_one
 from orbiters_core.mail import EmailSender, Mail
 from orbiters_core.members import MemberService
 from orbiters_core.models import CV_MAX_BYTES
-from orbiters_core.perks import GUIDE_FILENAME, guide_bytes
+from orbiters_core.perks import GUIDE_FILENAME, PerkService, guide_bytes
 from orbiters_core.schemas import Ack, EnterRequest, LinkRequest, MemberProfile, MemberUpdate
 
 router = APIRouter(prefix="/api/hub", tags=["hub-member"])
@@ -133,14 +133,16 @@ def my_cv(member: MemberDep, session: SessionDep, settings: SettingsDep) -> Resp
 
 
 @router.get("/me/guida")
-def my_guide(member: MemberDep) -> Response:
+def my_guide(member: MemberDep, session: SessionDep) -> Response:
     """The guide, to a member and to nobody else.
 
     `MemberDep` is the whole access rule: the perk of being in the community is that
     this answers at all, so an anonymous caller gets the same 401 as `/me` rather than
     a redirect or a teaser. The file is `orbiters_core`'s own package data, and the
-    member row is not read for anything beyond having resolved.
+    member row is not read for anything beyond having resolved. Since ORB-156 the
+    download is written down first, who and when, for the admin area's counter.
     """
+    PerkService(session).record_guide_download(member.id)
     return perk_response(guide_bytes(), GUIDE_FILENAME)
 
 

--- a/projects/hub/apps/api/tests/test_admin_api.py
+++ b/projects/hub/apps/api/tests/test_admin_api.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import Iterator
+from uuid import UUID
 
 import pytest
 from fastapi.testclient import TestClient
@@ -11,6 +12,7 @@ from sqlalchemy.orm import Session
 from orbiters_api.deps import get_http_call
 from orbiters_core.admin import AdminService
 from orbiters_core.config import Settings, get_settings
+from orbiters_core.perks import PerkService
 
 PDF = b"%PDF-1.7\n1 0 obj<<>>endobj\n%%EOF\n"
 CREDENTIALS = {"email": "ivan@orbiters.it", "password": "una-password-lunga"}
@@ -27,7 +29,14 @@ def admin(api_engine: Engine, api_session: Session) -> Iterator[None]:
     )
     yield
     api_session.rollback()
-    for table in ("comments", "admin_sessions", "admin_users", "freelancers", "companies"):
+    for table in (
+        "guide_downloads",
+        "comments",
+        "admin_sessions",
+        "admin_users",
+        "freelancers",
+        "companies",
+    ):
         api_session.execute(text(f"DELETE FROM {table}"))
     api_session.commit()
 
@@ -56,6 +65,7 @@ def test_without_the_cookie_every_admin_route_is_a_401(client: TestClient, admin
         "/api/hub/signups",
         "/api/hub/admins",
         "/api/hub/pigro/istanze",
+        "/api/hub/perks/guida",
     ):
         assert client.get(path).status_code == 401, path
     refused = client.post(
@@ -64,6 +74,43 @@ def test_without_the_cookie_every_admin_route_is_a_401(client: TestClient, admin
     )
     assert refused.status_code == 401
     assert client.patch(f"/api/hub/admins/{MISSING}", json={"nome": "X"}).status_code == 401
+
+
+def test_the_guide_page_counts_downloads_and_names_who_took_it(
+    client: TestClient, admin: None, api_session: Session
+) -> None:
+    """ORB-156: zero of everything on an empty hub, then the numbers follow the rows.
+    Two people on file, three downloads by one of them: totale 3, membri 1 of 2, all
+    three in the last week, the latest first, each with the member's name."""
+    assert client.post("/api/hub/auth/login", json=CREDENTIALS).status_code == 200
+    empty = client.get("/api/hub/perks/guida")
+    assert empty.status_code == 200
+    assert empty.json() == {
+        "totale": 0,
+        "membri": 0,
+        "membri_totali": 0,
+        "ultimi_7_giorni": 0,
+        "recenti": [],
+    }
+
+    _apply(client, "ada@studio.it")
+    _apply(client, "bob@studio.it")
+    listed = client.get("/api/hub/freelancers").json()["items"]
+    people = {item["email"]: item["id"] for item in listed}
+    perks = PerkService(api_session)
+    for _ in range(3):
+        perks.record_guide_download(UUID(people["ada@studio.it"]))
+
+    stats = client.get("/api/hub/perks/guida").json()
+    assert (stats["totale"], stats["membri"], stats["membri_totali"]) == (3, 1, 2)
+    assert stats["ultimi_7_giorni"] == 3
+    assert len(stats["recenti"]) == 3
+    latest = stats["recenti"][0]
+    assert (latest["nome"], latest["cognome"]) == ("Ada", "Lovelace")
+    assert latest["email"] == "ada@studio.it"
+    assert latest["freelancer_id"] == people["ada@studio.it"]
+    moments = [item["downloaded_at"] for item in stats["recenti"]]
+    assert moments == sorted(moments, reverse=True)
 
 
 def test_login_sets_a_secure_httponly_cookie_and_the_lists_open(

--- a/projects/hub/apps/api/tests/test_member_api.py
+++ b/projects/hub/apps/api/tests/test_member_api.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 import httpx
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import text
+from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 
 from orbiters_api.deps import get_sender
@@ -15,6 +15,7 @@ from orbiters_api.ratelimit import reset_rate_limit
 from orbiters_core.admin import AdminService
 from orbiters_core.config import Settings
 from orbiters_core.mail import Mail, RecordingSender
+from orbiters_core.models import GuideDownload
 from orbiters_core.perks import GUIDE_PATH
 
 PDF = b"%PDF-1.7\n1 0 obj<<>>endobj\n%%EOF\n"
@@ -40,6 +41,7 @@ def clean(api_session: Session) -> Iterator[None]:
     yield
     api_session.rollback()
     for table in (
+        "guide_downloads",
         "member_sessions",
         "magic_link_tokens",
         "comments",
@@ -187,6 +189,27 @@ def test_the_guide_is_a_perk_of_the_session_and_not_a_public_file(
 
     client.post("/api/hub/me/logout")
     assert client.get("/api/hub/me/guida").status_code == 401
+
+
+def test_every_download_of_the_guide_is_written_down_with_the_member_behind_it(
+    client: TestClient, sender: RecordingSender, api_session: Session, clean: None
+) -> None:
+    """ORB-156: the admin's counter is a row per download, who and when. Two downloads
+    by the same member are two rows for one person, an anonymous 401 writes nothing,
+    and the bytes still arrive: recording is a side of the route, not a gate."""
+    _apply(client, "ada@studio.it")
+    assert client.get("/api/hub/me/guida").status_code == 401
+    assert api_session.scalar(select(func.count()).select_from(GuideDownload)) == 0
+
+    profile, _ = _enter(client, sender, "ada@studio.it")
+    for _ in range(2):
+        answer = client.get("/api/hub/me/guida")
+        assert answer.status_code == 200 and answer.content == GUIDE_PATH.read_bytes()
+    api_session.expire_all()
+    rows = api_session.scalars(select(GuideDownload)).all()
+    assert len(rows) == 2
+    assert {str(row.freelancer_id) for row in rows} == {profile["id"]}
+    assert all(row.downloaded_at is not None for row in rows)
 
 
 def test_a_wrong_token_is_a_401_and_a_malformed_one_a_422(

--- a/projects/hub/apps/mcp/src/orbiters_mcp/server.py
+++ b/projects/hub/apps/mcp/src/orbiters_mcp/server.py
@@ -24,6 +24,7 @@ from orbiters_core.comments import CommentService
 from orbiters_core.companies import CompanyService
 from orbiters_core.errors import DomainError
 from orbiters_core.freelancers import FreelancerService
+from orbiters_core.perks import PerkService
 from orbiters_core.schemas import StatusChange
 from orbiters_core.service import LIST_LIMIT_DEFAULT, SignupService
 
@@ -131,6 +132,14 @@ def build_server(factory: SessionFactory) -> MCPServer:
                 "company", UUID(company_id), testo, autore or DEFAULT_AUTHOR
             )
         )
+
+    @mcp.tool()
+    def guide_stats() -> dict[str, Any]:
+        """Quanti hanno scaricato la guida ai primi passi da freelance: `totale` i
+        download, `membri` le persone diverse dietro, `membri_totali` quante potevano,
+        `ultimi_7_giorni` i download dell'ultima settimana e `recenti` gli ultimi con
+        nome ed email. Solo lettura."""
+        return _run(lambda s: PerkService(s).guide_stats())
 
     def _run(call: Callable[[Session], BaseModel]) -> dict[str, Any]:
         """One session per call, closed whatever happened, and a domain error rendered

--- a/projects/hub/apps/mcp/tests/test_tools.py
+++ b/projects/hub/apps/mcp/tests/test_tools.py
@@ -59,6 +59,24 @@ async def test_no_tool_subscribes_or_applies_on_somebody_elses_behalf(
 PDF = b"%PDF-1.7\n1 0 obj<<>>endobj\n%%EOF\n"
 
 
+async def test_the_guide_stats_are_zero_on_an_empty_hub_and_read_only(
+    factory: sessionmaker[Session],
+) -> None:
+    """ORB-156: the counter the admin area shows is one tool away for an agent too."""
+    async with Client(build_server(factory)) as client:
+        result = await client.call_tool("guide_stats", {})
+        names = {tool.name for tool in (await client.list_tools()).tools}
+    body = _payload(result)
+    assert body == {
+        "totale": 0,
+        "membri": 0,
+        "membri_totali": 0,
+        "ultimi_7_giorni": 0,
+        "recenti": [],
+    }
+    assert "record_guide_download" not in names
+
+
 async def test_the_admin_tools_read_and_move_a_candidate_without_the_cv(
     factory: sessionmaker[Session],
 ) -> None:
@@ -119,6 +137,7 @@ async def test_the_admin_tools_read_and_move_a_candidate_without_the_cv(
             "get_company",
             "set_company_status",
             "add_company_comment",
+            "guide_stats",
         }
     _wipe(factory)
 

--- a/projects/hub/apps/web/src/lib/api.ts
+++ b/projects/hub/apps/web/src/lib/api.ts
@@ -187,6 +187,24 @@ export interface PigroSpace {
   membro: { id: string; nome: string; cognome: string } | null
 }
 
+/** The guide's numbers for the admin area (ORB-156), as `GET /api/hub/perks/guida` answers. */
+export interface GuideStats {
+  totale: number
+  membri: number
+  membri_totali: number
+  ultimi_7_giorni: number
+  recenti: GuideDownload[]
+}
+
+export interface GuideDownload {
+  id: string
+  freelancer_id: string
+  nome: string
+  cognome: string
+  email: string
+  downloaded_at: string
+}
+
 export interface Signup {
   id: string
   email: string
@@ -229,6 +247,8 @@ export const admin = {
   /** PigroCRM's spaces, read by the hub's API with the token it holds: the browser
    *  never talks to the CRM (ORB-142). A 503 carries the sentence the page shows. */
   pigroSpaces: () => request<{ totale: number; items: PigroSpace[] }>('/api/hub/pigro/istanze'),
+  /** How the guide is doing: downloads, the members behind them, the latest (ORB-156). */
+  guideStats: () => request<GuideStats>('/api/hub/perks/guida'),
   /** Who reads this area, oldest first, and one more of them (ORB-123). */
   admins: () => request<Admin[]>('/api/hub/admins'),
   createAdmin: (data: AdminCreate) => request<Admin>('/api/hub/admins', json(data)),

--- a/projects/hub/apps/web/src/pages/admin/AdminLayout.tsx
+++ b/projects/hub/apps/web/src/pages/admin/AdminLayout.tsx
@@ -1,5 +1,5 @@
 import { Link, Outlet, useNavigate } from '@tanstack/react-router'
-import { Boxes, Briefcase, LogOut, Mail, ShieldCheck, UserRound } from 'lucide-react'
+import { BookOpen, Boxes, Briefcase, LogOut, Mail, ShieldCheck, UserRound } from 'lucide-react'
 import { useEffect } from 'react'
 import { BrandMark } from '@/components/BrandMark'
 import { Button } from '@/components/ui/button'
@@ -10,6 +10,7 @@ const NAV = [
   { to: '/admin/aziende', label: 'Aziende', icon: Briefcase },
   { to: '/admin/iscrizioni', label: 'Iscrizioni', icon: Mail },
   { to: '/admin/pigro', label: 'Istanze Pigro', icon: Boxes },
+  { to: '/admin/guida', label: 'La guida', icon: BookOpen },
   { to: '/admin/amministratori', label: 'Amministratori', icon: ShieldCheck },
 ] as const
 

--- a/projects/hub/apps/web/src/pages/admin/Guida.test.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Guida.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AdminGuida } from './Guida'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, params, children, ...rest }: { to: string; params?: Record<string, string>; children: React.ReactNode }) => (
+    <a href={params ? to.replace('$id', params.id!) : to} {...rest}>{children}</a>
+  ),
+}))
+
+function answer(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+function mount() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <AdminGuida />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('the La guida page', () => {
+  it('shows the three numbers and the latest downloads, each naming the member (ORB-156)', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      answer(200, {
+        totale: 3,
+        membri: 1,
+        membri_totali: 2,
+        ultimi_7_giorni: 3,
+        recenti: [
+          { id: 'd-1', freelancer_id: 'f-1', nome: 'Ada', cognome: 'Lovelace', email: 'ada@studio.it', downloaded_at: '2026-09-11T09:00:00Z' },
+        ],
+      }),
+    )
+    mount()
+    const who = await screen.findByRole('link', { name: 'Ada Lovelace' })
+    expect(who).toHaveAttribute('href', '/admin/freelance/f-1')
+    expect(spy.mock.calls[0]![0]).toBe('/api/hub/perks/guida')
+    expect(screen.getByRole('heading', { name: /La guida/ })).toHaveTextContent('3')
+    expect(screen.getByText('Membri che l’hanno scaricata').nextElementSibling).toHaveTextContent('1su 2')
+    expect(screen.getByText('Ultimi 7 giorni').nextElementSibling).toHaveTextContent('3')
+    expect(screen.getByText('ada@studio.it')).toBeInTheDocument()
+  })
+
+  it('says when nobody has taken it yet', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      answer(200, { totale: 0, membri: 0, membri_totali: 4, ultimi_7_giorni: 0, recenti: [] }),
+    )
+    mount()
+    await screen.findByText('Nessun download ancora.')
+    expect(screen.getByText('Membri che l’hanno scaricata').nextElementSibling).toHaveTextContent('0su 4')
+  })
+
+  it('says when the numbers cannot be read', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(500, { detail: 'boom' }))
+    mount()
+    await screen.findByText('Non riesco a leggere i download.')
+  })
+})

--- a/projects/hub/apps/web/src/pages/admin/Guida.tsx
+++ b/projects/hub/apps/web/src/pages/admin/Guida.tsx
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
+import { admin } from '@/lib/api'
+import { formatDateTime } from '@/lib/format'
+import { Empty, Header } from './lists'
+
+/**
+ * How the guide is doing (ORB-156): every download the members' route wrote down, the
+ * distinct people behind them against everybody on file, the last week, and the latest
+ * ones by name. Read-only: the rows are written by `GET /api/hub/me/guida` when a member
+ * takes the file, and by nothing else.
+ */
+export function AdminGuida() {
+  const stats = useQuery({ queryKey: ['guide-stats'], queryFn: () => admin.guideStats() })
+  return (
+    <>
+      <Header title="La guida" count={stats.data?.totale} />
+      {stats.isError ? (
+        <Empty>Non riesco a leggere i download.</Empty>
+      ) : stats.isPending ? (
+        <Empty>Caricamento…</Empty>
+      ) : (
+        <>
+          <dl className="grid gap-4 border-b px-6 py-5 sm:grid-cols-3">
+            <Figure label="Download" value={stats.data.totale} />
+            <Figure
+              label="Membri che l’hanno scaricata"
+              value={stats.data.membri}
+              note={`su ${stats.data.membri_totali}`}
+            />
+            <Figure label="Ultimi 7 giorni" value={stats.data.ultimi_7_giorni} />
+          </dl>
+          {stats.data.recenti.length === 0 ? (
+            <Empty>Nessun download ancora.</Empty>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="text-left text-xs text-muted-foreground">
+                <tr className="border-b">
+                  <th className="px-6 py-2 font-medium">Chi</th>
+                  <th className="px-6 py-2 text-right font-medium">Quando</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.data.recenti.map((download) => (
+                  <tr key={download.id} className="border-b last:border-0 hover:bg-muted">
+                    <td className="px-6 py-2.5">
+                      <Link
+                        to="/admin/freelance/$id"
+                        params={{ id: download.freelancer_id }}
+                        className="font-medium hover:underline"
+                      >
+                        {download.nome} {download.cognome}
+                      </Link>
+                      <p className="text-xs text-muted-foreground">{download.email}</p>
+                    </td>
+                    <td className="px-6 py-2.5 text-right text-muted-foreground">
+                      {formatDateTime(download.downloaded_at)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </>
+  )
+}
+
+function Figure({ label, value, note }: { label: string; value: number; note?: string }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-1 text-3xl font-semibold tracking-tight">
+        {value}
+        {note && <span className="ml-2 text-base font-normal text-muted-foreground">{note}</span>}
+      </dd>
+    </div>
+  )
+}

--- a/projects/hub/apps/web/src/router.tsx
+++ b/projects/hub/apps/web/src/router.tsx
@@ -8,6 +8,7 @@ import { Shell } from '@/components/Shell'
 import { Chooser } from '@/pages/Chooser'
 import { CompanyWizard } from '@/pages/CompanyWizard'
 import { FreelancerWizard } from '@/pages/FreelancerWizard'
+import { AdminGuida } from '@/pages/admin/Guida'
 import { Thanks } from '@/pages/Thanks'
 import { AdminLayout } from '@/pages/admin/AdminLayout'
 import { AdminAdmins } from '@/pages/admin/Admins'
@@ -111,6 +112,7 @@ const adminIscrizioni = createRoute({
   component: AdminSignups,
 })
 const adminPigro = createRoute({ getParentRoute: () => adminArea, path: '/pigro', component: AdminPigro })
+const adminGuida = createRoute({ getParentRoute: () => adminArea, path: '/guida', component: AdminGuida })
 const adminAmministratori = createRoute({
   getParentRoute: () => adminArea,
   path: '/amministratori',
@@ -135,6 +137,7 @@ const routeTree = root.addChildren([
     adminAziendeDetail,
     adminIscrizioni,
     adminPigro,
+    adminGuida,
     adminAmministratori,
   ]),
 ])

--- a/projects/hub/packages/core/migrations/versions/0006_guide_downloads.py
+++ b/projects/hub/packages/core/migrations/versions/0006_guide_downloads.py
@@ -1,0 +1,44 @@
+"""guide_downloads: who fetched the guide, and when
+
+Revision ID: 0006
+Revises: 0005
+
+One table, nothing conditional. A row per download of the guide by a member (ORB-156),
+hanging on `freelancers.id` with ON DELETE CASCADE like the member's sessions do (0005).
+The admin area reads it as a counter and a recent list; nothing else writes it.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006"
+down_revision: str | Sequence[str] | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "guide_downloads",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "freelancer_id",
+            sa.Uuid(),
+            sa.ForeignKey("freelancers.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "downloaded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_guide_downloads_freelancer_id", "guide_downloads", ["freelancer_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_guide_downloads_freelancer_id", table_name="guide_downloads")
+    op.drop_table("guide_downloads")

--- a/projects/hub/packages/core/src/orbiters_core/models.py
+++ b/projects/hub/packages/core/src/orbiters_core/models.py
@@ -245,6 +245,23 @@ class MagicLinkToken(Base, PrimaryKeyMixin):
     used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
 
+class GuideDownload(Base, PrimaryKeyMixin):
+    """One row per time a member fetched the guide (ORB-156): who and when, and nothing
+    else. A log rather than a counter on the freelancer, so the admin can read a trend
+    and see who came back for it; nothing about the file itself is stored, since the
+    file is package data and the same for everybody. Hangs on the freelancer with
+    `ON DELETE CASCADE`, like their sessions: a deleted person takes their downloads."""
+
+    __tablename__ = "guide_downloads"
+
+    freelancer_id: Mapped[UUID] = mapped_column(
+        ForeignKey("freelancers.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    downloaded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
 class MemberSession(Base, PrimaryKeyMixin):
     """The admin session's shape, for a freelancer: opaque cookie, hashed at rest, sliding
     expiry, revoked by deleting the row. A second table and a second cookie rather than

--- a/projects/hub/packages/core/src/orbiters_core/perks.py
+++ b/projects/hub/packages/core/src/orbiters_core/perks.py
@@ -11,7 +11,15 @@ member session: a perk of being in the community, not a public download (Lorenzo
 2026-09-10).
 """
 
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from orbiters_core.models import Freelancer, GuideDownload
+from orbiters_core.schemas import GuideDownloadRead, GuideStats
 
 PERKS_DIR = Path(__file__).resolve().parent / "perks"
 
@@ -24,3 +32,61 @@ def guide_bytes() -> bytes:
     off local disk, and a module-level cache would keep a stale copy alive in a process
     that outlives a deploy of new content."""
     return GUIDE_PATH.read_bytes()
+
+
+RECENT_DOWNLOADS = 20
+
+
+class PerkService:
+    """What the hub remembers about a perk being taken (ORB-156): a row per download
+    of the guide, and the numbers the admin area reads off those rows. Nothing here
+    decides who may download; `MemberDep` does, before the route calls `record`."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def record_guide_download(self, freelancer_id: UUID) -> None:
+        """One row, committed on its own: the download is a fact whether or not the
+        bytes then reach the browser, and a failed write must not withhold the file."""
+        self.session.add(GuideDownload(freelancer_id=freelancer_id))
+        self.session.commit()
+
+    def guide_stats(self, now: datetime | None = None) -> GuideStats:
+        moment = now or datetime.now(UTC)
+        week_ago = moment - timedelta(days=7)
+        totale = self.session.scalar(select(func.count()).select_from(GuideDownload)) or 0
+        membri = (
+            self.session.scalar(select(func.count(func.distinct(GuideDownload.freelancer_id)))) or 0
+        )
+        membri_totali = self.session.scalar(select(func.count()).select_from(Freelancer)) or 0
+        ultimi = (
+            self.session.scalar(
+                select(func.count())
+                .select_from(GuideDownload)
+                .where(GuideDownload.downloaded_at >= week_ago)
+            )
+            or 0
+        )
+        rows = self.session.execute(
+            select(GuideDownload, Freelancer)
+            .join(Freelancer, Freelancer.id == GuideDownload.freelancer_id)
+            .order_by(GuideDownload.downloaded_at.desc(), GuideDownload.id.desc())
+            .limit(RECENT_DOWNLOADS)
+        ).all()
+        return GuideStats(
+            totale=totale,
+            membri=membri,
+            membri_totali=membri_totali,
+            ultimi_7_giorni=ultimi,
+            recenti=[
+                GuideDownloadRead(
+                    id=download.id,
+                    freelancer_id=download.freelancer_id,
+                    nome=person.nome,
+                    cognome=person.cognome,
+                    email=person.email,
+                    downloaded_at=download.downloaded_at,
+                )
+                for download, person in rows
+            ],
+        )

--- a/projects/hub/packages/core/src/orbiters_core/schemas.py
+++ b/projects/hub/packages/core/src/orbiters_core/schemas.py
@@ -465,6 +465,30 @@ class StatusChange(BaseModel):
     note: SafeStr | None = Field(default=None, max_length=PROGETTO_MAX_LENGTH)
 
 
+class GuideDownloadRead(BaseModel):
+    """One download, with the member's name for the admin's list."""
+
+    id: UUID
+    freelancer_id: UUID
+    nome: str
+    cognome: str
+    email: str
+    downloaded_at: datetime
+
+
+class GuideStats(BaseModel):
+    """The guide's numbers for the admin area (ORB-156). `totale` counts every download,
+    `membri` the distinct people behind them, `membri_totali` everybody who could have
+    (the freelancers on file), `ultimi_7_giorni` the downloads of the last week, and
+    `recenti` the latest ones, newest first, with a name each."""
+
+    totale: int
+    membri: int
+    membri_totali: int
+    ultimi_7_giorni: int
+    recenti: list[GuideDownloadRead]
+
+
 class CvFile(BaseModel):
     """The bytes and the two headers a download needs."""
 


### PR DESCRIPTION
## What this changes

Ivan asked for a counter of how many people have downloaded the guide, in a section of the admin area of its own. Until now `GET /api/hub/me/guida` streamed the PDF and remembered nothing. Now:

- **Every download is a row.** `guide_downloads` (who, when), written by the member's route before the bytes go out and by nothing else. A log rather than a counter on the freelancer, so the admin reads a trend and sees who came back for it. `ON DELETE CASCADE` on the freelancer, like their sessions.
- **The numbers.** `PerkService.guide_stats()` answers `totale` (every download), `membri` (distinct people), `membri_totali` (everybody on file, so the second reads as «3 su 58»), `ultimi_7_giorni`, and `recenti` (the latest twenty, newest first, with a name each).
- **«La guida» in the admin area**, between «Istanze Pigro» and «Amministratori»: three figures and the list, each name a link to the member's card, «Nessun download ancora.» when empty, a sentence when the API cannot be read.

## How I verified it

In the branch worktree, against a testcontainers Postgres: `uv run pytest projects/hub/packages/core/tests projects/hub/apps/api/tests projects/hub/apps/mcp/tests` 181 passed (three new: the member route writes one row per download and none on a 401; the admin route is a 401 without the cookie and answers zeros then the right numbers on three downloads by one of two members, newest first; the MCP tool answers zeros and there is no write tool); `test_the_migrations_produce_exactly_the_models_schema` holds with 0006, so the model and the migration agree. `ruff check` and `ruff format --check` clean. Hub web: `pnpm --filter hub lint` clean, `pnpm --filter hub test` 16 files / 67 tests (three new for the page), `pnpm --filter hub build` green. Then the real thing: a local Postgres, migrated to 0006, the API on 8084, the dev server on 5180, a local admin; the page read «La guida 0» with «Nessun download ancora.», then, after three members and four recorded downloads (one twelve days old), «4 · 3 su 3 · 3» with the four rows newest first and the older one dated 30 ago. Screenshots of both states, read before attaching.

## Migrations

`0006_guide_downloads`, revises 0005: one new table, `guide_downloads(id uuid pk, freelancer_id uuid fk freelancers.id on delete cascade, downloaded_at timestamptz default now())` with an index on `freelancer_id`. Nothing conditional: the table never existed in production. `compare_metadata` in `test_migrations.py` reports no difference between the migrated schema and the models. The API runs `upgrade_to_head` on start, so the tag's deploy applies it.

## API changes

- `GET /api/hub/me/guida` (member): unchanged response; now records a `guide_downloads` row before answering.
- `GET /api/hub/perks/guida` (admin, new): `{ totale, membri, membri_totali, ultimi_7_giorni, recenti: [{ id, freelancer_id, nome, cognome, email, downloaded_at }] }`, 401 without the admin cookie. `projects/hub/apps/web/src/lib/api.ts` gains `admin.guideStats()` and the two types.

## MCP surface

`guide_stats` added to `projects/hub/apps/mcp`, read-only, backed by `PerkService.guide_stats`. `tests/test_tools.py`: the pinned set of tool names gains it, and a new test asserts the zeros on an empty hub and that no `record_guide_download` tool exists.

## Anything a reviewer should look at twice

- The recording commits on its own before the bytes are sent; a failed write would raise and withhold the file. I kept it that way rather than swallowing the error, because a database that refuses a one-row insert is not a hub that should be handing out perks either.
- `membri_totali` counts every freelancer on file, whatever their `stato`, so the ratio is «of everyone who could», not «of the active ones».

## Screenshots

**1. `/hub/admin/guida` at 1440: empty, and after four downloads by three members**
![The La guida page, empty and filled](https://github.com/user-attachments/assets/e860c632-1860-4247-baa8-f6ba2995afbe)

Linear: ORB-156.
