### PR TITLE
feat(hub): a welcome mail tells a person their area is open, sent from the CLI

### DIFF
--- a/projects/hub/README.md
+++ b/projects/hub/README.md
@@ -105,6 +105,16 @@ docker compose -p orbiters exec api uv run --no-sync orbiters createadmin --emai
 
 Asks for the password on the terminal, twice, and never takes it as an argument.
 
+Telling the people with a card that their area is open (ORB-157), once, by hand:
+
+```
+docker compose -p orbiters exec api uv run --no-sync orbiters welcome --email you@example.com
+docker compose -p orbiters exec api uv run --no-sync orbiters welcome --all
+```
+
+One line per address with the outcome; that output is the record of the mailing. Needs
+`ORBITERS_RESEND_API_KEY` in the host `.env`, like the magic link.
+
 ## Deploy
 
 `.github/workflows/deploy-hub.yml`: preview on a push to `main` that touched the hub,

--- a/projects/hub/packages/core/src/orbiters_core/cli.py
+++ b/projects/hub/packages/core/src/orbiters_core/cli.py
@@ -6,11 +6,17 @@ import sys
 from collections.abc import Sequence
 from datetime import UTC, datetime
 
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
 from orbiters_core.admin import AdminService
-from orbiters_core.config import get_settings
+from orbiters_core.config import Settings, get_settings
 from orbiters_core.conversions import pixel_from_settings
 from orbiters_core.db import create_engine_from_settings, session_factory
 from orbiters_core.errors import DomainError
+from orbiters_core.mail import EmailSender, sender_from_settings, welcome_mail
+from orbiters_core.models import Freelancer
+from orbiters_core.schemas import FreelancerRead
 
 
 def createadmin(email: str | None, nome: str | None) -> int:
@@ -73,6 +79,53 @@ def conversions_check() -> int:
     return 1
 
 
+def send_welcome(
+    session: Session, settings: Settings, sender: EmailSender, emails: Sequence[str] | None
+) -> list[tuple[str, str]]:
+    """One welcome mail per freelancer card (ORB-157): the addresses given, or every card
+    when `emails` is `None`. Answers one line per address -- `inviata`, `rifiutata dal
+    provider`, or `nessuna scheda` -- which is the whole record of the mailing."""
+    stmt = select(Freelancer).order_by(Freelancer.created_at, Freelancer.id)
+    if emails is not None:
+        wanted = [email.strip().lower() for email in emails]
+        stmt = stmt.where(func.lower(Freelancer.email).in_(wanted))
+    rows = {row.email.lower(): row for row in session.scalars(stmt).all()}
+    targets = [email.strip().lower() for email in emails] if emails is not None else list(rows)
+    link = f"{settings.hub_url.rstrip('/')}/accedi"
+    outcomes: list[tuple[str, str]] = []
+    for email in targets:
+        row = rows.get(email)
+        if row is None:
+            outcomes.append((email, "nessuna scheda"))
+            continue
+        card = FreelancerRead.model_validate(row)
+        mail = welcome_mail(
+            row.email, row.nome, link, completa=card.completa, posizione=row.posizione
+        )
+        outcomes.append((email, "inviata" if sender.send(mail) else "rifiutata dal provider"))
+    return outcomes
+
+
+def welcome(emails: Sequence[str], everyone: bool) -> int:
+    """`orbiters welcome --email a@b.it [--email ...]` or `orbiters welcome --all`."""
+    if everyone == bool(emails):
+        print("Serve --all oppure almeno un --email, non entrambi.", file=sys.stderr)
+        return 2
+    settings = get_settings()
+    sender = sender_from_settings(settings)
+    if sender is None:
+        print("Nessuna chiave per la posta: serve ORBITERS_RESEND_API_KEY.", file=sys.stderr)
+        return 1
+    session = session_factory(create_engine_from_settings(settings))()
+    try:
+        outcomes = send_welcome(session, settings, sender, None if everyone else emails)
+    finally:
+        session.close()
+    for email, outcome in outcomes:
+        print(f"{email}: {outcome}")
+    return 0 if all(outcome == "inviata" for _, outcome in outcomes) else 1
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="orbiters")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -83,11 +136,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     admin = sub.add_parser("createadmin", help="Crea un amministratore dell'area admin")
     admin.add_argument("--email")
     admin.add_argument("--nome")
+    welcome_parser = sub.add_parser(
+        "welcome", help="Manda la mail «la tua area è aperta» a una scheda o a tutte"
+    )
+    welcome_parser.add_argument("--email", action="append", default=[])
+    welcome_parser.add_argument("--all", action="store_true")
     args = parser.parse_args(argv)
     if args.command == "conversions-check":
         return conversions_check()
     if args.command == "createadmin":
         return createadmin(args.email, args.nome)
+    if args.command == "welcome":
+        return welcome(args.email, args.all)
     parser.error(f"comando sconosciuto: {args.command}")
     return 2
 

--- a/projects/hub/packages/core/src/orbiters_core/mail.py
+++ b/projects/hub/packages/core/src/orbiters_core/mail.py
@@ -1,4 +1,4 @@
-"""Outbound mail: a seam, one provider, and the one mail the hub sends today.
+"""Outbound mail: a seam, one provider, and the two mails the hub sends today.
 
 The seam exists so tests never send and production never guesses: `sender_from_settings`
 answers `None` without a key, and the API turns that into a 503 sentence rather than a
@@ -233,4 +233,89 @@ def magic_link_mail(to: str, link: str, minutes: int) -> Mail:
         subject="Il tuo accesso a Orbiters",
         text=text,
         html=_frame("Il tuo accesso a Orbiters", body),
+    )
+
+
+LINKEDIN_PAGE = "https://www.linkedin.com/company/joinorbiters"
+PIGROCRM_LINE = (
+    "PigroCRM, gratis: preventivo, contratto, fattura, ore, con i dati fiscali già giusti."
+)
+GUIDE_LINE = (
+    "La guida «I primi passi da freelance»: venti minuti sulla parte che nessuno spiega "
+    "prima della prima fattura."
+)
+
+
+def welcome_mail(
+    to: str, nome: str, accedi_link: str, *, completa: bool, posizione: str | None
+) -> Mail:
+    """The one-off mail that tells a person their area is open (ORB-157): how to get in
+    (the address, no password), what their card looks like from our side, the two perks
+    that wait behind the login, and the LinkedIn page where the first job posts appear.
+    Same voice and same box as the magic link; `nome` and `posizione` are the person's
+    own words and are escaped wherever they land in the HTML."""
+    if completa:
+        card = (
+            f"La tua scheda è completa: sei {posizione}, e le aziende possono trovarti."
+            if posizione
+            else "La tua scheda è completa: le aziende possono trovarti."
+        )
+    else:
+        found = f" Ti abbiamo segnato come {posizione}." if posizione else ""
+        card = (
+            "Abbiamo preparato la tua scheda con quello che si trova in pubblico su di "
+            f"te.{found} Manca la tua parte: il CV, la tariffa a giornata, come preferisci "
+            "lavorare. Sono le cose che le aziende cercano."
+        )
+    text = (
+        f"Ciao {nome},\n"
+        "\n"
+        "la tua area su Orbiters è aperta. Si entra con la tua email, senza password: ti "
+        "mandiamo un link e sei dentro.\n"
+        "\n"
+        f"{accedi_link}\n"
+        "\n"
+        f"{card}\n"
+        "\n"
+        "Dentro trovi i vantaggi della community, disponibili dopo il login:\n"
+        f"- {PIGROCRM_LINE}\n"
+        f"- {GUIDE_LINE}\n"
+        "\n"
+        "Un'altra cosa: segui la pagina LinkedIn di Orbiters, "
+        f"{LINKEDIN_PAGE}. Oggi pomeriggio esce il post con le prime job post per "
+        "Forward Deployed Engineer.\n"
+        "\n"
+        "Noi di Orbiters\n"
+    )
+    e = html_escape.escape
+    safe_link = e(accedi_link, quote=True)
+    paragraph = 'style="margin:24px 0 0 0;"'
+    small = f'style="margin:24px 0 0 0;font-size:13px;line-height:1.5;color:{INK_QUIET};'
+    body = "\n".join(
+        (
+            f'<p style="margin:0 0 20px 0;">Ciao {e(nome)},</p>',
+            '<p style="margin:0 0 24px 0;">la tua area su Orbiters è aperta. Si entra con la '
+            "tua email, senza password: ti mandiamo un link e sei dentro.</p>",
+            _button(safe_link, "Entra nella tua area"),
+            f'<p {small}word-break:break-all;">'
+            "Se il bottone non si apre, copia questo indirizzo nel browser:<br>"
+            f"{_quiet_link(safe_link, safe_link)}</p>",
+            f"<p {paragraph}>{e(card)}</p>",
+            f"<p {paragraph}>Dentro trovi i vantaggi della community, disponibili dopo il "
+            "login:</p>",
+            '<ul style="margin:8px 0 0 0;padding:0 0 0 22px;">'
+            f'<li style="margin:0 0 8px 0;">{e(PIGROCRM_LINE)}</li>'
+            f"<li>{e(GUIDE_LINE)}</li></ul>",
+            f"<p {paragraph}>Un'altra cosa: segui "
+            f"{_quiet_link(LINKEDIN_PAGE, 'la pagina LinkedIn di Orbiters')}. Oggi "
+            "pomeriggio esce il post con le prime job post per Forward Deployed "
+            "Engineer.</p>",
+            f"<p {paragraph}>Noi di Orbiters</p>",
+        )
+    )
+    return Mail(
+        to=to,
+        subject="La tua area su Orbiters è aperta",
+        text=text,
+        html=_frame("La tua area su Orbiters è aperta", body),
     )

--- a/projects/hub/packages/core/tests/test_mail.py
+++ b/projects/hub/packages/core/tests/test_mail.py
@@ -14,6 +14,7 @@ from orbiters_core.mail import (
     ResendSender,
     magic_link_mail,
     sender_from_settings,
+    welcome_mail,
 )
 
 KEY = "re_non_una_chiave_vera"
@@ -113,3 +114,44 @@ def test_the_magic_link_mail_has_an_html_version_in_the_landings_system() -> Non
     # and it is attribute-safe.
     hostile = magic_link_mail("ada@studio.it", 'https://x.it/?t="><script>', 15)
     assert hostile.html is not None and "<script>" not in hostile.html
+
+
+# ---- the welcome mail (ORB-157) ---------------------------------------------------------
+
+ACCEDI = "https://joinorbiters.com/hub/accedi"
+
+
+def test_the_welcome_mail_says_how_to_enter_what_waits_inside_and_where_the_jobs_are() -> None:
+    mail = welcome_mail(
+        "ada@studio.it", "Ada", ACCEDI, completa=True, posizione="Backend developer"
+    )
+    assert mail.subject == "La tua area su Orbiters è aperta"
+    assert mail.text.startswith("Ciao Ada,")
+    assert ACCEDI in mail.text and "senza password" in mail.text
+    assert "sei Backend developer" in mail.text and "scheda è completa" in mail.text
+    assert "PigroCRM, gratis" in mail.text and "I primi passi da freelance" in mail.text
+    assert "disponibili dopo il login" in mail.text
+    assert "https://www.linkedin.com/company/joinorbiters" in mail.text
+    assert "Forward Deployed Engineer" in mail.text
+
+
+def test_the_welcome_mail_asks_an_incomplete_card_for_the_persons_part() -> None:
+    mail = welcome_mail("ada@studio.it", "Ada", ACCEDI, completa=False, posizione="AI Architect")
+    assert "quello che si trova in pubblico" in mail.text
+    assert "Ti abbiamo segnato come AI Architect." in mail.text
+    assert "il CV, la tariffa a giornata" in mail.text
+    bare = welcome_mail("ada@studio.it", "Ada", ACCEDI, completa=False, posizione=None)
+    assert "segnato come" not in bare.text and "Manca la tua parte" in bare.text
+
+
+def test_the_welcome_mail_has_the_landings_box_and_escapes_the_persons_words() -> None:
+    mail = welcome_mail("ada@studio.it", "<Ada>", ACCEDI, completa=False, posizione="<b>x</b>")
+    assert mail.html is not None
+    html = mail.html
+    assert html.count(ACCEDI) == 3 and "Entra nella tua area" in html
+    assert "<Ada>" not in html and "&lt;Ada&gt;" in html
+    assert "<b>x</b>" not in html and "&lt;b&gt;x&lt;/b&gt;" in html
+    assert 'href="https://www.linkedin.com/company/joinorbiters"' in html
+    for colour in ("#f1f2f3", "#011936", "#ed254e", "#e5133e"):
+        assert colour in html, colour
+    assert "border-radius" not in html and "Privacy" in html

--- a/projects/hub/packages/core/tests/test_members.py
+++ b/projects/hub/packages/core/tests/test_members.py
@@ -278,3 +278,29 @@ def test_confirming_a_researched_card_unchanged_still_makes_it_the_persons(
     assert row.compilata_da == "persona"
     texts = [c.testo for c in CommentService(hub_session).list("freelancer", freelancer_id)]
     assert texts[0] == "Scheda confermata dalla persona"
+
+
+# ---- the welcome mailing (ORB-157) ------------------------------------------------------
+
+
+def test_the_welcome_mailing_reaches_every_card_or_the_addresses_named(
+    members: MemberService, hub_session: Session
+) -> None:
+    from orbiters_core.cli import send_welcome
+    from orbiters_core.mail import RecordingSender
+
+    _apply(hub_session, "ada@studio.it")
+    drafted = _draft_card(hub_session, "bruna@studio.it")
+    sender = RecordingSender()
+    outcomes = send_welcome(hub_session, members.settings, sender, None)
+    assert outcomes == [("ada@studio.it", "inviata"), ("bruna@studio.it", "inviata")]
+    assert [mail.to for mail in sender.sent] == ["ada@studio.it", "bruna@studio.it"]
+    assert "http://localhost:5180/hub/accedi" in sender.sent[0].text
+    assert "scheda è completa" in sender.sent[0].text
+    assert "Manca la tua parte" in sender.sent[1].text
+    assert drafted is not None
+
+    named = send_welcome(
+        hub_session, members.settings, RecordingSender(), ["ADA@studio.it", "nessuno@studio.it"]
+    )
+    assert named == [("ada@studio.it", "inviata"), ("nessuno@studio.it", "nessuna scheda")]


### PR DESCRIPTION
## What this changes

Twenty-eight people have a freelancer card they can open through `/hub/accedi`, twenty-seven of them since this morning (ORB-155), and nobody has told them. The hub sent one mail only, the magic link.

Now it sends a second one, once, by hand: `welcome_mail` greets the person by name, says the area is open and how to get in (the address, no password, one button to `/hub/accedi`), says what their card looks like from our side («la tua scheda è completa: sei SW» or «abbiamo preparato la tua scheda … manca la tua parte: il CV, la tariffa a giornata, come preferisci lavorare»), lists the two perks behind the login (PigroCRM free, the guide) and points at the LinkedIn page where the first Forward Deployed Engineer job posts appear this afternoon. Same voice and same box as the magic link, text and HTML.

`orbiters welcome --email a@b.it` sends it to one card, `orbiters welcome --all` to every card, printing one line per address with the outcome. That output is the record of the mailing: no table, no unsubscribe link, because this is a one-off to people who asked to join (the card says why).

## How I verified it

- `uv run pytest -q projects/hub/packages/core/tests`: 136 passed (4 new: the words, the incomplete-card variant, the HTML frame with escaping of the person's words, and `send_welcome` over two cards and over named addresses through a `RecordingSender`).
- `uv run mypy`: clean over 288 files; ruff check and format clean.
- The test mail Ivan asked for went out at 10:58 UTC from `orbiters-api-1` in production, with the function body of this PR executed against the deployed helpers and the production sender, to `ivansala@humancraft.tech`, with his card's data (complete, «SW»); Resend accepted it. The rendered HTML is the screenshot below.

## Anything a reviewer should look at twice

- «Oggi pomeriggio» is written into the mail: it is true for the mailing Ivan is about to do and false for any later one. When the LinkedIn post is out, the sentence should point at the post instead, or go.
- `send_welcome` matches addresses case-insensitively and answers «nessuna scheda» for an address without a card rather than failing the whole run.

## Screenshots

**1. The welcome mail as a client renders it (Ivan's data, complete card).** After only: there was no such mail before.
![The welcome mail](https://github.com/user-attachments/assets/3a6ef1fd-dcc6-4450-ae46-30ec52a4c117)

Linear: ORB-157
