### PR TITLE
feat(website): PigroCRM has its own page at /pigrocrm again

### DIFF
--- a/projects/website/AGENTS.md
+++ b/projects/website/AGENTS.md
@@ -10,8 +10,8 @@ doing.
 
 ## No framework, and that is the requirement
 
-No React, no Tailwind, no router, no CSS framework. Five HTML pages, five scripts,
-four stylesheets, and a build that takes about 300 milliseconds. This is the first
+No React, no Tailwind, no router, no CSS framework. Six HTML pages, five scripts,
+five stylesheets, and a build that takes about 300 milliseconds. This is the first
 thing a visitor loads and it must not drag an application bundle behind it. A dependency
 added here has to justify itself against that, and "the CRM already uses it" is not a
 justification: the CRM is behind a login and this is not.

--- a/projects/website/README.md
+++ b/projects/website/README.md
@@ -5,7 +5,7 @@ community page with its signup form at `/orbiters`, and the two policy pages
 (`/privacy`, `/termini`); it is called `website` rather than `landing` because it is
 expected to grow past those.
 
-Five HTML pages, five scripts, four stylesheets. No React, no Tailwind, no router.
+Six HTML pages, five scripts, five stylesheets. No React, no Tailwind, no router.
 That absence is the requirement rather than an omission: this is the first page a
 visitor loads, and it does not drag an application bundle behind it. The build takes
 about 300 milliseconds. Anything added here should keep that true.
@@ -26,7 +26,8 @@ pnpm --filter website lint
 
 | Page | Served at | What it is |
 |---|---|---|
-| `src/index.html` | `joinorbiters.com/` | The Orbiters landing: two doors into the hub, how it works, the four voices, the perks. Since 2026-09-11 (ORB-145); `/pigrocrm`, where it lived before, is a 301 here |
+| `src/index.html` | `joinorbiters.com/` | The Orbiters landing: two doors into the hub, how it works, the four voices, the perks. Since 2026-09-11 (ORB-145) |
+| `src/pigrocrm.html` | `/pigrocrm` | PigroCRM's own page (ORB-159): the CRM's call to action with a drawn Claude conversation, what is inside, the guide, the closing box. Its own `pigrocrm.css` on top of `landing.css` |
 | `src/orbiters.html` | `/orbiters` | The community page and its signup form, the front door until 2026-09-11 |
 | `src/privacy.html` | `/privacy` | Privacy notice |
 | `src/termini.html` | `/termini` | Terms |
@@ -59,8 +60,8 @@ restated here:
 
 Its own container. `Dockerfile` builds the pages into an nginx image, `docker-compose.yml`
 runs it on 127.0.0.1:8082 (8083 for preview), and `deploy/nginx.conf` inside the image
-holds the path map: which extensionless path is which file, a 301 from `/pigrocrm` to
-`/`, and a 404 for anything else. That map and `src/path-map-plugin.ts` say the same
+holds the path map: which extensionless path is which file, and a 404 for anything
+else. That map and `src/path-map-plugin.ts` say the same
 thing twice, once for production and once for the dev and preview servers. Change one
 and change the other: `path-map-plugin.test.ts` reads `nginx.conf` and fails until you
 have.

--- a/projects/website/deploy/nginx.conf
+++ b/projects/website/deploy/nginx.conf
@@ -20,9 +20,9 @@ server {
 
     # The landing is the site's front door (Ivan, 2026-09-11, ORB-145). The community
     # page with the signup form keeps the name it had before it was the front door, and
-    # `/pigrocrm`, where the landing lived for two days, follows it home.
+    # `/pigrocrm` is the CRM's own page again (ORB-159), after two days as a 301.
     location = /         { try_files /index.html =404; }
-    location = /pigrocrm { return 301 /; }
+    location = /pigrocrm { try_files /pigrocrm.html =404; }
     location = /orbiters { try_files /orbiters.html =404; }
     # The pitch deck, a page shared by link (ORB-153).
     location = /pitch    { try_files /pitch.html =404; }

--- a/projects/website/e2e/site.spec.ts
+++ b/projects/website/e2e/site.spec.ts
@@ -435,10 +435,10 @@ test.describe('the path map, as production serves it', () => {
     await expect(page).toHaveTitle(source('orbiters.html')!)
   })
 
-  test('/pigrocrm, where the landing lived until 2026-09-11, is a 301 to /', async ({ page }) => {
-    const response = await page.request.get('/pigrocrm', { maxRedirects: 0 })
-    expect(response.status()).toBe(301)
-    expect(response.headers()['location']).toBe('/')
+  test('/pigrocrm is the CRM\'s own page again (ORB-159)', async ({ page }) => {
+    await page.goto('/pigrocrm')
+    await expect(page).toHaveTitle(source('pigrocrm.html')!)
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Il CRM che lavora')
   })
 
   for (const path of ['/nonexistent', '/pigrocrm/', '/index.html', '/orbiters.html']) {

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const PAGES = ['index.html', 'privacy.html', 'termini.html'] as const
+const PAGES = ['index.html', 'pigrocrm.html', 'privacy.html', 'termini.html'] as const
 const html = Object.fromEntries(
   PAGES.map((name) => [name, readFileSync(join(__dirname, name), 'utf-8')]),
 ) as Record<(typeof PAGES)[number], string>

--- a/projects/website/src/links.test.ts
+++ b/projects/website/src/links.test.ts
@@ -43,7 +43,7 @@ import { REDIRECTS, route } from './path-map-plugin'
  *   cannot, follow it further.
  */
 
-const PAGE_FILES = ['index.html', 'orbiters.html', 'privacy.html', 'termini.html', 'pitch.html'] as const
+const PAGE_FILES = ['index.html', 'pigrocrm.html', 'orbiters.html', 'privacy.html', 'termini.html', 'pitch.html'] as const
 type PageFile = (typeof PAGE_FILES)[number]
 
 const SRC_DIR = join(__dirname)
@@ -169,8 +169,10 @@ describe('checkHref, edge cases none of the four pages exercise today', () => {
   it('drops the query string before routing, like the dev server does', () => {
     expect(checkHref('index.html', '/privacy?utm_source=newsletter')).toBeUndefined()
     // The redirect-is-wrong rule still applies once the query string is gone.
-    expect(checkHref('index.html', '/pigrocrm?utm_source=newsletter')).toMatch(/is a redirect to \//)
+    expect(checkHref('index.html', '/pigrocrm?utm_source=newsletter')).toBeUndefined()
     expect(checkHref('index.html', '/orbiters?utm_source=newsletter')).toBeUndefined()
+    // The map knows no redirects any more; an unknown path is still refused.
+    expect(checkHref('index.html', '/vecchia?utm_source=newsletter')).toMatch(/404s it/)
   })
 
   it('skips a scheme it does not otherwise resolve, the same way it skips mailto:', () => {

--- a/projects/website/src/path-map-plugin.test.ts
+++ b/projects/website/src/path-map-plugin.test.ts
@@ -55,8 +55,9 @@ describe('route', () => {
     expect(route('/termini')).toEqual({ kind: 'page', file: '/termini.html' })
   })
 
-  it('sends /pigrocrm, where the landing lived until 2026-09-11, home to /', () => {
-    expect(route('/pigrocrm')).toEqual({ kind: 'redirect', to: '/' })
+  it('serves PigroCRM its own page at /pigrocrm again (ORB-159), and keeps no redirect', () => {
+    expect(route('/pigrocrm')).toEqual({ kind: 'page', file: '/pigrocrm.html' })
+    expect(REDIRECTS).toEqual({})
   })
 
   it('404s what nginx 404s: unknown paths, trailing slashes, and the files under their own names', () => {

--- a/projects/website/src/path-map-plugin.ts
+++ b/projects/website/src/path-map-plugin.ts
@@ -19,6 +19,7 @@ import type { Plugin } from 'vite'
 /** `location = <path> { try_files <file> =404; }`, one line each in nginx.conf. */
 export const PAGES: Readonly<Record<string, string>> = {
   '/': '/index.html',
+  '/pigrocrm': '/pigrocrm.html',
   '/orbiters': '/orbiters.html',
   '/pitch': '/pitch.html',
   '/privacy': '/privacy.html',
@@ -27,9 +28,7 @@ export const PAGES: Readonly<Record<string, string>> = {
 
 /** `location = <path> { return 301 <to>; }`. nginx's `return` drops the query string
  *  and so does this. */
-export const REDIRECTS: Readonly<Record<string, string>> = {
-  '/pigrocrm': '/',
-}
+export const REDIRECTS: Readonly<Record<string, string>> = {}
 
 /**
  * Paths the host's vhost (`deploy/joinorbiters.conf`) hands to other tenants of the

--- a/projects/website/src/pigrocrm.css
+++ b/projects/website/src/pigrocrm.css
@@ -1,0 +1,214 @@
+/* PigroCRM's own page (ORB-159), on top of landing.css. Two things live here and not
+   there: the hero in two halves, and the conversation with Claude drawn in the hero.
+   The conversation is a picture of another product's window, so it keeps that
+   product's shapes -- rounded corners, a soft shadow -- which landing.css forbids for
+   the site's own components and `landing-style.test.ts` pins; this sheet is where that
+   exception is allowed to live, and nothing here reaches a component of the site. */
+
+/* --- The hero, in two halves on a wide screen and stacked on a phone. */
+.hero-split {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 3rem);
+  align-items: center;
+}
+
+@media (min-width: 60rem) {
+  .hero-split {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+  }
+}
+
+.hero-copy {
+  display: grid;
+  gap: 1.25rem;
+}
+
+/* --- The conversation window. */
+.chat {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.chat-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 2.5rem;
+  padding-inline: 1rem;
+  background: #e9e7df;
+  border-radius: 14px 14px 0 0;
+  position: relative;
+}
+
+.chat-bar i {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  display: block;
+}
+
+.chat-bar i:nth-child(1) { background: #ff5f57; }
+.chat-bar i:nth-child(2) { background: #febc2e; }
+.chat-bar i:nth-child(3) { background: #28c840; }
+
+.chat-bar span {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--landing-ink-quiet);
+}
+
+.chat-body {
+  background: #faf9f5;
+  border-radius: 0 0 14px 14px;
+  box-shadow: 0 24px 60px color-mix(in oklab, var(--landing-ink) 28%, transparent);
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+  margin-top: -0.75rem;
+}
+
+.chat-body p {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--landing-ink);
+}
+
+.chat-user {
+  justify-self: end;
+  max-width: 85%;
+  background: #eeece4;
+  padding: 0.7rem 1rem;
+  border-radius: 18px 18px 4px 18px;
+}
+
+.chat-turn {
+  display: grid;
+  grid-template-columns: 1.75rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+/* The assistant's mark: a four-spoke star in the terracotta that product uses. */
+.chat-mark {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: #d97757;
+  position: relative;
+  margin-top: 0.15rem;
+}
+
+.chat-mark::before,
+.chat-mark::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 1rem;
+  height: 2px;
+  background: #faf9f5;
+}
+
+.chat-mark::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.chat-mark::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.chat-text {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+/* The tool call, as the product shows one: a card with the tool's name, its
+   arguments as a small table, and the one line it answered. */
+.chat-tool {
+  border: 1px solid #ddd9cc;
+  border-radius: 10px;
+  background: #ffffff;
+  padding: 0.75rem 0.9rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.chat-tool p,
+.chat-tool dt,
+.chat-tool dd {
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.chat-tool-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--landing-ink-quiet);
+}
+
+.chat-tool-name span {
+  display: inline-block;
+  background: var(--landing-ink);
+  color: #ffffff;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.45rem;
+  margin-right: 0.5rem;
+  border-radius: 4px;
+}
+
+.chat-tool dl {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0;
+}
+
+.chat-tool dl div {
+  display: grid;
+  grid-template-columns: 5rem minmax(0, 1fr);
+  gap: 0.5rem;
+}
+
+.chat-tool dt {
+  color: var(--landing-ink-quiet);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.chat-tool dd {
+  margin: 0;
+  color: var(--landing-ink);
+}
+
+.chat-tool-out {
+  border-top: 1px solid #ddd9cc;
+  padding-top: 0.5rem;
+  color: #2e7d4f;
+}
+
+.chat figcaption {
+  color: var(--landing-ink-quiet);
+}
+
+/* --- The six things, on the dark band: a title and a line each, no card. */
+.inside h3 {
+  margin-bottom: 0.35rem;
+}
+
+.inside > div {
+  border-top-width: 2px;
+  border-top-color: var(--landing-rule-on-ink);
+  padding-top: 1rem;
+}
+
+/* Three columns, two rows: six things read as a set, not as four and two. */
+@media (min-width: 48rem) {
+  .inside {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/projects/website/src/pigrocrm.html
+++ b/projects/website/src/pigrocrm.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PigroCRM — il CRM di Orbiters, gratis per chi è in community</title>
+    <meta
+      name="description"
+      content="PigroCRM: clienti, offerte, fatture e pagamenti in un posto solo, e un assistente AI che fa il lavoro noioso. Lo abbiamo costruito da freelance per i freelance. Gratis per chi è in Orbiters, open source per tutti."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="PigroCRM — il CRM di Orbiters, che lavora al posto tuo" />
+    <meta
+      property="og:description"
+      content="Clienti, offerte, fatture e pagamenti in un posto solo. Un assistente AI fa il lavoro noioso. Gratis per chi è in Orbiters."
+    />
+    <meta property="og:locale" content="it_IT" />
+    <link rel="icon" type="image/svg+xml" href="./orbiters-logo.svg" />
+    <link rel="stylesheet" href="./landing.css" />
+    <link rel="stylesheet" href="./pigrocrm.css" />
+    <!-- The reveal gate, the landing's (ORB-145): landing.css hides `[data-reveal]` only
+      under `html.js`, and after three seconds nothing is hidden whatever the script did. -->
+    <script>
+      document.documentElement.classList.add('js')
+      setTimeout(function () { document.documentElement.classList.add('reveal-all') }, 3000)
+    </script>
+    <!-- The cookie notice and the measurement pixel, as on the landing and the community
+      page: this is the third page an ad can land on (ORB-159), so it asks the same
+      question and loads the SDK only on a yes. privacy.html names all three. -->
+    <script type="module" src="./consent.js"></script>
+  </head>
+  <body>
+    <canvas id="field" aria-hidden="true"></canvas>
+
+    <header class="wrap top">
+      <a class="brand" href="/"><span class="glyph" aria-hidden="true"></span>Orbiters</a>
+      <a class="quiet-link" href="/app/">Accedi</a>
+    </header>
+
+    <!-- PigroCRM's own page (ORB-159), on the landing's base: the same field, the same
+      deck rhythm, the same bands. What is its own is the hero, a box in two halves: the
+      CRM's call to action on the left and, on the right, a conversation with Claude that
+      issues an invoice through PigroCRM's MCP. The conversation is drawn, not a
+      screenshot: `pigrocrm.css` owns its shapes, so the landing's own sheet keeps its
+      hard-edge rules. -->
+    <main class="deck">
+      <section class="hero">
+        <div class="wrap">
+          <div class="box">
+            <div class="hero-split">
+              <div class="hero-copy">
+                <p class="kicker">PigroCRM</p>
+                <h1 class="measure-tight">Il CRM che lavora <span class="accent">al posto tuo.</span></h1>
+                <p class="lead measure">
+                  Clienti, offerte, fatture e pagamenti in un posto solo. Un assistente AI fa il
+                  lavoro noioso: glielo dici, e lui lo fa su PigroCRM.
+                </p>
+                <p class="actions">
+                  <a class="cta" href="https://pigro.joinorbiters.com/app/registrati">Crea il tuo spazio</a>
+                  <a class="cta secondary" href="/hub/freelance">Entra in Orbiters</a>
+                </p>
+                <p class="fine">
+                  Gratis per chi è in community. Uno spazio tuo, con un database separato, su
+                  pigro.joinorbiters.com/il-tuo-nome. Open source, self-hosted quando vuoi.
+                </p>
+              </div>
+              <figure class="chat" aria-label="Una conversazione con Claude che emette una fattura su PigroCRM">
+                <div class="chat-bar"><i></i><i></i><i></i><span>Claude</span></div>
+                <div class="chat-body">
+                  <p class="chat-user">Emetti la fattura per il cliente XYZ su maggio.</p>
+                  <div class="chat-turn">
+                    <span class="chat-mark" aria-hidden="true"></span>
+                    <div class="chat-text">
+                      <p>Su PigroCRM XYZ ha 6 giornate registrate a maggio, 2.700,00 €. Preparo la fattura e la emetto.</p>
+                      <div class="chat-tool">
+                        <p class="chat-tool-name"><span>PigroCRM</span> issue_invoice</p>
+                        <dl>
+                          <div><dt>cliente</dt><dd>XYZ</dd></div>
+                          <div><dt>periodo</dt><dd>maggio 2026</dd></div>
+                          <div><dt>righe</dt><dd>6 giornate · 450,00 €</dd></div>
+                        </dl>
+                        <p class="chat-tool-out">Fattura 2026/14 emessa · 2.700,00 € · scadenza 30 giugno</p>
+                      </div>
+                      <p>Fatto: <strong>fattura 2026/14</strong> emessa per 2.700,00 €, scadenza 30 giugno. Il PDF è sulla scheda di XYZ e la mail di invio è in bozza, la mandi quando vuoi.</p>
+                    </div>
+                  </div>
+                </div>
+                <figcaption class="fine">L'assistente parla con PigroCRM attraverso il suo MCP: ogni azione resta tua da rivedere.</figcaption>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="band dark" aria-labelledby="dentro">
+        <div class="wrap section">
+          <p class="kicker" data-reveal>Cosa c'è dentro</p>
+          <h2 class="statement" id="dentro" data-reveal style="--d: 0.1s">
+            Sei cose. <span class="accent">Nessun piano da scegliere.</span>
+          </h2>
+          <div class="grid-3 inside">
+            <div data-reveal style="--d: 0.25s"><h3>Clienti e trattative</h3><p>Contatti, deal e attività in un posto solo, con i campi che servono a te.</p></div>
+            <div data-reveal style="--d: 0.35s"><h3>Offerte e contratti</h3><p>PDF dai tuoi template, già con i tuoi dati fiscali, pronti da mandare.</p></div>
+            <div data-reveal style="--d: 0.45s"><h3>Fatture e ore</h3><p>Emetti, incassa, tieni lo stato di ognuna sotto gli occhi. Anche in forfettario.</p></div>
+            <div data-reveal style="--d: 0.55s"><h3>Le email sulla scheda</h3><p>Quello che vi siete scritti resta accanto al cliente, senza aprire Gmail.</p></div>
+            <div data-reveal style="--d: 0.65s"><h3>Un assistente AI</h3><p>Registra le ore, prepara le offerte, emette le fatture, ti riassume la settimana.</p></div>
+            <div data-reveal style="--d: 0.75s"><h3>Uno spazio tuo</h3><p>Database separato, su pigro.joinorbiters.com/il-tuo-nome. O sul tuo server: è open source.</p></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- The second perk. It is announced here and downloaded in the hub: the file is
+        behind the member session (`GET /api/hub/me/guida`), so this section links to the
+        wizard and never to a PDF. Deliberately a section of its own rather than a fourth
+        line inside the CRM's: ORB-68 is the card that makes the perks read as a set with
+        the CRM as the largest of them, and it should absorb this block when it lands.
+        No size or page count in this copy on purpose, since the file lives in another
+        project and a number here would have nothing holding it true. -->
+      <section class="band dark centred" aria-labelledby="guida">
+        <div class="wrap section">
+          <p class="kicker" id="guida" data-reveal>La guida, il secondo perk</p>
+          <h2 class="statement" data-reveal style="--d: 0.1s">I primi passi <span class="accent">da freelance.</span></h2>
+          <p class="lead measure" data-reveal style="--d: 0.25s">
+            La parte che nessuno ti spiega prima della prima fattura: come dirti in una frase,
+            come arrivare a un numero e difenderlo, cosa scrivere prima di iniziare, e le
+            richieste che arrivano a tutti. Si legge in venti minuti.
+          </p>
+          <p class="actions" data-reveal style="--d: 0.4s">
+            <a class="cta" href="/hub/freelance?perk=guida">Entra e scaricala</a>
+          </p>
+          <p class="fine measure" data-reveal style="--d: 0.5s">
+            PDF, la scarichi dalla tua area appena sei dentro. Gratis, come PigroCRM.
+          </p>
+        </div>
+      </section>
+
+      <section class="band" aria-labelledby="orbita">
+        <div class="wrap section">
+          <div class="box" data-reveal>
+            <h2 class="measure-tight" id="orbita">Pronto a entrare <span class="accent">in orbita?</span></h2>
+            <p class="actions">
+              <a class="cta" href="/hub/freelance">Entra come talento</a>
+              <a class="cta secondary" href="/hub/aziende">Ho un progetto</a>
+            </p>
+            <p class="fine measure">
+              Il CV resta nel nostro database, lo leggiamo noi e chi ti proporrà un progetto, e lo
+              cancelliamo quando ce lo chiedi. Il resto è nella
+              <a class="quiet-link" href="/privacy">privacy</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <footer class="wrap rule" style="padding-block: 2rem">
+        <p class="fine" style="display: flex; gap: 1.5rem; flex-wrap: wrap">
+          <a class="quiet-link" href="/">Orbiters</a>
+          <a class="quiet-link" href="/privacy">Privacy</a>
+          <a class="quiet-link" href="/termini">Termini</a>
+          <a class="quiet-link" href="https://humancraft.tech/">Humancraft</a>
+          <a class="quiet-link" href="/hub/admin/freelance">Admin</a>
+        </p>
+      </footer>
+    </main>
+
+    <script type="module" src="./field.js"></script>
+    <script type="module" src="./landing.js"></script>
+  </body>
+</html>

--- a/projects/website/src/pixel.test.ts
+++ b/projects/website/src/pixel.test.ts
@@ -18,7 +18,7 @@ import { describe, expect, it } from 'vitest'
 const PIXEL_ID = '9r6qrnPxBV8WDVGtpuaqxh'
 const SDK_URL = 'https://bzrcdn.openai.com/sdk/oaiq.min.js'
 
-const MEASURED = ['index.html', 'orbiters.html'] as const
+const MEASURED = ['index.html', 'pigrocrm.html', 'orbiters.html'] as const
 const UNMEASURED = ['privacy.html', 'termini.html'] as const
 const ALL = [...MEASURED, ...UNMEASURED]
 

--- a/projects/website/src/privacy.html
+++ b/projects/website/src/privacy.html
@@ -84,8 +84,9 @@
           nel CRM né nella pagina dei termini o in questa.
         </p>
         <p>
-          Sulla home e sulla pagina della <a class="quiet-link" href="/orbiters">community</a>, che sono
-          le due pagine su cui possono arrivare i nostri annunci, c'è un'eccezione e la diciamo:
+          Sulla home, sulla pagina della <a class="quiet-link" href="/orbiters">community</a> e su
+          quella di <a class="quiet-link" href="/pigrocrm">PigroCRM</a>, che sono le tre pagine su cui
+          possono arrivare i nostri annunci, c'è un'eccezione e la diciamo:
           il pixel di misurazione di ChatGPT Ads (OpenAI). Serve a sapere se un annuncio ha portato
           un'iscrizione, e per farlo scrive un cookie di prima parte sul nostro dominio
           (<code>__obref</code>) e comunica a OpenAI la visita e l'eventuale iscrizione, con

--- a/projects/website/vite.config.ts
+++ b/projects/website/vite.config.ts
@@ -16,8 +16,8 @@ export default defineConfig({
   // application's bundle behind it.
   //
   // `pathMapPlugin` is the dev and preview servers' copy of deploy/nginx.conf: `/` is
-  // the landing, `/orbiters` the community page, `/pigrocrm` a 301 to `/`, and anything
-  // else a 404. Its unit test reads nginx.conf, so the two cannot drift quietly.
+  // the landing, `/pigrocrm` the CRM's page, `/orbiters` the community page, and
+  // anything else a 404. Its unit test reads nginx.conf, so the two cannot drift quietly.
   plugins: [palettePlugin(), pathMapPlugin()],
   // 'mpa' turns off Vite's fallback to index.html for a path that resolves to no file.
   // With it on, an unknown path answered 200 with PigroCRM's page here and 404 in
@@ -33,6 +33,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         index: path.resolve(__dirname, 'src/index.html'),
+        pigrocrm: path.resolve(__dirname, 'src/pigrocrm.html'),
         privacy: path.resolve(__dirname, 'src/privacy.html'),
         termini: path.resolve(__dirname, 'src/termini.html'),
         orbiters: path.resolve(__dirname, 'src/orbiters.html'),


### PR DESCRIPTION
## What this changes

Ivan asked for a landing of PigroCRM's own at `/pigrocrm`, on the base of the new landing: a first box as the CRM's call to action with a Claude screenshot inside («emetti la fattura per il cliente XYZ su maggio»), then the guide's call to action, then the closing «Pronto a entrare in orbita?». So `src/pigrocrm.html`, with the landing's field, bands, kicker, statement and reveal:

- **Hero**: a box in two halves. Left, «Il CRM che lavora al posto tuo.», the lead, «Crea il tuo spazio» (to `pigro.joinorbiters.com/app/registrati`) and «Entra in Orbiters» (to the wizard), the fine print about the free space and self-hosting. Right, a drawn conversation with Claude: the request, the assistant's reading of the month, a tool card `PigroCRM · issue_invoice` with client, period and lines and its one-line result, and the answer naming the invoice, the amount and the due date. Drawn in HTML rather than a screenshot, so it stays crisp, editable and under 3 KB; the caption says the assistant talks to PigroCRM through its MCP and every action stays the person's to review.
- **«Cosa c'è dentro»**, a dark band: six things in three columns, one line each.
- **The guide band** and **the closing box**, the landing's own markup verbatim (the guide button carries `?perk=guida`).
- `pigrocrm.css` holds the conversation's shapes (rounded corners, one soft shadow, that product's colours); `landing.css` is untouched and its hard-edge rules still pinned.
- The page carries the consent notice and the pixel like the two other pages an ad can land on; `pixel.test.ts` lists it among the measured pages and `privacy.html` now names three pages.
- `/pigrocrm` is a page again in `deploy/nginx.conf` and `src/path-map-plugin.ts`; `REDIRECTS` is empty and the tests say so; the e2e path-map test checks the title and the h1; README and AGENTS.md count six pages and five stylesheets.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 11 files / 217 tests (the shared page tests now run on `pigrocrm.html` too: title and Open Graph, no foreign subresource, the brand and «Accedi», the consent script once, every link resolvable), `pnpm --filter website build` emits `pigrocrm.html` (9.7 KB) and `pigrocrm.css` (2.6 KB), `pnpm --filter website test:e2e` 51 passed with `/pigrocrm` in every page-wide test (no foreign host, the consent notice and its refusal, no JavaScript, no sideways scroll at phone widths). Screenshots at 1440 (top and full page) and 390, read before attaching.

## Anything a reviewer should look at twice

- The conversation is fiction by design: client «XYZ», six days at 450 €, invoice 2026/14. No real name, no fiscal identifier, nothing the identity guard scans for. The tool name `issue_invoice` is the CRM's real MCP tool, so the picture tells the truth about what the assistant can do.
- `pigrocrm.css` uses rounded corners and a blurred shadow, which `landing.css` forbids. That is intentional and confined: the window is a picture of Claude, not a component of the site, and `landing-style.test.ts` pins only `landing.css`.

## Screenshots

**1. `/pigrocrm` at 1440: before (the landing, which the path redirected to) and after**
![The PigroCRM page before and after](https://github.com/user-attachments/assets/62610713-84aa-4857-a531-00e44c945f6a)

Linear: ORB-159.
