### PR TITLE
feat(hub): the welcome mail speaks to every address, in the voice its card deserves

### DIFF
--- a/projects/hub/README.md
+++ b/projects/hub/README.md
@@ -115,8 +115,13 @@ docker compose -p orbiters exec api uv run --no-sync orbiters welcome --email yo
 docker compose -p orbiters exec api uv run --no-sync orbiters welcome --all
 ```
 
-One line per address with the outcome; that output is the record of the mailing. Needs
-`ORBITERS_RESEND_API_KEY` in the host `.env`, like the magic link.
+`--all` covers every address the hub knows, signups and cards alike, and the mail speaks
+in one of three voices: a card the person filled (it is complete, enter), a card we drafted
+from public sources (a recap, the ask to enter and complete it, and that an offer in line
+with the profile is already there), or no card at all (the wizard first, then the address
+is the way in). One line per address with the outcome and the voice; that output is the
+record of the mailing. Needs `ORBITERS_RESEND_API_KEY` in the host `.env`, like the magic
+link.
 
 ## Deploy
 

--- a/projects/hub/packages/core/src/orbiters_core/cli.py
+++ b/projects/hub/packages/core/src/orbiters_core/cli.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Sequence
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from orbiters_core.admin import AdminService
@@ -14,9 +14,8 @@ from orbiters_core.config import Settings, get_settings
 from orbiters_core.conversions import pixel_from_settings
 from orbiters_core.db import create_engine_from_settings, session_factory
 from orbiters_core.errors import DomainError
-from orbiters_core.mail import EmailSender, sender_from_settings, welcome_mail
-from orbiters_core.models import Freelancer
-from orbiters_core.schemas import FreelancerRead
+from orbiters_core.mail import CardSummary, EmailSender, sender_from_settings, welcome_mail
+from orbiters_core.models import Freelancer, Signup
 
 
 def createadmin(email: str | None, nome: str | None) -> int:
@@ -82,27 +81,58 @@ def conversions_check() -> int:
 def send_welcome(
     session: Session, settings: Settings, sender: EmailSender, emails: Sequence[str] | None
 ) -> list[tuple[str, str]]:
-    """One welcome mail per freelancer card (ORB-157): the addresses given, or every card
-    when `emails` is `None`. Answers one line per address -- `inviata`, `rifiutata dal
-    provider`, or `nessuna scheda` -- which is the whole record of the mailing."""
-    stmt = select(Freelancer).order_by(Freelancer.created_at, Freelancer.id)
+    """One welcome mail per address the hub knows (ORB-157): every signup and every card,
+    or the addresses given. The voice follows what we hold for the address: a card the
+    person filled, a card we drafted from public sources, or no card at all (the wizard,
+    then). Answers one line per address -- `inviata` with the kind, or `rifiutata dal
+    provider` -- which is the whole record of the mailing."""
+    cards = {
+        row.email.lower(): row
+        for row in session.scalars(
+            select(Freelancer).order_by(Freelancer.created_at, Freelancer.id)
+        ).all()
+    }
+    signups = {
+        row.email.lower(): row
+        for row in session.scalars(select(Signup).order_by(Signup.created_at, Signup.id)).all()
+    }
     if emails is not None:
-        wanted = [email.strip().lower() for email in emails]
-        stmt = stmt.where(func.lower(Freelancer.email).in_(wanted))
-    rows = {row.email.lower(): row for row in session.scalars(stmt).all()}
-    targets = [email.strip().lower() for email in emails] if emails is not None else list(rows)
-    link = f"{settings.hub_url.rstrip('/')}/accedi"
+        targets = [email.strip().lower() for email in emails]
+    else:
+        targets = list(dict.fromkeys([*signups, *cards]))
+    base = settings.hub_url.rstrip("/")
+    accedi, wizard = f"{base}/accedi", f"{base}/freelance"
     outcomes: list[tuple[str, str]] = []
     for email in targets:
-        row = rows.get(email)
-        if row is None:
-            outcomes.append((email, "nessuna scheda"))
+        card = cards.get(email)
+        signup = signups.get(email)
+        if card is None and signup is None:
+            outcomes.append((email, "indirizzo sconosciuto"))
             continue
-        card = FreelancerRead.model_validate(row)
-        mail = welcome_mail(
-            row.email, row.nome, link, completa=card.completa, posizione=row.posizione
-        )
-        outcomes.append((email, "inviata" if sender.send(mail) else "rifiutata dal provider"))
+        if card is not None and card.compilata_da == "persona":
+            kind = "persona"
+            mail = welcome_mail(card.email, card.nome, accedi, kind=kind, posizione=card.posizione)
+        elif card is not None:
+            kind = "admin"
+            mail = welcome_mail(
+                card.email,
+                card.nome,
+                accedi,
+                kind=kind,
+                summary=CardSummary(
+                    nome=card.nome,
+                    cognome=card.cognome,
+                    posizione=card.posizione,
+                    linkedin_url=card.linkedin_url,
+                    links=tuple(card.links),
+                ),
+            )
+        else:
+            assert signup is not None
+            kind = "nessuna"
+            mail = welcome_mail(signup.email, signup.nome, accedi, kind=kind, wizard_link=wizard)
+        sent = sender.send(mail)
+        outcomes.append((email, f"inviata ({kind})" if sent else "rifiutata dal provider"))
     return outcomes
 
 
@@ -123,7 +153,7 @@ def welcome(emails: Sequence[str], everyone: bool) -> int:
         session.close()
     for email, outcome in outcomes:
         print(f"{email}: {outcome}")
-    return 0 if all(outcome == "inviata" for _, outcome in outcomes) else 1
+    return 0 if all(outcome.startswith("inviata") for _, outcome in outcomes) else 1
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -137,7 +167,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     admin.add_argument("--email")
     admin.add_argument("--nome")
     welcome_parser = sub.add_parser(
-        "welcome", help="Manda la mail «la tua area è aperta» a una scheda o a tutte"
+        "welcome",
+        help="Manda la mail «la tua area è aperta» a un indirizzo o a tutti quelli noti",
     )
     welcome_parser.add_argument("--email", action="append", default=[])
     welcome_parser.add_argument("--all", action="store_true")

--- a/projects/hub/packages/core/src/orbiters_core/mail.py
+++ b/projects/hub/packages/core/src/orbiters_core/mail.py
@@ -246,70 +246,167 @@ GUIDE_LINE = (
 )
 
 
+@dataclass(frozen=True)
+class CardSummary:
+    """What the welcome mail says about a card we wrote from public sources (ORB-157):
+    the person's own words as we found them, so they can see what a company sees."""
+
+    nome: str
+    cognome: str
+    posizione: str | None
+    linkedin_url: str | None
+    links: tuple[str, ...]
+
+
 def welcome_mail(
-    to: str, nome: str, accedi_link: str, *, completa: bool, posizione: str | None
+    to: str,
+    nome: str | None,
+    accedi_link: str,
+    *,
+    kind: str,
+    posizione: str | None = None,
+    summary: CardSummary | None = None,
+    wizard_link: str | None = None,
 ) -> Mail:
-    """The one-off mail that tells a person their area is open (ORB-157): how to get in
-    (the address, no password), what their card looks like from our side, the two perks
-    that wait behind the login, and the LinkedIn page where the first job posts appear.
-    Same voice and same box as the magic link; `nome` and `posizione` are the person's
-    own words and are escaped wherever they land in the HTML."""
-    if completa:
-        card = (
-            f"La tua scheda è completa: sei {posizione}, e le aziende possono trovarti."
-            if posizione
-            else "La tua scheda è completa: le aziende possono trovarti."
-        )
-    else:
-        found = f" Ti abbiamo segnato come {posizione}." if posizione else ""
-        card = (
-            "Abbiamo preparato la tua scheda con quello che si trova in pubblico su di "
-            f"te.{found} Manca la tua parte: il CV, la tariffa a giornata, come preferisci "
-            "lavorare. Sono le cose che le aziende cercano."
-        )
-    text = (
-        f"Ciao {nome},\n"
-        "\n"
+    """The one-off mail that tells a person their area is open (ORB-157), in three
+    voices decided with Ivan on 2026-09-11:
+
+    - `kind == "persona"`: they filled the card themselves; it is complete, they enter.
+    - `kind == "admin"`: we wrote the card from public sources. A short recap of what we
+      found, the ask to enter and add what nothing public states (CV, rate, remote
+      option), and that an offer in line with the profile is already there: reply to
+      talk about it.
+    - `kind == "nessuna"`: nothing public was enough for a card. The wizard, five minutes,
+      and from then on the address is the way in.
+
+    Same box and voice as the magic link; the person's words are escaped in the HTML."""
+    e = html_escape.escape
+    greeting = f"Ciao {nome}," if nome else "Ciao,"
+    paragraph = 'style="margin:24px 0 0 0;"'
+    small = f'style="margin:24px 0 0 0;font-size:13px;line-height:1.5;color:{INK_QUIET};'
+    li = 'style="margin:0 0 8px 0;"'
+    perks_text = (
+        "Dentro trovi i vantaggi della community, disponibili dopo il login:\n"
+        f"- {PIGROCRM_LINE}\n"
+        f"- {GUIDE_LINE}\n"
+    )
+    perks_html = (
+        f"<p {paragraph}>Dentro trovi i vantaggi della community, disponibili dopo il "
+        "login:</p>"
+        '<ul style="margin:8px 0 0 0;padding:0 0 0 22px;">'
+        f"<li {li}>{e(PIGROCRM_LINE)}</li><li>{e(GUIDE_LINE)}</li></ul>"
+    )
+    linkedin_text = (
+        "Un'altra cosa: segui la pagina LinkedIn di Orbiters, "
+        f"{LINKEDIN_PAGE}. Oggi pomeriggio esce il post con le prime job post per "
+        "Forward Deployed Engineer.\n"
+    )
+    linkedin_html = (
+        f"<p {paragraph}>Un'altra cosa: segui "
+        f"{_quiet_link(LINKEDIN_PAGE, 'la pagina LinkedIn di Orbiters')}. Oggi pomeriggio "
+        "esce il post con le prime job post per Forward Deployed Engineer.</p>"
+    )
+    safe_accedi = e(accedi_link, quote=True)
+    enter_text = (
         "la tua area su Orbiters è aperta. Si entra con la tua email, senza password: ti "
         "mandiamo un link e sei dentro.\n"
         "\n"
         f"{accedi_link}\n"
-        "\n"
-        f"{card}\n"
-        "\n"
-        "Dentro trovi i vantaggi della community, disponibili dopo il login:\n"
-        f"- {PIGROCRM_LINE}\n"
-        f"- {GUIDE_LINE}\n"
-        "\n"
-        "Un'altra cosa: segui la pagina LinkedIn di Orbiters, "
-        f"{LINKEDIN_PAGE}. Oggi pomeriggio esce il post con le prime job post per "
-        "Forward Deployed Engineer.\n"
-        "\n"
+    )
+    enter_html = (
+        '<p style="margin:0 0 24px 0;">la tua area su Orbiters è aperta. Si entra con la '
+        "tua email, senza password: ti mandiamo un link e sei dentro.</p>"
+        + _button(safe_accedi, "Entra nella tua area")
+        + f'<p {small}word-break:break-all;">'
+        "Se il bottone non si apre, copia questo indirizzo nel browser:<br>"
+        f"{_quiet_link(safe_accedi, safe_accedi)}</p>"
+    )
+
+    if kind == "persona":
+        card_text = (
+            f"La tua scheda è completa: sei {posizione}, e le aziende possono trovarti."
+            if posizione
+            else "La tua scheda è completa: le aziende possono trovarti."
+        )
+        middle_text = enter_text + "\n" + card_text + "\n"
+        middle_html = enter_html + f"<p {paragraph}>{e(card_text)}</p>"
+    elif kind == "admin":
+        assert summary is not None
+        found: list[tuple[str, str]] = [("Nome", f"{summary.nome} {summary.cognome}")]
+        if summary.posizione:
+            found.append(("Posizione", summary.posizione))
+        if summary.linkedin_url:
+            found.append(("LinkedIn", summary.linkedin_url))
+        if summary.links:
+            found.append(("Link", ", ".join(summary.links)))
+        intro = (
+            "Abbiamo preparato la tua scheda con quello che si trova in pubblico su di te. "
+            "Ecco cosa c'è:"
+        )
+        missing = (
+            "Manca la tua parte: il CV, la tariffa a giornata, come preferisci lavorare. "
+            "Sono le cose che le aziende cercano: entra e completala."
+        )
+        offer = (
+            "Una cosa in più: abbiamo già un'offerta in linea con il tuo profilo. Se vuoi "
+            "approfondire, rispondi a questa mail e ne parliamo."
+        )
+        middle_text = (
+            enter_text
+            + "\n"
+            + intro
+            + "\n"
+            + "".join(f"- {label}: {value}\n" for label, value in found)
+            + "\n"
+            + missing
+            + "\n"
+            + "\n"
+            + offer
+            + "\n"
+        )
+        middle_html = (
+            enter_html
+            + f"<p {paragraph}>{e(intro)}</p>"
+            + '<ul style="margin:8px 0 0 0;padding:0 0 0 22px;">'
+            + "".join(
+                f"<li {li}><strong>{e(label)}:</strong> {e(value)}</li>" for label, value in found
+            )
+            + "</ul>"
+            + f"<p {paragraph}>{e(missing)}</p>"
+            + f"<p {paragraph}>{e(offer)}</p>"
+        )
+    elif kind == "nessuna":
+        assert wizard_link is not None
+        safe_wizard = e(wizard_link, quote=True)
+        intro = (
+            "la tua area su Orbiters è aperta, ma la tua scheda non siamo riusciti a "
+            "prepararla noi: in pubblico non c'era abbastanza. Compilala tu, ci vogliono "
+            "cinque minuti."
+        )
+        after = f"Da quel momento entri con la tua email, senza password, da qui: {accedi_link}"
+        middle_text = intro + "\n\n" + wizard_link + "\n\n" + after + "\n"
+        middle_html = (
+            f'<p style="margin:0 0 24px 0;">{e(intro)}</p>'
+            + _button(safe_wizard, "Compila il tuo profilo")
+            + f'<p {small}word-break:break-all;">'
+            "Se il bottone non si apre, copia questo indirizzo nel browser:<br>"
+            f"{_quiet_link(safe_wizard, safe_wizard)}</p>"
+            + f"<p {paragraph}>Da quel momento entri con la tua email, senza password, da "
+            f"{_quiet_link(safe_accedi, safe_accedi)}.</p>"
+        )
+    else:
+        raise ValueError(f"kind sconosciuto: {kind}")
+
+    text = (
+        f"{greeting}\n\n" + middle_text + "\n" + perks_text + "\n" + linkedin_text + "\n"
         "Noi di Orbiters\n"
     )
-    e = html_escape.escape
-    safe_link = e(accedi_link, quote=True)
-    paragraph = 'style="margin:24px 0 0 0;"'
-    small = f'style="margin:24px 0 0 0;font-size:13px;line-height:1.5;color:{INK_QUIET};'
     body = "\n".join(
         (
-            f'<p style="margin:0 0 20px 0;">Ciao {e(nome)},</p>',
-            '<p style="margin:0 0 24px 0;">la tua area su Orbiters è aperta. Si entra con la '
-            "tua email, senza password: ti mandiamo un link e sei dentro.</p>",
-            _button(safe_link, "Entra nella tua area"),
-            f'<p {small}word-break:break-all;">'
-            "Se il bottone non si apre, copia questo indirizzo nel browser:<br>"
-            f"{_quiet_link(safe_link, safe_link)}</p>",
-            f"<p {paragraph}>{e(card)}</p>",
-            f"<p {paragraph}>Dentro trovi i vantaggi della community, disponibili dopo il "
-            "login:</p>",
-            '<ul style="margin:8px 0 0 0;padding:0 0 0 22px;">'
-            f'<li style="margin:0 0 8px 0;">{e(PIGROCRM_LINE)}</li>'
-            f"<li>{e(GUIDE_LINE)}</li></ul>",
-            f"<p {paragraph}>Un'altra cosa: segui "
-            f"{_quiet_link(LINKEDIN_PAGE, 'la pagina LinkedIn di Orbiters')}. Oggi "
-            "pomeriggio esce il post con le prime job post per Forward Deployed "
-            "Engineer.</p>",
+            f'<p style="margin:0 0 20px 0;">{e(greeting)}</p>',
+            middle_html,
+            perks_html,
+            linkedin_html,
             f"<p {paragraph}>Noi di Orbiters</p>",
         )
     )

--- a/projects/hub/packages/core/tests/test_mail.py
+++ b/projects/hub/packages/core/tests/test_mail.py
@@ -6,9 +6,12 @@ the JSON and the failure classification run for real.
 
 import json
 
+import pytest
+
 from orbiters_core.config import Settings
 from orbiters_core.mail import (
     RESEND_URL,
+    CardSummary,
     Mail,
     RecordingSender,
     ResendSender,
@@ -119,39 +122,80 @@ def test_the_magic_link_mail_has_an_html_version_in_the_landings_system() -> Non
 # ---- the welcome mail (ORB-157) ---------------------------------------------------------
 
 ACCEDI = "https://joinorbiters.com/hub/accedi"
+WIZARD = "https://joinorbiters.com/hub/freelance"
 
 
-def test_the_welcome_mail_says_how_to_enter_what_waits_inside_and_where_the_jobs_are() -> None:
-    mail = welcome_mail(
-        "ada@studio.it", "Ada", ACCEDI, completa=True, posizione="Backend developer"
-    )
+def _common(mail: Mail) -> None:
     assert mail.subject == "La tua area su Orbiters è aperta"
-    assert mail.text.startswith("Ciao Ada,")
-    assert ACCEDI in mail.text and "senza password" in mail.text
-    assert "sei Backend developer" in mail.text and "scheda è completa" in mail.text
     assert "PigroCRM, gratis" in mail.text and "I primi passi da freelance" in mail.text
     assert "disponibili dopo il login" in mail.text
     assert "https://www.linkedin.com/company/joinorbiters" in mail.text
     assert "Forward Deployed Engineer" in mail.text
-
-
-def test_the_welcome_mail_asks_an_incomplete_card_for_the_persons_part() -> None:
-    mail = welcome_mail("ada@studio.it", "Ada", ACCEDI, completa=False, posizione="AI Architect")
-    assert "quello che si trova in pubblico" in mail.text
-    assert "Ti abbiamo segnato come AI Architect." in mail.text
-    assert "il CV, la tariffa a giornata" in mail.text
-    bare = welcome_mail("ada@studio.it", "Ada", ACCEDI, completa=False, posizione=None)
-    assert "segnato come" not in bare.text and "Manca la tua parte" in bare.text
-
-
-def test_the_welcome_mail_has_the_landings_box_and_escapes_the_persons_words() -> None:
-    mail = welcome_mail("ada@studio.it", "<Ada>", ACCEDI, completa=False, posizione="<b>x</b>")
-    assert mail.html is not None
-    html = mail.html
-    assert html.count(ACCEDI) == 3 and "Entra nella tua area" in html
-    assert "<Ada>" not in html and "&lt;Ada&gt;" in html
-    assert "<b>x</b>" not in html and "&lt;b&gt;x&lt;/b&gt;" in html
-    assert 'href="https://www.linkedin.com/company/joinorbiters"' in html
+    assert mail.html is not None and "Privacy" in mail.html and "border-radius" not in mail.html
     for colour in ("#f1f2f3", "#011936", "#ed254e", "#e5133e"):
-        assert colour in html, colour
-    assert "border-radius" not in html and "Privacy" in html
+        assert colour in mail.html, colour
+
+
+def test_a_person_who_filled_their_card_is_told_it_is_complete() -> None:
+    mail = welcome_mail(
+        "ada@studio.it", "Ada", ACCEDI, kind="persona", posizione="Backend developer"
+    )
+    _common(mail)
+    assert mail.text.startswith("Ciao Ada,")
+    assert ACCEDI in mail.text and "senza password" in mail.text
+    assert "sei Backend developer" in mail.text and "scheda è completa" in mail.text
+    assert mail.html is not None and mail.html.count(ACCEDI) == 3
+    assert "Entra nella tua area" in mail.html
+
+
+def test_a_card_we_drafted_gets_a_recap_the_ask_to_complete_and_the_offer() -> None:
+    summary = CardSummary(
+        nome="Bruna",
+        cognome="Esposito",
+        posizione="Senior Frontend Developer",
+        linkedin_url="https://www.linkedin.com/in/bruna-esposito/",
+        links=("https://github.com/brunaesposito",),
+    )
+    mail = welcome_mail("bruna@studio.it", "Bruna", ACCEDI, kind="admin", summary=summary)
+    _common(mail)
+    assert "quello che si trova in pubblico" in mail.text
+    for line in (
+        "- Nome: Bruna Esposito",
+        "- Posizione: Senior Frontend Developer",
+        "- LinkedIn: https://www.linkedin.com/in/bruna-esposito/",
+        "- Link: https://github.com/brunaesposito",
+    ):
+        assert line in mail.text, line
+    assert "il CV, la tariffa a giornata" in mail.text and "entra e completala" in mail.text
+    assert "già un'offerta in linea con il tuo profilo" in mail.text
+    assert "rispondi a questa mail" in mail.text
+    # A recap with nothing but the name lists only the name.
+    bare = welcome_mail(
+        "bruna@studio.it",
+        "Bruna",
+        ACCEDI,
+        kind="admin",
+        summary=CardSummary("Bruna", "Esposito", None, None, ()),
+    )
+    assert "- Nome: Bruna Esposito" in bare.text and "- Posizione" not in bare.text
+
+
+def test_an_address_without_a_card_is_sent_to_the_wizard() -> None:
+    mail = welcome_mail("x@studio.it", None, ACCEDI, kind="nessuna", wizard_link=WIZARD)
+    _common(mail)
+    assert mail.text.startswith("Ciao,\n")
+    assert "non siamo riusciti a prepararla noi" in mail.text
+    assert WIZARD in mail.text and ACCEDI in mail.text
+    assert mail.html is not None and "Compila il tuo profilo" in mail.html
+    named = welcome_mail("x@studio.it", "Marco", ACCEDI, kind="nessuna", wizard_link=WIZARD)
+    assert named.text.startswith("Ciao Marco,")
+
+
+def test_the_welcome_mail_escapes_the_persons_words_and_refuses_an_unknown_kind() -> None:
+    summary = CardSummary("<Ada>", "L", "<b>x</b>", None, ())
+    mail = welcome_mail("ada@studio.it", "<Ada>", ACCEDI, kind="admin", summary=summary)
+    assert mail.html is not None
+    assert "<Ada>" not in mail.html and "&lt;Ada&gt;" in mail.html
+    assert "<b>x</b>" not in mail.html and "&lt;b&gt;x&lt;/b&gt;" in mail.html
+    with pytest.raises(ValueError):
+        welcome_mail("ada@studio.it", "Ada", ACCEDI, kind="boh")

--- a/projects/hub/packages/core/tests/test_members.py
+++ b/projects/hub/packages/core/tests/test_members.py
@@ -317,24 +317,40 @@ def test_entering_is_recorded_and_the_card_and_the_stats_read_it_back(
 # ---- the welcome mailing (ORB-157) ------------------------------------------------------
 
 
-def test_the_welcome_mailing_reaches_every_card_or_the_addresses_named(
+def test_the_welcome_mailing_speaks_to_every_address_the_hub_knows(
     members: MemberService, hub_session: Session
 ) -> None:
     from orbiters_core.cli import send_welcome
     from orbiters_core.mail import RecordingSender
+    from orbiters_core.schemas import SignupCreate
+    from orbiters_core.service import SignupService
 
-    _apply(hub_session, "ada@studio.it")
-    drafted = _draft_card(hub_session, "bruna@studio.it")
+    _apply(hub_session, "ada@studio.it")  # a card the person filled, no signup
+    _draft_card(hub_session, "bruna@studio.it")  # a signup and a card we drafted
+    SignupService(hub_session).subscribe(
+        SignupCreate(email="carlo@studio.it", nome="Carlo", cognome="Verdi")
+    )  # a signup and nothing else
     sender = RecordingSender()
     outcomes = send_welcome(hub_session, members.settings, sender, None)
-    assert outcomes == [("ada@studio.it", "inviata"), ("bruna@studio.it", "inviata")]
-    assert [mail.to for mail in sender.sent] == ["ada@studio.it", "bruna@studio.it"]
-    assert "http://localhost:5180/hub/accedi" in sender.sent[0].text
-    assert "scheda è completa" in sender.sent[0].text
-    assert "Manca la tua parte" in sender.sent[1].text
-    assert drafted is not None
+    assert outcomes == [
+        ("bruna@studio.it", "inviata (admin)"),
+        ("carlo@studio.it", "inviata (nessuna)"),
+        ("ada@studio.it", "inviata (persona)"),
+    ]
+    by_to = {mail.to: mail for mail in sender.sent}
+    assert "http://localhost:5180/hub/accedi" in by_to["ada@studio.it"].text
+    assert "scheda è completa" in by_to["ada@studio.it"].text
+    assert "- Posizione: Backend developer" in by_to["bruna@studio.it"].text
+    assert "offerta in linea" in by_to["bruna@studio.it"].text
+    assert "http://localhost:5180/hub/freelance" in by_to["carlo@studio.it"].text
+    assert by_to["carlo@studio.it"].text.startswith("Ciao Carlo,")
 
     named = send_welcome(
         hub_session, members.settings, RecordingSender(), ["ADA@studio.it", "nessuno@studio.it"]
     )
-    assert named == [("ada@studio.it", "inviata"), ("nessuno@studio.it", "nessuna scheda")]
+    assert named == [
+        ("ada@studio.it", "inviata (persona)"),
+        ("nessuno@studio.it", "indirizzo sconosciuto"),
+    ]
+    hub_session.execute(text("DELETE FROM signups"))
+    hub_session.commit()


### PR DESCRIPTION
## What this changes

The welcome mail (PR #69) spoke to one kind of address: a card, complete or not. Ivan wants the mailing to reach everybody the hub knows and to say something different depending on what we hold: «se non siamo stati in grado di completare il profilo indica che possono fare il login e completare il profilo; per chi ha avuto il profilo automaticamente metti un breve riepilogo del profilo e che abbiamo già un'offerta in linea con il profilo, e se si vuole approfondire di contattare».

`welcome_mail` now has three voices, chosen by `kind`:

- `persona`, a card the person filled: unchanged, «la tua scheda è completa».
- `admin`, a card we drafted from public sources: a recap of what we found (name, position, LinkedIn, links), the ask to enter and add the CV, the rate and the remote option, and «abbiamo già un'offerta in linea con il tuo profilo. Se vuoi approfondire, rispondi a questa mail e ne parliamo».
- `nessuna`, an address with no card: «la tua scheda non siamo riusciti a prepararla noi», a button to the wizard `/hub/freelance`, and that from then on the address is the way in through `/hub/accedi`. Greeted by name when the signup has one, «Ciao,» otherwise.

`orbiters welcome --all` walks every signup and every card, once per address, and prints the voice beside the outcome: `inviata (admin)`, `inviata (nessuna)`, `inviata (persona)`, `rifiutata dal provider`, `indirizzo sconosciuto`.

## How I verified it

- `uv run pytest -q projects/hub/packages/core/tests projects/hub/apps/api/tests projects/hub/apps/mcp/tests`: 204 passed. New: one test per voice on the words, one on escaping and the unknown kind, and `send_welcome` over a filled card, a drafted card with its signup and a bare signup through a `RecordingSender`, plus the named-addresses path.
- `uv run mypy`: clean over 289 files; ruff check and format clean.
- The two new voices rendered as a client would (below). The `persona` voice is the one already sent to Ivan as a test on 2026-09-11 (PR #69).

## Anything a reviewer should look at twice

- An address with no card cannot use `/hub/accedi` (`request_link` answers nothing for an unknown address), so that voice sends the person to the wizard first rather than to the login. Ivan's words were «possono fare il login e completare il profilo»; this is the way the hub can honour them.
- «Una cosa in più: abbiamo già un'offerta in linea con il tuo profilo» goes to every drafted card, as Ivan asked. The reply lands on `ciao@joinorbiters.com`.

## Screenshots

**1. The voice for a card we drafted: recap, the ask to complete, the offer.** After only: the voice is new.
![Welcome mail, drafted card](https://github.com/user-attachments/assets/c52757ef-08aa-4e59-9083-dbb80da7d0fb)

**2. The voice for an address with no card: the wizard first.** After only.
![Welcome mail, no card](https://github.com/user-attachments/assets/506bd7c4-f9a9-4da9-8aa4-478c23222fbc)

Linear: ORB-157
