### PR TITLE
style(website): /pigrocrm keeps one door and lists four things

### DIFF
--- a/projects/website/README.md
+++ b/projects/website/README.md
@@ -27,7 +27,7 @@ pnpm --filter website lint
 | Page | Served at | What it is |
 |---|---|---|
 | `src/index.html` | `joinorbiters.com/` | The Orbiters landing: two doors into the hub, how it works, the four voices, the perks. Since 2026-09-11 (ORB-145) |
-| `src/pigrocrm.html` | `/pigrocrm` | PigroCRM's own page (ORB-159): the CRM's call to action with a drawn Claude conversation, what is inside, the guide, the closing box. Its own `pigrocrm.css` on top of `landing.css` |
+| `src/pigrocrm.html` | `/pigrocrm` | PigroCRM's own page (ORB-159): one door into Orbiters beside a drawn Claude conversation, the four things inside, the guide, the closing box. Its own `pigrocrm.css` on top of `landing.css` |
 | `src/orbiters.html` | `/orbiters` | The community page and its signup form, the front door until 2026-09-11 |
 | `src/privacy.html` | `/privacy` | Privacy notice |
 | `src/termini.html` | `/termini` | Terms |

--- a/projects/website/src/pigrocrm.css
+++ b/projects/website/src/pigrocrm.css
@@ -206,9 +206,15 @@
   padding-top: 1rem;
 }
 
-/* Three columns, two rows: six things read as a set, not as four and two. */
+/* Four things: two by two on a tablet, four across on a wide screen (ORB-160). */
 @media (min-width: 48rem) {
   .inside {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 72rem) {
+  .inside {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }

--- a/projects/website/src/pigrocrm.html
+++ b/projects/website/src/pigrocrm.html
@@ -56,13 +56,9 @@
                   lavoro noioso: glielo dici, e lui lo fa su PigroCRM.
                 </p>
                 <p class="actions">
-                  <a class="cta" href="https://pigro.joinorbiters.com/app/registrati">Crea il tuo spazio</a>
-                  <a class="cta secondary" href="/hub/freelance">Entra in Orbiters</a>
+                  <a class="cta" href="/hub/freelance">Entra in Orbiters</a>
                 </p>
-                <p class="fine">
-                  Gratis per chi è in community. Uno spazio tuo, con un database separato, su
-                  pigro.joinorbiters.com/il-tuo-nome. Open source, self-hosted quando vuoi.
-                </p>
+                <p class="fine">Gratis per chi è in community.</p>
               </div>
               <figure class="chat" aria-label="Una conversazione con Claude che emette una fattura su PigroCRM">
                 <div class="chat-bar"><i></i><i></i><i></i><span>Claude</span></div>
@@ -85,7 +81,6 @@
                     </div>
                   </div>
                 </div>
-                <figcaption class="fine">L'assistente parla con PigroCRM attraverso il suo MCP: ogni azione resta tua da rivedere.</figcaption>
               </figure>
             </div>
           </div>
@@ -96,15 +91,13 @@
         <div class="wrap section">
           <p class="kicker" data-reveal>Cosa c'è dentro</p>
           <h2 class="statement" id="dentro" data-reveal style="--d: 0.1s">
-            Sei cose. <span class="accent">Nessun piano da scegliere.</span>
+            Quattro cose. <span class="accent">Nessun piano da scegliere.</span>
           </h2>
           <div class="grid-3 inside">
             <div data-reveal style="--d: 0.25s"><h3>Clienti e trattative</h3><p>Contatti, deal e attività in un posto solo, con i campi che servono a te.</p></div>
             <div data-reveal style="--d: 0.35s"><h3>Offerte e contratti</h3><p>PDF dai tuoi template, già con i tuoi dati fiscali, pronti da mandare.</p></div>
             <div data-reveal style="--d: 0.45s"><h3>Fatture e ore</h3><p>Emetti, incassa, tieni lo stato di ognuna sotto gli occhi. Anche in forfettario.</p></div>
-            <div data-reveal style="--d: 0.55s"><h3>Le email sulla scheda</h3><p>Quello che vi siete scritti resta accanto al cliente, senza aprire Gmail.</p></div>
-            <div data-reveal style="--d: 0.65s"><h3>Un assistente AI</h3><p>Registra le ore, prepara le offerte, emette le fatture, ti riassume la settimana.</p></div>
-            <div data-reveal style="--d: 0.75s"><h3>Uno spazio tuo</h3><p>Database separato, su pigro.joinorbiters.com/il-tuo-nome. O sul tuo server: è open source.</p></div>
+            <div data-reveal style="--d: 0.55s"><h3>Un assistente AI</h3><p>Registra le ore, prepara le offerte, emette le fatture, ti riassume la settimana.</p></div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## What this changes

Ivan's review of `/pigrocrm` on production. The hero's call to action was too wordy: it keeps one button, «Entra in Orbiters», with «Gratis per chi è in community.» under it; «Crea il tuo spazio» and the two lines about the separate database and self-hosting go. The caption under the Claude conversation («L'assistente parla con PigroCRM attraverso il suo MCP…») goes. On the dark band «Le email sulla scheda» and «Uno spazio tuo» leave, the statement reads «Quattro cose. Nessun piano da scegliere.», and the four sit two by two on a tablet and four across on a wide screen.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 217 tests, `pnpm --filter website build` green, `pnpm --filter website test:e2e` 51 passed. Screenshots of the hero and the band at 1440 on the preview, read before attaching.

## Screenshots

**1. `/pigrocrm` hero at 1440, before and after**
![The PigroCRM hero before and after](https://github.com/user-attachments/assets/888ca6c1-e3b6-4921-9546-2069f0a5c72a)

Linear: ORB-160.
