### PR TITLE
feat(hub): the freelancer list says where each lead came from

### DIFF
--- a/projects/hub/apps/api/tests/test_admin_api.py
+++ b/projects/hub/apps/api/tests/test_admin_api.py
@@ -632,6 +632,9 @@ def test_an_admin_writes_an_incomplete_card_from_a_signup_and_the_list_points_at
     assert client.get(f"/api/hub/freelancers/{card['id']}/cv").status_code == 404
     listed = client.get("/api/hub/freelancers").json()["items"]
     assert listed[0]["id"] == card["id"] and listed[0]["completa"] is False
+    # Born from a signup, so it also signed up on the landing: «form» (ORB-161).
+    assert listed[0]["provenienza"] == "form"
+    assert client.get(f"/api/hub/freelancers/{card['id']}").json()["provenienza"] == "form"
 
     # A wrong id is a 404, a bad body a 422 naming the field, as everywhere else.
     assert client.post(f"/api/hub/signups/{MISSING}/scheda", json=DRAFT).status_code == 404

--- a/projects/hub/apps/web/src/lib/api.ts
+++ b/projects/hub/apps/web/src/lib/api.ts
@@ -154,6 +154,9 @@ export interface Freelancer {
   commenti: Comment[]
   /** How many times the person came in through the magic link (ORB-158). */
   accessi: number
+  /** Where the lead came from (ORB-161): «form» when the address is also among the
+   *  signups («Iscrizioni»), «landing» otherwise. */
+  provenienza: 'form' | 'landing'
   /** When they last did, null if never. */
   ultimo_accesso: string | null
 }

--- a/projects/hub/apps/web/src/pages/admin/lists.test.tsx
+++ b/projects/hub/apps/web/src/pages/admin/lists.test.tsx
@@ -38,6 +38,7 @@ const INCOMPLETE = {
   completa: false,
   commenti: [],
   accessi: 0,
+  provenienza: 'form',
   ultimo_accesso: null,
 }
 
@@ -55,6 +56,7 @@ const COMPLETE = {
   compilata_da: 'persona',
   completa: true,
   accessi: 3,
+  provenienza: 'landing',
   ultimo_accesso: '2026-09-11T12:04:00Z',
 }
 
@@ -154,6 +156,15 @@ describe('the Developer e CTO list', () => {
     expect(cellUnder(ada, 'Ultimo accesso')).toHaveTextContent('—')
     const grace = screen.getByText('grace@studio.it').closest('tr')!
     expect(cellUnder(grace, 'Ultimo accesso')).toHaveTextContent(/11 set 2026/)
+  })
+
+  it('says where each lead came from: «form» when the address also signed up, «landing» otherwise (ORB-161)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(200, { totale: 2, items: [INCOMPLETE, COMPLETE] }))
+    mount('/admin/freelance')
+    const ada = (await screen.findByText('ada@studio.it')).closest('tr')!
+    expect(cellUnder(ada, 'Provenienza')).toHaveTextContent('form')
+    const grace = screen.getByText('grace@studio.it').closest('tr')!
+    expect(cellUnder(grace, 'Provenienza')).toHaveTextContent('landing')
   })
 })
 

--- a/projects/hub/apps/web/src/pages/admin/lists.tsx
+++ b/projects/hub/apps/web/src/pages/admin/lists.tsx
@@ -128,6 +128,7 @@ export function AdminFreelancers() {
           <thead className="text-left text-xs text-muted-foreground">
             <tr className="border-b">
               <th className="px-6 py-2 font-medium">Chi</th>
+              <th className="px-3 py-2 font-medium">Provenienza</th>
               <th className="px-3 py-2 font-medium">Posizione</th>
               <th className="px-3 py-2 text-right font-medium">Tariffa</th>
               <th className="px-3 py-2 font-medium">Dove</th>
@@ -145,6 +146,7 @@ export function AdminFreelancers() {
                   </Link>
                   <p className="text-xs text-muted-foreground">{item.email}</p>
                 </td>
+                <td className="px-3 py-2.5 text-muted-foreground">{item.provenienza}</td>
                 <td className="px-3 py-2.5">{item.posizione ?? '—'}</td>
                 <td className="px-3 py-2.5 text-right tabular-nums">
                   {item.tariffa_giornaliera === null ? '—' : formatEuro(item.tariffa_giornaliera)}
@@ -260,6 +262,7 @@ export function AdminFreelancerDetail() {
             ) : '—'}
           </Row>
           <Row label="Arrivato">{formatDate(f.created_at)}{f.utm_source ? ` · da ${f.utm_source}` : ''}</Row>
+          <Row label="Provenienza">{f.provenienza}</Row>
           <Row label="Accessi">
             {f.accessi === 0 || f.ultimo_accesso === null
               ? 'Mai entrato'

--- a/projects/hub/packages/core/src/orbiters_core/freelancers.py
+++ b/projects/hub/packages/core/src/orbiters_core/freelancers.py
@@ -78,12 +78,19 @@ def _logins_per_card() -> Subquery:
     )
 
 
+def _signed_up() -> Subquery:
+    """Which addresses are also on the landing's list (ORB-161), lowercased once so the
+    join lands on `uq_orbiters_signups_email_lower` rather than on a function per row."""
+    return select(func.lower(Signup.email).label("email")).subquery()
+
+
 def _read_with_logins(
-    row: Freelancer, accessi: int | None, ultimo: datetime | None
+    row: Freelancer, accessi: int | None, ultimo: datetime | None, signed_up: object
 ) -> FreelancerRead:
     read = FreelancerRead.model_validate(row)
     read.accessi = accessi or 0
     read.ultimo_accesso = ultimo
+    read.provenienza = "form" if signed_up is not None else "landing"
     return read
 
 
@@ -179,9 +186,11 @@ class FreelancerService:
         self, limit: int = LIST_LIMIT_DEFAULT, stato: str | None = None
     ) -> FreelancerList:
         limit = max(1, min(limit, LIST_LIMIT_MAX))
-        logins = _logins_per_card()
-        stmt = select(Freelancer, logins.c.accessi, logins.c.ultimo_accesso).outerjoin(
-            logins, logins.c.freelancer_id == Freelancer.id
+        logins, signed = _logins_per_card(), _signed_up()
+        stmt = (
+            select(Freelancer, logins.c.accessi, logins.c.ultimo_accesso, signed.c.email)
+            .outerjoin(logins, logins.c.freelancer_id == Freelancer.id)
+            .outerjoin(signed, signed.c.email == func.lower(Freelancer.email))
         )
         count = select(func.count()).select_from(Freelancer)
         if stato is not None:
@@ -193,7 +202,10 @@ class FreelancerService:
         totale = self.session.scalar(count) or 0
         return FreelancerList(
             totale=totale,
-            items=[_read_with_logins(row, accessi, ultimo) for row, accessi, ultimo in rows],
+            items=[
+                _read_with_logins(row, accessi, ultimo, signed_up)
+                for row, accessi, ultimo, signed_up in rows
+            ],
         )
 
     def get(self, freelancer_id: UUID) -> FreelancerRead:
@@ -206,7 +218,11 @@ class FreelancerService:
                 logins.c.freelancer_id == row.id
             )
         ).first()
-        read = _read_with_logins(row, *(counted or (None, None)))
+        signed_up = self.session.scalar(
+            select(Signup.id).where(func.lower(Signup.email) == row.email.lower())
+        )
+        accessi, ultimo = counted if counted is not None else (None, None)
+        read = _read_with_logins(row, accessi, ultimo, signed_up)
         read.commenti = CommentService(self.session).list(ENTITY, freelancer_id)
         return read
 

--- a/projects/hub/packages/core/src/orbiters_core/schemas.py
+++ b/projects/hub/packages/core/src/orbiters_core/schemas.py
@@ -484,6 +484,10 @@ class FreelancerRead(BaseModel):
     # Filled by the service with one grouped join; `0` and `None` for a card never opened.
     accessi: int = 0
     ultimo_accesso: datetime | None = None
+    # Where the lead came from, in Ivan's words (ORB-161): «form» when the address also
+    # left its email on the landing («Iscrizioni»), «landing» otherwise. Derived by the
+    # service from the two tables, never stored, so it cannot drift.
+    provenienza: str = "landing"
     utm_source: str | None = None
     utm_medium: str | None = None
     utm_campaign: str | None = None

--- a/projects/hub/packages/core/tests/test_freelancers_companies.py
+++ b/projects/hub/packages/core/tests/test_freelancers_companies.py
@@ -315,3 +315,14 @@ def test_a_card_without_a_cv_has_none_to_download(clean: Session) -> None:
     with pytest.raises(NotFound) as missing:
         service.cv(drafted.id)
     assert missing.value.details["entity"] == "cv"
+
+
+def test_a_card_says_whether_its_address_also_signed_up_on_the_landing(clean: Session) -> None:
+    service = FreelancerService(clean)
+    wizard_only = service.apply(_application("solo@studio.it"), PDF, "cv.pdf", "application/pdf")
+    _signup(clean, "Ada@studio.it")
+    both = service.apply(_application("ada@studio.it"), PDF, "cv.pdf", "application/pdf")
+    listed = {item.email: item.provenienza for item in service.list_recent().items}
+    assert listed == {"solo@studio.it": "landing", "ada@studio.it": "form"}
+    assert service.get(wizard_only.id).provenienza == "landing"
+    assert service.get(both.id).provenienza == "form"


### PR DESCRIPTION
## What this changes

«Developer e CTO» listed every card without saying where the lead came from: through the hub's wizard alone, or from an address that first left its email on the landing and shows under «Iscrizioni». Ivan asked for a column, «form» when the address is also among the signups, «landing» otherwise, in those words.

Every card the admin reads now carries `provenienza`, derived from the two tables and never stored: one more outer join in the statements that already count the logins. The list gains a «Provenienza» column after «Chi», the card a «Provenienza» row. The MCP reads carry the field with no change to their names.

## How I verified it

- `uv run pytest -q projects/hub/packages/core/tests projects/hub/apps/api/tests projects/hub/apps/mcp/tests`: 205 passed (new: a wizard-only card reads «landing» and one whose address also signed up, with a different case, reads «form», on the list and on the detail; the API test on a card born from a signup asserts «form» on both routes).
- `uv run mypy`: clean over 289 files; ruff check and format clean.
- `pnpm --filter hub test`: 79 passed (new: the list shows «form» and «landing» under the column). `pnpm --filter hub lint` and `pnpm --filter hub build` clean.
- Screenshots against a throwaway Postgres at head, three cards, the feature API on 8139 and main's on 8140.

## Anything a reviewer should look at twice

The values are Ivan's words: «form» for an address that signed up on the landing, «landing» for one that did not. They read the other way round from what the names suggest, and they are kept as asked; the API doc comment says what each means.

## API changes

`FreelancerRead` (list items and detail) gains `provenienza: "form" | "landing"`. The hand-written client `projects/hub/apps/web/src/lib/api.ts` follows on `Freelancer`.

## Screenshots

**1. The list: the «Provenienza» column**
![Freelancer list, before and after](https://github.com/user-attachments/assets/f1c65520-6c75-4791-a779-0f58e28a949e)

**2. The card: the «Provenienza» row**
![Freelancer detail, before and after](https://github.com/user-attachments/assets/c33ec547-0e30-4414-bb2e-a7e375fb3d7a)

Linear: ORB-161
