### PR TITLE
style(website): the PigroCRM hero lead is one sentence

### DIFF
--- a/projects/website/src/pigrocrm.html
+++ b/projects/website/src/pigrocrm.html
@@ -52,8 +52,8 @@
                 <p class="kicker">PigroCRM</p>
                 <h1 class="measure-tight">Il CRM che lavora <span class="accent">al posto tuo.</span></h1>
                 <p class="lead measure">
-                  Clienti, offerte, fatture e pagamenti in un posto solo. Un assistente AI fa il
-                  lavoro noioso: glielo dici, e lui lo fa su PigroCRM.
+                  Clienti, offerte, fatture e pagamenti in un posto solo, con un assistente AI che
+                  fa il lavoro noioso per te.
                 </p>
                 <p class="actions">
                   <a class="cta" href="/hub/freelance">Entra in Orbiters</a>


### PR DESCRIPTION
## What this changes

The lead under «Il CRM che lavora al posto tuo.» on `/pigrocrm` was two sentences («Clienti, offerte, fatture e pagamenti in un posto solo. Un assistente AI fa il lavoro noioso: glielo dici, e lui lo fa su PigroCRM.») and Ivan wants one. It is now «Clienti, offerte, fatture e pagamenti in un posto solo, con un assistente AI che fa il lavoro noioso per te.» One string in `pigrocrm.html`.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 217 tests, `pnpm --filter website build` green, `pnpm --filter website test:e2e` 51 passed. The preview renders the new sentence in the hero; screenshot read before attaching.

## Screenshots

**1. `/pigrocrm` hero at 1440, before and after**
![The PigroCRM hero lead before and after](https://github.com/user-attachments/assets/a631c893-be43-4c44-a8d5-87ef2c48f378)

Linear: ORB-162.
