### PR TITLE
feat(hub): signups without a card sit in the freelancer list as leads

### DIFF
--- a/projects/hub/apps/api/tests/test_admin_api.py
+++ b/projects/hub/apps/api/tests/test_admin_api.py
@@ -630,8 +630,11 @@ def test_an_admin_writes_an_incomplete_card_from_a_signup_and_the_list_points_at
     item = next(i for i in items if i["id"] == signup_id)
     assert item["freelancer_id"] == card["id"]
     assert client.get(f"/api/hub/freelancers/{card['id']}/cv").status_code == 404
-    listed = client.get("/api/hub/freelancers").json()["items"]
+    everything = client.get("/api/hub/freelancers").json()
+    listed = everything["items"]
     assert listed[0]["id"] == card["id"] and listed[0]["completa"] is False
+    # With a card, the signup is no longer a lead (ORB-163).
+    assert everything["lead"] == [] and everything["totale_lead"] == 0
     # Born from a signup, so it also signed up on the landing: «form» (ORB-161).
     assert listed[0]["provenienza"] == "form"
     assert client.get(f"/api/hub/freelancers/{card['id']}").json()["provenienza"] == "form"
@@ -641,6 +644,18 @@ def test_an_admin_writes_an_incomplete_card_from_a_signup_and_the_list_points_at
     bad = client.post(f"/api/hub/signups/{signup_id}/scheda", json={**DRAFT, "fonti": []})
     assert bad.status_code == 422
     assert bad.json()["detail"][0]["loc"][-1] == "fonti"
+
+
+def test_a_signup_without_a_card_is_a_lead_on_the_freelancer_list(
+    client: TestClient, admin: None
+) -> None:
+    signup_id = _signup(client, "lead@studio.it")
+    everything = client.get("/api/hub/freelancers").json()
+    assert everything["items"] == [] and everything["totale_lead"] == 1
+    assert everything["lead"][0]["id"] == signup_id
+    assert everything["lead"][0]["email"] == "lead@studio.it"
+    assert client.get("/api/hub/freelancers", params={"stato": "lead"}).json()["totale_lead"] == 1
+    assert client.get("/api/hub/freelancers", params={"stato": "nuovo"}).json()["lead"] == []
 
 
 def test_research_is_refused_on_a_card_the_person_filled(client: TestClient, admin: None) -> None:

--- a/projects/hub/apps/mcp/src/orbiters_mcp/server.py
+++ b/projects/hub/apps/mcp/src/orbiters_mcp/server.py
@@ -105,7 +105,9 @@ def build_server(factory: SessionFactory) -> MCPServer:
         """I freelance che hanno compilato il profilo sull'hub, dal più recente: nome,
         email, posizione, tariffa a giornata, disponibilità (remoto/ibrido/in_sede), link,
         stato della candidatura (nuovo, contattato, attivo, scartato) e note. Mai il CV:
-        quello si scarica dall'area admin. `stato` filtra; `totale` conta tutto."""
+        quello si scarica dall'area admin. `stato` filtra; `totale` conta tutto. `lead`
+        sono le iscrizioni senza scheda (nome se c'è, email, quando), `totale_lead` quante:
+        piene senza filtro o con `stato="lead"`, vuote con un altro stato."""
         return _run(lambda s: FreelancerService(s).list_recent(limit=limit, stato=stato))
 
     @mcp.tool()

--- a/projects/hub/apps/web/src/lib/api.ts
+++ b/projects/hub/apps/web/src/lib/api.ts
@@ -253,8 +253,10 @@ export const admin = {
     request<Admin>('/api/hub/auth/login', json({ email, password })),
   logout: () => request<void>('/api/hub/auth/logout', { method: 'POST' }),
   me: () => request<Admin>('/api/hub/auth/me'),
+  /** Cards and, beside them, the leads: signups whose address has no card yet (ORB-163).
+   *  `stato: 'lead'` answers leads alone; another state answers cards alone. */
   freelancers: (stato?: string) =>
-    request<{ totale: number; items: Freelancer[] }>(
+    request<{ totale: number; items: Freelancer[]; totale_lead: number; lead: Signup[] }>(
       `/api/hub/freelancers?limit=500${stato ? `&stato=${encodeURIComponent(stato)}` : ''}`,
     ),
   freelancer: (id: string) => request<Freelancer>(`/api/hub/freelancers/${id}`),

--- a/projects/hub/apps/web/src/lib/format.ts
+++ b/projects/hub/apps/web/src/lib/format.ts
@@ -30,9 +30,13 @@ export function formatBytes(size: number): string {
 
 export const REMOTO_LABELS = { remoto: 'Da remoto', ibrido: 'Ibrido', in_sede: 'In sede' } as const
 export const FREELANCER_STATES = ['nuovo', 'contattato', 'attivo', 'scartato'] as const
+/** The states the freelancer list filters by: the card's four, plus the pseudo-state of a
+ *  signup with no card (ORB-163). */
+export const FREELANCER_LIST_STATES = [...FREELANCER_STATES, 'lead'] as const
 export const COMPANY_STATES = ['nuovo', 'contattato', 'in_corso', 'chiuso'] as const
 export const STATE_LABELS: Record<string, string> = {
   nuovo: 'Nuovo',
+  lead: 'Lead',
   contattato: 'Contattato',
   attivo: 'Attivo',
   scartato: 'Scartato',

--- a/projects/hub/apps/web/src/pages/admin/lists.test.tsx
+++ b/projects/hub/apps/web/src/pages/admin/lists.test.tsx
@@ -133,7 +133,7 @@ describe('the Iscrizioni page', () => {
 
 describe('the Developer e CTO list', () => {
   it('renders an incomplete card with dashes and a «Da completare» pill', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(200, { totale: 2, items: [INCOMPLETE, COMPLETE] }))
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(200, { totale: 2, items: [INCOMPLETE, COMPLETE], totale_lead: 0, lead: [] }))
     mount('/admin/freelance')
     const ada = (await screen.findByText('ada@studio.it')).closest('tr')!
     expect(cellUnder(ada, 'Posizione')).toHaveTextContent('—')
@@ -150,7 +150,7 @@ describe('the Developer e CTO list', () => {
   })
 
   it('shows when each member last came in, or a dash for one who never did (ORB-158)', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(200, { totale: 2, items: [INCOMPLETE, COMPLETE] }))
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(200, { totale: 2, items: [INCOMPLETE, COMPLETE], totale_lead: 0, lead: [] }))
     mount('/admin/freelance')
     const ada = (await screen.findByText('ada@studio.it')).closest('tr')!
     expect(cellUnder(ada, 'Ultimo accesso')).toHaveTextContent('—')
@@ -159,12 +159,30 @@ describe('the Developer e CTO list', () => {
   })
 
   it('says where each lead came from: «form» when the address also signed up, «landing» otherwise (ORB-161)', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(200, { totale: 2, items: [INCOMPLETE, COMPLETE] }))
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(answer(200, { totale: 2, items: [INCOMPLETE, COMPLETE], totale_lead: 0, lead: [] }))
     mount('/admin/freelance')
     const ada = (await screen.findByText('ada@studio.it')).closest('tr')!
     expect(cellUnder(ada, 'Provenienza')).toHaveTextContent('form')
     const grace = screen.getByText('grace@studio.it').closest('tr')!
     expect(cellUnder(grace, 'Provenienza')).toHaveTextContent('landing')
+  })
+})
+
+describe('the leads on the Developer e CTO list (ORB-163)', () => {
+  it('lists a signup with no card as a «Lead» row with dashes and no link, and counts it', async () => {
+    const lead = SIGNUPS.find((signup) => signup.freelancer_id === null)!
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      answer(200, { totale: 1, items: [COMPLETE], totale_lead: 1, lead: [lead] }),
+    )
+    mount('/admin/freelance')
+    const row = (await screen.findByText(lead.email)).closest('tr')!
+    expect(cellUnder(row, 'Stato')).toHaveTextContent('Lead')
+    expect(cellUnder(row, 'Provenienza')).toHaveTextContent('form')
+    expect(cellUnder(row, 'Posizione')).toHaveTextContent('—')
+    expect(cellUnder(row, 'Ultimo accesso')).toHaveTextContent('—')
+    expect(within(row).queryByRole('link')).toBeNull()
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('2')
+    expect(screen.getByRole('button', { name: 'Lead' })).toBeInTheDocument()
   })
 })
 

--- a/projects/hub/apps/web/src/pages/admin/lists.tsx
+++ b/projects/hub/apps/web/src/pages/admin/lists.tsx
@@ -5,9 +5,10 @@ import { useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { admin, type Comment, type Company, type Freelancer } from '@/lib/api'
+import { admin, type Comment, type Company, type Freelancer, type Signup } from '@/lib/api'
 import {
   COMPANY_STATES,
+  FREELANCER_LIST_STATES,
   FREELANCER_STATES,
   REMOTO_LABELS,
   STATE_LABELS,
@@ -21,6 +22,7 @@ import { Comments } from './Comments'
 
 const TONE: Record<string, string> = {
   nuovo: 'bg-[var(--color-royal-gold)]',
+  lead: 'bg-muted',
   contattato: 'bg-muted-foreground',
   attivo: 'bg-foreground',
   in_corso: 'bg-foreground',
@@ -109,19 +111,32 @@ export function Figure({ label, value, note }: { label: string; value: number; n
 
 // ---- freelancers -----------------------------------------------------------------------
 
+/** One row of the freelancer table: a card, or a lead (a signup with no card, ORB-163),
+ *  ordered together by when they arrived. */
+type FreelancerRow = { kind: 'card'; at: string; card: Freelancer } | { kind: 'lead'; at: string; lead: Signup }
+
+function mergeRows(items: Freelancer[], leads: Signup[]): FreelancerRow[] {
+  const rows: FreelancerRow[] = [
+    ...items.map((card): FreelancerRow => ({ kind: 'card', at: card.created_at, card })),
+    ...leads.map((lead): FreelancerRow => ({ kind: 'lead', at: lead.created_at, lead })),
+  ]
+  return rows.sort((a, b) => b.at.localeCompare(a.at))
+}
+
 export function AdminFreelancers() {
   const [stato, setStato] = useState<string | undefined>(undefined)
   const list = useQuery({ queryKey: ['freelancers', stato], queryFn: () => admin.freelancers(stato) })
+  const rows = list.data ? mergeRows(list.data.items, list.data.lead) : []
   return (
     <>
-      <Header title="Developer e CTO" count={list.data?.totale}>
-        <StateFilter states={FREELANCER_STATES} value={stato} onChange={setStato} />
+      <Header title="Developer e CTO" count={list.data ? list.data.totale + list.data.totale_lead : undefined}>
+        <StateFilter states={FREELANCER_LIST_STATES} value={stato} onChange={setStato} />
       </Header>
       {list.isError ? (
         <Empty>Non riesco a leggere la lista.</Empty>
       ) : list.isPending ? (
         <Empty>Caricamento…</Empty>
-      ) : list.data.items.length === 0 ? (
+      ) : rows.length === 0 ? (
         <Empty>Nessun profilo qui.</Empty>
       ) : (
         <table className="w-full text-sm">
@@ -138,36 +153,61 @@ export function AdminFreelancers() {
             </tr>
           </thead>
           <tbody>
-            {list.data.items.map((item) => (
-              <tr key={item.id} className="border-b last:border-0 hover:bg-muted">
+            {rows.map((row) =>
+              row.kind === 'lead' ? (
+                <LeadRow key={`lead-${row.lead.id}`} lead={row.lead} />
+              ) : (
+              <tr key={row.card.id} className="border-b last:border-0 hover:bg-muted">
                 <td className="px-6 py-2.5">
-                  <Link to="/admin/freelance/$id" params={{ id: item.id }} className="font-medium hover:underline">
-                    {item.nome} {item.cognome}
+                  <Link to="/admin/freelance/$id" params={{ id: row.card.id }} className="font-medium hover:underline">
+                    {row.card.nome} {row.card.cognome}
                   </Link>
-                  <p className="text-xs text-muted-foreground">{item.email}</p>
+                  <p className="text-xs text-muted-foreground">{row.card.email}</p>
                 </td>
-                <td className="px-3 py-2.5 text-muted-foreground">{item.provenienza}</td>
-                <td className="px-3 py-2.5">{item.posizione ?? '—'}</td>
+                <td className="px-3 py-2.5 text-muted-foreground">{row.card.provenienza}</td>
+                <td className="px-3 py-2.5">{row.card.posizione ?? '—'}</td>
                 <td className="px-3 py-2.5 text-right tabular-nums">
-                  {item.tariffa_giornaliera === null ? '—' : formatEuro(item.tariffa_giornaliera)}
+                  {row.card.tariffa_giornaliera === null ? '—' : formatEuro(row.card.tariffa_giornaliera)}
                 </td>
-                <td className="px-3 py-2.5">{item.remoto ? REMOTO_LABELS[item.remoto] : '—'}</td>
+                <td className="px-3 py-2.5">{row.card.remoto ? REMOTO_LABELS[row.card.remoto] : '—'}</td>
                 <td className="px-3 py-2.5">
                   <div className="flex flex-wrap items-center gap-1.5">
-                    <StatePill stato={item.stato} />
-                    {!item.completa && <IncompletePill />}
+                    <StatePill stato={row.card.stato} />
+                    {!row.card.completa && <IncompletePill />}
                   </div>
                 </td>
                 <td className="px-3 py-2.5 text-muted-foreground">
-                  {item.ultimo_accesso === null ? '—' : formatDateTime(item.ultimo_accesso)}
+                  {row.card.ultimo_accesso === null ? '—' : formatDateTime(row.card.ultimo_accesso)}
                 </td>
-                <td className="px-6 py-2.5 text-right text-muted-foreground">{formatDate(item.created_at)}</td>
+                <td className="px-6 py-2.5 text-right text-muted-foreground">{formatDate(row.card.created_at)}</td>
               </tr>
-            ))}
+              ),
+            )}
           </tbody>
         </table>
       )}
     </>
+  )
+}
+
+/** A signup with no card (ORB-163): what the landing knows, a «Lead» pill, dashes for
+ *  everything a card would carry, and no link, since there is no card to open. */
+function LeadRow({ lead }: { lead: Signup }) {
+  const name = [lead.nome, lead.cognome].filter(Boolean).join(' ')
+  return (
+    <tr className="border-b last:border-0 hover:bg-muted">
+      <td className="px-6 py-2.5">
+        <p className="font-medium">{name || '—'}</p>
+        <p className="text-xs text-muted-foreground">{lead.email}</p>
+      </td>
+      <td className="px-3 py-2.5 text-muted-foreground">form</td>
+      <td className="px-3 py-2.5">—</td>
+      <td className="px-3 py-2.5 text-right">—</td>
+      <td className="px-3 py-2.5">—</td>
+      <td className="px-3 py-2.5"><StatePill stato="lead" /></td>
+      <td className="px-3 py-2.5 text-muted-foreground">—</td>
+      <td className="px-6 py-2.5 text-right text-muted-foreground">{formatDate(lead.created_at)}</td>
+    </tr>
   )
 }
 

--- a/projects/hub/packages/core/src/orbiters_core/freelancers.py
+++ b/projects/hub/packages/core/src/orbiters_core/freelancers.py
@@ -24,10 +24,14 @@ from orbiters_core.schemas import (
     FreelancerDraft,
     FreelancerList,
     FreelancerRead,
+    SignupListItem,
     StatusChange,
 )
 
 ENTITY = "freelancer"
+# The pseudo-state the list filter uses for signups without a card (ORB-163): never
+# stored on a row, since a lead has no row of its own.
+LEAD_STATE = "lead"
 LIST_LIMIT_DEFAULT = 100
 LIST_LIMIT_MAX = 500
 PDF_MAGIC = b"%PDF-"
@@ -186,6 +190,10 @@ class FreelancerService:
         self, limit: int = LIST_LIMIT_DEFAULT, stato: str | None = None
     ) -> FreelancerList:
         limit = max(1, min(limit, LIST_LIMIT_MAX))
+        if stato == LEAD_STATE:
+            lead, totale_lead = self._leads(limit)
+            return FreelancerList(totale=0, items=[], totale_lead=totale_lead, lead=lead)
+        lead, totale_lead = self._leads(limit) if stato is None else ([], 0)
         logins, signed = _logins_per_card(), _signed_up()
         stmt = (
             select(Freelancer, logins.c.accessi, logins.c.ultimo_accesso, signed.c.email)
@@ -206,7 +214,30 @@ class FreelancerService:
                 _read_with_logins(row, accessi, ultimo, signed_up)
                 for row, accessi, ultimo, signed_up in rows
             ],
+            totale_lead=totale_lead,
+            lead=lead,
         )
+
+    def _leads(self, limit: int) -> tuple[list[SignupListItem], int]:
+        """Signups whose address has no card (ORB-163), newest first, and how many
+        there are: one anti-join on the two case-insensitive indexes."""
+        no_card = Freelancer.id.is_(None)
+        base = select(Signup).outerjoin(
+            Freelancer, func.lower(Freelancer.email) == func.lower(Signup.email)
+        )
+        rows = self.session.scalars(
+            base.where(no_card).order_by(Signup.created_at.desc(), Signup.id.desc()).limit(limit)
+        ).all()
+        totale = (
+            self.session.scalar(
+                select(func.count())
+                .select_from(Signup)
+                .outerjoin(Freelancer, func.lower(Freelancer.email) == func.lower(Signup.email))
+                .where(no_card)
+            )
+            or 0
+        )
+        return [SignupListItem.model_validate(row) for row in rows], totale
 
     def get(self, freelancer_id: UUID) -> FreelancerRead:
         """The row with its thread of comments, newest first. Only here: the list

--- a/projects/hub/packages/core/src/orbiters_core/schemas.py
+++ b/projects/hub/packages/core/src/orbiters_core/schemas.py
@@ -505,8 +505,15 @@ class FreelancerRead(BaseModel):
 
 
 class FreelancerList(BaseModel):
+    """The cards, and since ORB-163 the leads beside them: signups whose address has no
+    card yet, as «Developer e CTO» shows them with a «Lead» state. `totale` counts the
+    cards the filter selects, `totale_lead` the leads; `lead` is empty when a `stato`
+    other than «lead» is asked for, `items` when «lead» is."""
+
     totale: int
     items: list[FreelancerRead]
+    totale_lead: int = 0
+    lead: list[SignupListItem] = Field(default_factory=list)
 
 
 class CompanyRead(BaseModel):

--- a/projects/hub/packages/core/tests/test_freelancers_companies.py
+++ b/projects/hub/packages/core/tests/test_freelancers_companies.py
@@ -326,3 +326,21 @@ def test_a_card_says_whether_its_address_also_signed_up_on_the_landing(clean: Se
     assert listed == {"solo@studio.it": "landing", "ada@studio.it": "form"}
     assert service.get(wizard_only.id).provenienza == "landing"
     assert service.get(both.id).provenienza == "form"
+
+
+def test_signups_without_a_card_are_the_leads_beside_the_cards(clean: Session) -> None:
+    service = FreelancerService(clean)
+    service.apply(_application("ada@studio.it"), PDF, "cv.pdf", "application/pdf")
+    _signup(clean, "ADA@studio.it")  # has a card: not a lead
+    _signup(clean, "nuovo@studio.it", nome="Nuovo", cognome="Arrivato")
+    everything = service.list_recent()
+    assert [item.email for item in everything.items] == ["ada@studio.it"]
+    assert [lead.email for lead in everything.lead] == ["nuovo@studio.it"]
+    assert (everything.totale, everything.totale_lead) == (1, 1)
+    assert everything.lead[0].freelancer_id is None and everything.lead[0].nome == "Nuovo"
+    only_leads = service.list_recent(stato="lead")
+    assert only_leads.items == [] and [lead.email for lead in only_leads.lead] == [
+        "nuovo@studio.it"
+    ]
+    only_new = service.list_recent(stato="nuovo")
+    assert len(only_new.items) == 1 and only_new.lead == [] and only_new.totale_lead == 0


### PR DESCRIPTION
## What this changes

An address that left its email on the landing and has no card showed under «Iscrizioni» alone, so the admin read two lists to see every lead. Ivan asked: «anche le iscrizioni mancanti le vorrei vedere nella tabella di Developer e CTO, con uno stato tipo lead».

`GET /api/hub/freelancers` now carries the leads beside the cards: `lead`, the signups whose address has no card yet, newest first, and `totale_lead`. Without a `stato` filter the answer has both; `stato=lead` the leads alone; another state the cards alone. The web merges the two by date into one table. A lead row shows what the landing knows (the name when there is one, else «—», and the address), «form» as provenance, dashes for position, rate, place and last login, a «Lead» pill, the signup date, and no link, since there is no card to open. The filter gains a «Lead» button and the header counts cards and leads together. The MCP tool `list_freelancers` reads the same shape.

No `freelancers` row is created for a lead: a signup is not a card, and the bare addresses have no name to give one.

## How I verified it

- `uv run pytest -q projects/hub/packages/core/tests projects/hub/apps/api/tests projects/hub/apps/mcp/tests`: 207 passed (new: a signup with a card is not a lead while one without is, the three filter cases; over HTTP a bare signup is a lead with its id and address, «lead» and «nuovo» filters answer as designed).
- `uv run mypy`: clean over 289 files; ruff check and format clean.
- `pnpm --filter hub test`: 80 passed (new: a lead row with the pill, «form», dashes, no link, the header count and the «Lead» filter button). `pnpm --filter hub lint` and `pnpm --filter hub build` clean.
- Screenshot against a throwaway Postgres at head, three cards and two signups without a card, the feature API on 8141 and main's on 8142.

## Anything a reviewer should look at twice

- The header count adds `totale_lead` to `totale`, so «Developer e CTO 5» now means three cards and two leads; the «Lead» filter shows leads alone and the other filters cards alone.
- Leads are ordered with cards by `created_at` on the client, after the server has applied `limit` to each list separately.

## API changes

`GET /api/hub/freelancers`: the body gains `totale_lead: int` and `lead: SignupListItem[]`; `stato=lead` is accepted. The hand-written client `projects/hub/apps/web/src/lib/api.ts` follows.

## MCP surface

No tool added or renamed; `list_freelancers` carries `lead` and `totale_lead`, and its docstring says so.

## Screenshots

**1. The list with two leads among the cards, and the «Lead» filter**
![Freelancer list, before and after](https://github.com/user-attachments/assets/a5c2bca5-c7b4-4053-b0b4-0ea9b38b0151)

Linear: ORB-163
