### PR TITLE
style(website): /pigrocrm shows the four voices on white

### DIFF
--- a/projects/website/src/pigrocrm.css
+++ b/projects/website/src/pigrocrm.css
@@ -218,3 +218,16 @@
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
+
+/* --- The four voices on white (ORB-164): the landing draws them on the ink with light
+   rules; here the box is white, so the rules are the ink at the card's strength and the
+   captions keep their quiet ink. The `data-reveal` blocks inside inherit nothing odd:
+   the box itself rises, the figures with it. */
+.voices-light .voices .testimonial {
+  border-top-color: color-mix(in oklab, var(--landing-ink) 15%, transparent);
+}
+
+.voices-light .voices [data-reveal] {
+  opacity: 1;
+  transform: none;
+}

--- a/projects/website/src/pigrocrm.html
+++ b/projects/website/src/pigrocrm.html
@@ -102,6 +102,56 @@
         </div>
       </section>
 
+      <!-- The four voices, the landing's, on white (ORB-164): a box on the light band
+        between what is inside and the guide, so the page says who is already using
+        this before it asks. Same names, faces and links as on the landing. -->
+      <section class="band" aria-labelledby="voci">
+        <div class="wrap section">
+          <p class="kicker" id="voci" data-reveal>Hanno lavorato con noi</p>
+          <h2 class="statement" data-reveal style="--d: 0.1s">Chi è già <span class="accent">in orbita.</span></h2>
+          <div class="box voices-light" data-reveal style="--d: 0.2s">
+            <div class="grid-2 voices">
+              <figure class="testimonial" data-reveal style="--d: 0.25s">
+                <blockquote>
+                  <p>«Il progetto giusto mi è arrivato da chi conosceva già il mio lavoro.»</p>
+                </blockquote>
+                <figcaption class="who">
+                  <a class="avatar" href="https://www.linkedin.com/in/ivan-sala/" aria-label="Ivan Sala su LinkedIn"><img src="./voices/ivan-sala.webp" alt="" width="96" height="96" loading="lazy" /></a>
+                  <span><strong>Ivan Sala</strong><br /><span class="role">Fractional CTO · talento</span></span>
+                </figcaption>
+              </figure>
+              <figure class="testimonial" data-reveal style="--d: 0.4s">
+                <blockquote>
+                  <p>«Persone già selezionate da chi fa il loro mestiere. Niente CV da filtrare.»</p>
+                </blockquote>
+                <figcaption class="who">
+                  <a class="avatar" href="https://www.linkedin.com/in/informatizzato/" aria-label="Lorenzo Fiore su LinkedIn"><img src="./voices/lorenzo-fiore.webp" alt="" width="96" height="96" loading="lazy" /></a>
+                  <span><strong>Lorenzo Fiore</strong><br /><span class="role">Fractional CTO · azienda</span></span>
+                </figcaption>
+              </figure>
+              <figure class="testimonial" data-reveal style="--d: 0.55s">
+                <blockquote>
+                  <p>«Cercavo un backend developer. In una settimana avevo due nomi giusti.»</p>
+                </blockquote>
+                <figcaption class="who">
+                  <a class="avatar" href="https://www.linkedin.com/in/luca-franzesi/" aria-label="Luca Franzesi su LinkedIn"><img src="./voices/luca-franzesi.webp" alt="" width="96" height="96" loading="lazy" /></a>
+                  <span><strong>Luca Franzesi</strong><br /><span class="role">Head of Software Solution · azienda</span></span>
+                </figcaption>
+              </figure>
+              <figure class="testimonial" data-reveal style="--d: 0.7s">
+                <blockquote>
+                  <p>«Offerta, contratto e fattura in una sera. Il resto del tempo lo passo a lavorare.»</p>
+                </blockquote>
+                <figcaption class="who">
+                  <a class="avatar" href="https://www.linkedin.com/in/andreaciceri/" aria-label="Andrea Ciceri su LinkedIn"><img src="./voices/andrea-ciceri.webp" alt="" width="96" height="96" loading="lazy" /></a>
+                  <span><strong>Andrea Ciceri</strong><br /><span class="role">Lead Infrastructure Engineer · talento</span></span>
+                </figcaption>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <!-- The second perk. It is announced here and downloaded in the hub: the file is
         behind the member session (`GET /api/hub/me/guida`), so this section links to the
         wizard and never to a PDF. Deliberately a section of its own rather than a fourth


### PR DESCRIPTION
## What this changes

Ivan asked for the testimonials on `/pigrocrm` too, between «Cosa c'è dentro» and the guide, on a white background. The landing's four voices (the same figures: faces, names, roles, LinkedIn links) now sit in a white box on a light band there, under the kicker «Hanno lavorato con noi» and the statement «Chi è già in orbita.». On the landing the voices are drawn on the ink with light rules; here the box is white, so the rules are the ink at the card's strength. The markup is copied from `index.html`, so a change to a voice is still two places, and the page's own sheet holds the two rules it needs.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 217 tests, `pnpm --filter website build` green, `pnpm --filter website test:e2e` 51 passed. Screenshot of the new section at 1440, read before attaching.

## Screenshots

**1. `/pigrocrm` full page at 1440, before and after**
![The PigroCRM page with the four voices](https://github.com/user-attachments/assets/95e883d4-33db-4446-8707-52c48d019f7a)

Linear: ORB-164.
