### PR TITLE
style(website): the perk section takes the guide's shape

### DIFF
--- a/projects/website/src/index.html
+++ b/projects/website/src/index.html
@@ -193,41 +193,23 @@
         </div>
       </section>
 
-      <section class="band" aria-labelledby="perk">
+      <!-- The first perk, in the guide's shape (ORB-165): kicker, statement, one lead,
+        one door, one line, centred on a light band. The detail lives on /pigrocrm now. -->
+      <section class="band centred" aria-labelledby="perk">
         <div class="wrap section">
           <p class="kicker" id="perk" data-reveal>PigroCRM, il perk</p>
-          <div class="box" data-reveal style="--d: 0.15s">
-            <h2 class="measure-tight">Il CRM che lavora <span class="accent">al posto tuo.</span></h2>
-            <p class="lead measure">
-              L'abbiamo fatto per noi: developer e CTO freelance in Italia, spesso in forfettario,
-              con pochi clienti da tenere stretti e troppe cose da ricordare. Poi ci è sembrato
-              giusto darlo a chi entra.
-            </p>
-            <ul class="tiles measure">
-              <li>Clienti, contatti e trattative in un posto solo, con i campi che servono a te.</li>
-              <li>Offerte e contratti in PDF dai tuoi template, già con i tuoi dati fiscali.</li>
-              <li>Fatture e ore lavorate, con lo stato di ognuna sempre sotto gli occhi.</li>
-              <li>Le email con un cliente sulla sua scheda, senza aprire Gmail.</li>
-              <li>
-                Un assistente AI che fa il lavoro noioso: registra le ore, prepara le offerte, ti
-                riassume la settimana.
-              </li>
-              <li>Uno spazio tutto tuo, con un database separato, su pigro.joinorbiters.com/il-tuo-nome.</li>
-            </ul>
-            <p class="lead measure">
-              <strong>Gratis per chi è in community.</strong> Nessun piano, nessuna carta, nessuna
-              sorpresa dopo.
-            </p>
-            <p class="fine measure">
-              Sei già dei nostri?
-              <a class="quiet-link" href="https://pigro.joinorbiters.com/app/registrati"
-                >Crea il tuo spazio PigroCRM</a
-              >. Preferisci averlo sul tuo server? È open source e self-hosted quando vuoi:
-              <a class="quiet-link" href="https://github.com/joinorbiters/orbiters/blob/main/projects/pigrocrm/README.md#deploy"
-                >le istruzioni sono su GitHub</a
-              >.
-            </p>
-          </div>
+          <h2 class="statement" data-reveal style="--d: 0.1s">Il CRM che lavora <span class="accent">al posto tuo.</span></h2>
+          <p class="lead measure" data-reveal style="--d: 0.25s">
+            L'abbiamo fatto per noi, developer e CTO freelance in Italia, spesso in forfettario:
+            clienti, offerte, fatture e pagamenti in un posto solo, con un assistente AI che fa il
+            lavoro noioso per te.
+          </p>
+          <p class="actions" data-reveal style="--d: 0.4s">
+            <a class="cta" href="/pigrocrm">Scopri PigroCRM</a>
+          </p>
+          <p class="fine measure" data-reveal style="--d: 0.5s">
+            Gratis per chi è in community. Open source, self-hosted quando vuoi.
+          </p>
         </div>
       </section>
 

--- a/projects/website/src/landing-pages.test.ts
+++ b/projects/website/src/landing-pages.test.ts
@@ -131,8 +131,10 @@ describe('index.html', () => {
     expect(page).toMatch(/<a class="cta secondary" href="\/hub\/aziende">[^<]+<\/a>/)
     // The old door, the email form on `/`, is not what this page sells any more.
     expect(page).not.toMatch(/<a class="cta" href="\/orbiters">/)
-    // Whoever is already in still finds their space.
-    expect(page).toContain('href="https://pigro.joinorbiters.com/app/registrati"')
+    // Whoever is already in finds the CRM through its own page (ORB-165): the landing
+    // no longer links the registration form directly.
+    expect(page).toMatch(/<a class="cta" href="\/pigrocrm">Scopri PigroCRM<\/a>/)
+    expect(page).not.toContain('pigro.joinorbiters.com/app/registrati')
     // No invented plan or trial: the one price is "be in the community".
     expect(page).not.toMatch(/Prova gratis|abbonamento|piano (Pro|Business)/i)
   })


### PR DESCRIPTION
## What this changes

Ivan asked for two things on the landing: the «Sei già dei nostri? Crea il tuo spazio PigroCRM.» link had to point at `/pigrocrm`, and the «PigroCRM, il perk» section had to mirror the structure of «I primi passi da freelance.». The section is now a centred band of the same shape: kicker, statement («Il CRM che lavora al posto tuo.»), one lead (one sentence, keeping «developer e CTO freelance in Italia, spesso in forfettario»), one door «Scopri PigroCRM» to `/pigrocrm`, and one line of fine print («Gratis per chi è in community. Open source, self-hosted quando vuoi.»). The boxed list of six tiles, the registration link and the GitHub link go: the CRM's own page carries all of that now. The band stays light, so the page still alternates dark (voices), light (perk), dark (guide), boxed (close). `landing-pages.test.ts` pinned the registration link; it pins the door instead.

## How I verified it

In the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 217 tests (the words the positioning test looks for, «forfettario», «self-hosted», «gratis», are still on the page), `pnpm --filter website build` green, `pnpm --filter website test:e2e` 51 passed. Screenshot of the section at 1440, read before attaching.

## Screenshots

**1. The guide band (the shape mirrored) and the new perk band, at 1440**
![The guide band and the new perk band](https://github.com/user-attachments/assets/48291492-3930-4f35-a4c6-fa4d4b011204)

Linear: ORB-165.
