### PR TITLE
feat(website): the campaign follows a visitor into the wizard

### DIFF
--- a/projects/hub/apps/web/src/lib/utm.test.ts
+++ b/projects/hub/apps/web/src/lib/utm.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { readUtm } from './utm'
+import { afterEach, beforeEach } from 'vitest'
+import { UTM_STORAGE_KEY, readUtm, recallUtm, rememberUtm, resolveUtm } from './utm'
 
 describe('readUtm', () => {
   it('keeps the six UTM keys and nothing else', () => {
@@ -14,5 +15,31 @@ describe('readUtm', () => {
 
   it('is empty for an empty search', () => {
     expect(readUtm('')).toEqual({})
+  })
+})
+
+describe('resolveUtm, with what the tab remembers (ORB-166)', () => {
+  beforeEach(() => window.sessionStorage.clear())
+  afterEach(() => window.sessionStorage.clear())
+
+  it('prefers the URL and remembers it for the tab', () => {
+    expect(resolveUtm('?utm_source=linkedin&utm_id=42')).toEqual({ utm_source: 'linkedin', utm_id: '42' })
+    expect(window.sessionStorage.getItem(UTM_STORAGE_KEY)).toBe('utm_source=linkedin&utm_id=42')
+  })
+
+  it('falls back to what the landing left in the tab when the URL has nothing', () => {
+    window.sessionStorage.setItem(UTM_STORAGE_KEY, 'utm_source=linkedin&utm_campaign=orbita&gclid=x')
+    expect(resolveUtm('')).toEqual({ utm_source: 'linkedin', utm_campaign: 'orbita' })
+    expect(resolveUtm('?perk=guida')).toEqual({ utm_source: 'linkedin', utm_campaign: 'orbita' })
+  })
+
+  it('is empty when neither the URL nor the tab knows a campaign', () => {
+    expect(resolveUtm('?perk=guida')).toEqual({})
+    expect(recallUtm()).toEqual({})
+  })
+
+  it('remembers nothing for an empty attribution', () => {
+    rememberUtm({})
+    expect(window.sessionStorage.getItem(UTM_STORAGE_KEY)).toBeNull()
   })
 })

--- a/projects/hub/apps/web/src/lib/utm.ts
+++ b/projects/hub/apps/web/src/lib/utm.ts
@@ -12,6 +12,12 @@ export const UTM_KEYS = [
 
 export type Utm = Partial<Record<(typeof UTM_KEYS)[number], string>>
 
+/** Where the landing (`projects/website/src/landing.js`) leaves the campaign for the
+ *  tab, and where this app leaves what it read, so a detour through the chooser or a
+ *  reload of the wizard without the query string still knows where the person came
+ *  from (ORB-166). Session storage: it dies with the tab and holds only the campaign. */
+export const UTM_STORAGE_KEY = 'orbiters.utm'
+
 export function readUtm(search: string): Utm {
   const params = new URLSearchParams(search)
   const utm: Utm = {}
@@ -20,4 +26,40 @@ export function readUtm(search: string): Utm {
     if (value) utm[key] = value
   }
   return utm
+}
+
+function storage(): Storage | null {
+  try {
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
+
+/** What the tab remembers, if anything readable. */
+export function recallUtm(): Utm {
+  const raw = storage()?.getItem(UTM_STORAGE_KEY)
+  return raw ? readUtm(`?${raw}`) : {}
+}
+
+/** Remember a non-empty attribution for the tab; a storage that refuses is not an error. */
+export function rememberUtm(utm: Utm): void {
+  if (Object.keys(utm).length === 0) return
+  try {
+    storage()?.setItem(UTM_STORAGE_KEY, new URLSearchParams(utm).toString())
+  } catch {
+    /* refused: the URL still has it, or nothing does */
+  }
+}
+
+/** The attribution to send with an application: the URL's own keys when it has any,
+ *  remembered for the tab; otherwise what the tab remembers from the landing or from
+ *  an earlier page of this app. */
+export function resolveUtm(search: string): Utm {
+  const own = readUtm(search)
+  if (Object.keys(own).length > 0) {
+    rememberUtm(own)
+    return own
+  }
+  return recallUtm()
 }

--- a/projects/hub/apps/web/src/pages/CompanyWizard.tsx
+++ b/projects/hub/apps/web/src/pages/CompanyWizard.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { ApiError, requestPeople, type CompanyRequest } from '@/lib/api'
-import { readUtm } from '@/lib/utm'
+import { resolveUtm } from '@/lib/utm'
 import { LongTextField, TextField } from '@/wizard/fields'
 import { Wizard, type Step } from '@/wizard/Wizard'
 
@@ -145,7 +145,7 @@ export function CompanyWizard() {
     try {
       await requestPeople(
         { ...value, budget_giornaliero: value.budget_giornaliero.replace(',', '.') },
-        readUtm(searchStr),
+        resolveUtm(searchStr),
       )
       void navigate({ to: '/grazie', search: { chi: 'azienda' } })
     } catch (error) {

--- a/projects/hub/apps/web/src/pages/FreelancerWizard.tsx
+++ b/projects/hub/apps/web/src/pages/FreelancerWizard.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { ApiError, applyAsFreelancer, type FreelancerApplication } from '@/lib/api'
-import { readUtm } from '@/lib/utm'
+import { resolveUtm } from '@/lib/utm'
 import { ChoiceField, FileField, LinksField, TextField } from '@/wizard/fields'
 import { Wizard, type Step } from '@/wizard/Wizard'
 
@@ -224,7 +224,7 @@ export function FreelancerWizard() {
     setSubmitting(true)
     setSubmitError(null)
     try {
-      await applyAsFreelancer(value, readUtm(searchStr))
+      await applyAsFreelancer(value, resolveUtm(searchStr))
       void navigate({ to: '/grazie', search: { chi: 'freelance' } })
     } catch (error) {
       const failure = error instanceof ApiError ? error : null

--- a/projects/website/e2e/site.spec.ts
+++ b/projects/website/e2e/site.spec.ts
@@ -424,6 +424,37 @@ test.describe('every page of the site', () => {
 // page at `/` and a 200 for any path at all, so a test written against `/` checked a
 // page production never serves there. These pin the served map to deploy/nginx.conf's:
 // the same file under each name, the same redirect, and a 404 where nginx has one.
+// The campaign follows the visitor into the hub (ORB-166): every door on the landing
+// carries the six UTM keys the page was opened with, and nothing else does.
+test.describe('a visitor from a campaign', () => {
+  for (const path of ['/', '/pigrocrm']) {
+    test(`${path} carries the UTM keys onto every link into the hub`, async ({ page }) => {
+      await page.goto(`${path}?utm_source=linkedin&utm_campaign=orbita&utm_id=42&gclid=nope`, { waitUntil: 'networkidle' })
+      const doors = await page.locator('a[href^="/hub/"]').evaluateAll((links) => links.map((a) => a.getAttribute('href')))
+      expect(doors.length).toBeGreaterThan(0)
+      for (const href of doors) {
+        const url = new URL(href!, 'https://joinorbiters.com')
+        expect(url.searchParams.get('utm_source'), href!).toBe('linkedin')
+        expect(url.searchParams.get('utm_campaign'), href!).toBe('orbita')
+        expect(url.searchParams.get('utm_id'), href!).toBe('42')
+        expect(url.searchParams.has('gclid'), href!).toBe(false)
+      }
+      // The guide's door keeps its own key beside the campaign's.
+      expect(doors.some((href) => href!.startsWith('/hub/freelance?perk=guida&utm_source=linkedin'))).toBe(true)
+      // The rest of the page's links are what the markup says.
+      expect(await page.locator('a[href="/privacy"]').count()).toBeGreaterThan(0)
+      expect(await page.evaluate(() => sessionStorage.getItem('orbiters.utm'))).toBe('utm_source=linkedin&utm_campaign=orbita&utm_id=42')
+    })
+  }
+
+  test('/ without a campaign leaves the doors as the markup wrote them', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' })
+    const doors = await page.locator('a[href^="/hub/"]').evaluateAll((links) => links.map((a) => a.getAttribute('href')))
+    expect(doors.filter((href) => href!.includes('utm_'))).toEqual([])
+    expect(await page.evaluate(() => sessionStorage.getItem('orbiters.utm'))).toBeNull()
+  })
+})
+
 test.describe('the path map, as production serves it', () => {
   const source = (name: string) =>
     readFileSync(new URL(`../src/${name}`, import.meta.url), 'utf-8').match(/<title>([^<]+)<\/title>/)?.[1]

--- a/projects/website/src/landing.js
+++ b/projects/website/src/landing.js
@@ -14,8 +14,57 @@
  * script does not reach: landing.css hides a block only under `html.js`, which the
  * inline gate in the page's head sets, and shows everything again after three seconds
  * whatever happened here. Under reduced motion every block is marked at once.
+ *
+ * Since ORB-166 the script also carries the campaign: a visitor from an ad lands here
+ * with the six UTM keys in the URL, and the doors into the hub are plain paths, so the
+ * first click used to lose them. `carryUtm` appends the keys the page was opened with
+ * to every link into `/hub/` (never overriding one a link already carries, `perk` and
+ * the like untouched) and writes them in `sessionStorage` under `orbiters.utm`, the key
+ * the hub's `resolveUtm` reads when its own URL has none. Session storage on purpose:
+ * it dies with the tab, and the only thing it holds is the campaign, never the person.
+ * Without JavaScript the links are what the markup says and the attribution is lost,
+ * which is what happened before and is the honest fallback.
  */
 ;(function () {
+  var UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'utm_id']
+  var UTM_STORAGE_KEY = 'orbiters.utm'
+
+  /** The UTM keys in `search`, trimmed and capped at 200 characters like the hub does. */
+  function readUtm(search) {
+    var params = new URLSearchParams(search)
+    var utm = new URLSearchParams()
+    UTM_KEYS.forEach(function (key) {
+      var value = (params.get(key) || '').trim().slice(0, 200)
+      if (value) utm.set(key, value)
+    })
+    return utm
+  }
+
+  /** Appends the page's UTM keys to every link into the hub and remembers them for the
+   *  tab. Returns how many links were rewritten, for the test. */
+  function carryUtm(root, search) {
+    var utm = readUtm(search === undefined ? window.location.search : search)
+    var keys = Array.from(utm.keys())
+    if (!keys.length) return 0
+    try {
+      window.sessionStorage.setItem(UTM_STORAGE_KEY, utm.toString())
+    } catch {
+      /* storage refused: the links still carry the keys */
+    }
+    var rewritten = 0
+    ;(root || document).querySelectorAll('a[href^="/hub/"]').forEach(function (link) {
+      var url = new URL(link.getAttribute('href'), window.location.origin)
+      keys.forEach(function (key) {
+        if (!url.searchParams.has(key)) url.searchParams.set(key, utm.get(key))
+      })
+      link.setAttribute('href', url.pathname + url.search + url.hash)
+      rewritten += 1
+    })
+    return rewritten
+  }
+
+  window.__landing = { carryUtm: carryUtm, readUtm: readUtm, UTM_KEYS: UTM_KEYS, UTM_STORAGE_KEY: UTM_STORAGE_KEY }
+
   function reveal() {
     var blocks = document.querySelectorAll('[data-reveal]')
     if (!blocks.length) return
@@ -40,6 +89,7 @@
   }
 
   function start() {
+    carryUtm()
     reveal()
     var role = document.querySelector('h1 .role')
     if (role && window.__typewriter) window.__typewriter.mount(role)

--- a/projects/website/src/landing.test.ts
+++ b/projects/website/src/landing.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+/**
+ * landing.js carries the campaign a visitor landed with into the hub (ORB-166): the
+ * six UTM keys go onto every link into `/hub/`, nothing else is touched, and the same
+ * keys are remembered for the tab under the key the hub reads.
+ */
+const source = readFileSync(join(__dirname, 'landing.js'), 'utf-8')
+
+interface Landing {
+  carryUtm: (root?: ParentNode, search?: string) => number
+  readUtm: (search: string) => URLSearchParams
+  UTM_KEYS: readonly string[]
+  UTM_STORAGE_KEY: string
+}
+
+function load(): Landing {
+  new Function(source)()
+  const api = (window as Window & { __landing?: Landing }).__landing
+  if (!api) throw new Error('landing.js did not expose window.__landing')
+  return api
+}
+
+function fixture(hrefs: string[]) {
+  const root = document.createElement('div')
+  root.innerHTML = hrefs.map((href) => `<a href="${href}">x</a>`).join('')
+  return root
+}
+
+const hrefsOf = (root: ParentNode) => [...root.querySelectorAll('a')].map((a) => a.getAttribute('href'))
+
+beforeEach(() => window.sessionStorage.clear())
+afterEach(() => window.sessionStorage.clear())
+
+describe('carryUtm', () => {
+  it('appends the UTM keys of the page to every link into the hub, and to nothing else', () => {
+    const landing = load()
+    const root = fixture(['/hub/freelance', '/hub/aziende', '/hub/freelance?perk=guida', '/privacy', 'https://pigro.joinorbiters.com/app/'])
+    const rewritten = landing.carryUtm(root, '?utm_source=linkedin&utm_campaign=orbita&utm_id=42&gclid=nope&utm_term=%20')
+    expect(rewritten).toBe(3)
+    expect(hrefsOf(root)).toEqual([
+      '/hub/freelance?utm_source=linkedin&utm_campaign=orbita&utm_id=42',
+      '/hub/aziende?utm_source=linkedin&utm_campaign=orbita&utm_id=42',
+      '/hub/freelance?perk=guida&utm_source=linkedin&utm_campaign=orbita&utm_id=42',
+      '/privacy',
+      'https://pigro.joinorbiters.com/app/',
+    ])
+  })
+
+  it('remembers the keys for the tab under the name the hub reads', () => {
+    const landing = load()
+    landing.carryUtm(fixture(['/hub/freelance']), '?utm_source=linkedin&utm_medium=paid')
+    expect(landing.UTM_STORAGE_KEY).toBe('orbiters.utm')
+    expect(window.sessionStorage.getItem('orbiters.utm')).toBe('utm_source=linkedin&utm_medium=paid')
+  })
+
+  it('never overrides a key a link already carries', () => {
+    const landing = load()
+    const root = fixture(['/hub/freelance?utm_source=newsletter'])
+    landing.carryUtm(root, '?utm_source=linkedin&utm_campaign=orbita')
+    expect(hrefsOf(root)).toEqual(['/hub/freelance?utm_source=newsletter&utm_campaign=orbita'])
+  })
+
+  it('leaves the page alone when it was opened without a campaign', () => {
+    const landing = load()
+    const root = fixture(['/hub/freelance', '/hub/aziende'])
+    expect(landing.carryUtm(root, '?ref=friend')).toBe(0)
+    expect(hrefsOf(root)).toEqual(['/hub/freelance', '/hub/aziende'])
+    expect(window.sessionStorage.getItem('orbiters.utm')).toBeNull()
+  })
+
+  it('caps a value at 200 characters, like the hub does', () => {
+    const landing = load()
+    const long = 'x'.repeat(250)
+    expect(landing.readUtm(`?utm_content=${long}`).get('utm_content')).toHaveLength(200)
+  })
+})

--- a/projects/website/src/privacy.html
+++ b/projects/website/src/privacy.html
@@ -48,7 +48,8 @@
           quello che riguarda la community: quando apre e come partecipare, i progetti, gli
           strumenti, le persone che ne fanno parte. Per nient'altro. Se arrivi da una campagna
           salviamo anche i parametri della campagna (<code>utm_*</code>), così sappiamo da dove
-          sei arrivato. Base giuridica: il tuo consenso, dato compilando il form. Conserviamo
+          sei arrivato: li portiamo con te dalla pagina su cui sei atterrato al form, nella stessa
+          scheda del browser, e li scriviamo solo se poi ti iscrivi. Base giuridica: il tuo consenso, dato compilando il form. Conserviamo
           questi dati finché resti in Orbiters, cioè finché non ci chiedi di toglierli, e non li
           cediamo a nessuno.
         </p>


### PR DESCRIPTION
## What this changes

Ivan: a visitor from a LinkedIn sponsored post lands on the site with the campaign's parameters in the URL, and if they then sign up in the community we want to know where they came from. The hub's two wizards already store the six UTM keys they find in their own URL on the freelancer or company row, so the gap was the first click: the landing's doors into the hub («Entra come talento», «Cerchi persone?», «Entra e scaricala», «Scopri PigroCRM», «Ho un progetto») were plain paths, and the query string stayed behind.

- **`landing.js` carries the campaign.** `carryUtm` reads the six UTM keys off the page's URL (trimmed, capped at 200 characters like the hub), appends them to every `a[href^="/hub/"]` without overriding a key a link already carries (`?perk=guida` keeps its place), and writes them in `sessionStorage` under `orbiters.utm`. Session storage on purpose: it dies with the tab and holds only the campaign, never the person. Without JavaScript the links are what the markup says, which is what happened before.
- **The hub falls back to the tab.** `resolveUtm(search)` in `lib/utm.ts`: the URL's own keys when it has any, remembered for the tab; otherwise what the tab remembers, from the landing or from an earlier page of this app. Both wizards use it in place of `readUtm`, so a detour through the chooser or a reload of the wizard without the query string still sends the attribution. `readUtm` is unchanged and still pure.
- **`privacy.html`** adds to its sentence on `utm_*`: the parameters travel with the visitor from the page they landed on to the form, in the same browser tab, and are written only if they sign up.

## How I verified it

Website, in the branch worktree: `pnpm --filter website lint` clean, `pnpm --filter website test` 12 files / 222 tests (five new in `landing.test.ts`: rewrite of hub links only, no override, the tab's memory, no campaign no change, the 200-character cap), `pnpm --filter website build` green, `pnpm --filter website test:e2e` 54 passed (three new: on `/` and `/pigrocrm` opened with `utm_source=linkedin&utm_campaign=orbita&utm_id=42&gclid=nope` every hub door carries the three keys and not `gclid`, the guide door keeps `perk=guida` first, `sessionStorage` holds the campaign; without a campaign the doors are untouched and the storage empty). Hub web: `pnpm --filter hub lint` clean, `pnpm --filter hub test` 18 files / 84 tests (four new for `resolveUtm`/`recallUtm`/`rememberUtm`; the wizard test that posts the multipart body with `utm_source=linkedin` still passes through `resolveUtm`), `pnpm --filter hub build` green.

## Anything a reviewer should look at twice

- The attribution is only ever *sent* when the application is submitted, as before; nothing new is written server-side by this change. The API and the database are untouched.
- `sessionStorage` is per tab. A visitor who lands on the site, closes the tab and comes back tomorrow by typing the address is a direct visit, which is correct.
- The same-origin assumption: the landing and the hub share `joinorbiters.com`, so the storage the landing writes is the storage the hub reads. On the preview, where both run under one origin too, the e2e test reads it back.

## Screenshots

Nothing visible changes: the doors look the same and only their `href` gains a query string when the page was opened with one. The e2e tests above read the attributes and the storage instead.

Linear: ORB-166.
