### PR TITLE
feat(hub): a card remembers which page the person started from

### DIFF
--- a/projects/hub/apps/api/src/orbiters_api/routers/freelancers.py
+++ b/projects/hub/apps/api/src/orbiters_api/routers/freelancers.py
@@ -62,6 +62,7 @@ def apply(
     utm_content: Annotated[str | None, Form()] = None,
     utm_term: Annotated[str | None, Form()] = None,
     utm_id: Annotated[str | None, Form()] = None,
+    origine: Annotated[str | None, Form()] = None,
 ) -> Ack:
     spend_one(request)
     try:
@@ -81,6 +82,7 @@ def apply(
                 utm_content=utm_content,
                 utm_term=utm_term,
                 utm_id=utm_id,
+                origine=origine or None,
             ),
         )
     except ValidationError as exc:

--- a/projects/hub/apps/api/tests/test_hub_api.py
+++ b/projects/hub/apps/api/tests/test_hub_api.py
@@ -54,6 +54,47 @@ def test_an_application_with_a_cv_is_accepted_and_stored(
     assert row.utm_source == "linkedin"
 
 
+def test_the_page_the_person_started_from_is_stored_beside_the_campaign(
+    client: TestClient, api_session: Session
+) -> None:
+    """ORB-167: `origine` is the page of the site the door was on, `home` or `pigrocrm`,
+    as the landing's script put it on the link. A slug, or nothing: a value that is not
+    one is refused with the field's name, the same as any other field."""
+    _clean(api_session)
+    accepted = client.post(
+        "/api/hub/freelancers",
+        data={**_form(), "origine": "pigrocrm"},
+        files={"cv": ("Ada CV.pdf", PDF, "application/pdf")},
+    )
+    assert accepted.status_code == 201, accepted.text
+    row = api_session.execute(text("SELECT origine, utm_source FROM freelancers")).one()
+    assert (row.origine, row.utm_source) == ("pigrocrm", "linkedin")
+
+    refused = client.post(
+        "/api/hub/freelancers",
+        data={**_form(email="bob@studio.it"), "origine": "<script>"},
+        files={"cv": ("CV.pdf", PDF, "application/pdf")},
+    )
+    assert refused.status_code == 422
+    assert "origine" in [error["loc"][-1] for error in refused.json()["detail"]]
+
+    company = client.post(
+        "/api/hub/companies",
+        json={
+            "nome_azienda": "XYZ",
+            "referente": "Grace Hopper",
+            "email": "grace@xyz.it",
+            "progetto": "Un backend da rifare.",
+            "periodo_da": "2026-10-01",
+            "durata": "3 mesi",
+            "budget_giornaliero": "500",
+            "utm": {"utm_source": "linkedin", "origine": "home"},
+        },
+    )
+    assert company.status_code == 201, company.text
+    assert api_session.execute(text("SELECT origine FROM companies")).scalar() == "home"
+
+
 def test_a_missing_or_non_pdf_cv_is_a_422_that_names_the_field(
     client: TestClient, api_session: Session
 ) -> None:

--- a/projects/hub/apps/web/src/lib/api.ts
+++ b/projects/hub/apps/web/src/lib/api.ts
@@ -142,6 +142,8 @@ export interface Freelancer {
   links: string[]
   stato: 'nuovo' | 'contattato' | 'attivo' | 'scartato'
   note: string | null
+  /** The page of the site the person started from, `home` or `pigrocrm` (ORB-167). */
+  origine: string | null
   utm_source: string | null
   utm_campaign: string | null
   created_at: string
@@ -172,6 +174,8 @@ export interface Company {
   budget_giornaliero: string
   stato: 'nuovo' | 'contattato' | 'in_corso' | 'chiuso'
   note: string | null
+  /** The page of the site the person started from, `home` or `pigrocrm` (ORB-167). */
+  origine: string | null
   utm_source: string | null
   created_at: string
   commenti: Comment[]

--- a/projects/hub/apps/web/src/lib/utm.test.ts
+++ b/projects/hub/apps/web/src/lib/utm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { afterEach, beforeEach } from 'vitest'
-import { UTM_STORAGE_KEY, readUtm, recallUtm, rememberUtm, resolveUtm } from './utm'
+import { ORIGIN_STORAGE_KEY, UTM_STORAGE_KEY, readOrigin, readUtm, recallUtm, rememberUtm, resolveAttribution, resolveOrigin, resolveUtm } from './utm'
 
 describe('readUtm', () => {
   it('keeps the six UTM keys and nothing else', () => {
@@ -41,5 +41,32 @@ describe('resolveUtm, with what the tab remembers (ORB-166)', () => {
   it('remembers nothing for an empty attribution', () => {
     rememberUtm({})
     expect(window.sessionStorage.getItem(UTM_STORAGE_KEY)).toBeNull()
+  })
+})
+
+describe('the page the person started from (ORB-167)', () => {
+  beforeEach(() => window.sessionStorage.clear())
+  afterEach(() => window.sessionStorage.clear())
+
+  it('reads `da=` when it is a slug, and nothing else', () => {
+    expect(readOrigin('?da=pigrocrm&utm_source=linkedin')).toBe('pigrocrm')
+    expect(readOrigin('?da=home')).toBe('home')
+    expect(readOrigin('?da=%3Cscript%3E')).toBeNull()
+    expect(readOrigin('?da=')).toBeNull()
+    expect(readOrigin('')).toBeNull()
+  })
+
+  it('prefers the URL, remembers it for the tab, and falls back to the tab', () => {
+    expect(resolveOrigin('?da=pigrocrm')).toBe('pigrocrm')
+    expect(window.sessionStorage.getItem(ORIGIN_STORAGE_KEY)).toBe('pigrocrm')
+    expect(resolveOrigin('?perk=guida')).toBe('pigrocrm')
+    window.sessionStorage.setItem(ORIGIN_STORAGE_KEY, 'not a slug!')
+    expect(resolveOrigin('')).toBeNull()
+  })
+
+  it('folds the page into the attribution an application sends', () => {
+    expect(resolveAttribution('?utm_source=linkedin&da=home')).toEqual({ utm_source: 'linkedin', origine: 'home' })
+    window.sessionStorage.clear()
+    expect(resolveAttribution('')).toEqual({})
   })
 })

--- a/projects/hub/apps/web/src/lib/utm.ts
+++ b/projects/hub/apps/web/src/lib/utm.ts
@@ -10,7 +10,13 @@ export const UTM_KEYS = [
   'utm_id',
 ] as const
 
-export type Utm = Partial<Record<(typeof UTM_KEYS)[number], string>>
+/** The six UTM keys, plus `origine`: the page of the site the person started from,
+ *  `home` or `pigrocrm`, which the landing puts on its doors as `da=` (ORB-167). */
+export type Utm = Partial<Record<(typeof UTM_KEYS)[number] | 'origine', string>>
+
+/** Where the landing leaves the page it was, beside the campaign. */
+export const ORIGIN_STORAGE_KEY = 'orbiters.da'
+const ORIGIN_SHAPE = /^[a-z0-9-]{1,40}$/
 
 /** Where the landing (`projects/website/src/landing.js`) leaves the campaign for the
  *  tab, and where this app leaves what it read, so a detour through the chooser or a
@@ -62,4 +68,32 @@ export function resolveUtm(search: string): Utm {
     return own
   }
   return recallUtm()
+}
+
+/** `da=` off a search string, when it is a slug; anything else reads as unknown. */
+export function readOrigin(search: string): string | null {
+  const value = new URLSearchParams(search).get('da')?.trim() ?? ''
+  return ORIGIN_SHAPE.test(value) ? value : null
+}
+
+/** The page the person started from: the URL's own `da=` when it has one, remembered
+ *  for the tab; otherwise what the tab remembers from the landing. */
+export function resolveOrigin(search: string): string | null {
+  const own = readOrigin(search)
+  if (own) {
+    try {
+      storage()?.setItem(ORIGIN_STORAGE_KEY, own)
+    } catch {
+      /* refused: the URL still has it */
+    }
+    return own
+  }
+  const remembered = storage()?.getItem(ORIGIN_STORAGE_KEY) ?? ''
+  return ORIGIN_SHAPE.test(remembered) ? remembered : null
+}
+
+/** Everything an application says about where it came from: the campaign and the page. */
+export function resolveAttribution(search: string): Utm {
+  const origin = resolveOrigin(search)
+  return { ...resolveUtm(search), ...(origin ? { origine: origin } : {}) }
 }

--- a/projects/hub/apps/web/src/pages/CompanyWizard.tsx
+++ b/projects/hub/apps/web/src/pages/CompanyWizard.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { ApiError, requestPeople, type CompanyRequest } from '@/lib/api'
-import { resolveUtm } from '@/lib/utm'
+import { resolveAttribution } from '@/lib/utm'
 import { LongTextField, TextField } from '@/wizard/fields'
 import { Wizard, type Step } from '@/wizard/Wizard'
 
@@ -145,7 +145,7 @@ export function CompanyWizard() {
     try {
       await requestPeople(
         { ...value, budget_giornaliero: value.budget_giornaliero.replace(',', '.') },
-        resolveUtm(searchStr),
+        resolveAttribution(searchStr),
       )
       void navigate({ to: '/grazie', search: { chi: 'azienda' } })
     } catch (error) {

--- a/projects/hub/apps/web/src/pages/FreelancerWizard.test.tsx
+++ b/projects/hub/apps/web/src/pages/FreelancerWizard.test.tsx
@@ -12,7 +12,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { FREELANCER_STEPS, FreelancerWizard, readPerk } from './FreelancerWizard'
 
 /** The wizard mounted on its own little router, so `navigate` has somewhere to go. */
-function mount(path = '/freelance?utm_source=linkedin') {
+function mount(path = '/freelance?utm_source=linkedin&da=pigrocrm') {
   const root = createRootRoute({ component: () => <Outlet /> })
   const freelance = createRoute({ getParentRoute: () => root, path: '/freelance', component: FreelancerWizard })
   const grazie = createRoute({
@@ -121,6 +121,7 @@ describe('FreelancerWizard', () => {
     expect(body.get('email')).toBe('ada@studio.it')
     expect(body.get('remoto')).toBe('remoto')
     expect(body.get('utm_source')).toBe('linkedin')
+    expect(body.get('origine')).toBe('pigrocrm')
     expect(body.getAll('links')).toEqual(['https://github.com/ada'])
   })
 })

--- a/projects/hub/apps/web/src/pages/FreelancerWizard.tsx
+++ b/projects/hub/apps/web/src/pages/FreelancerWizard.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { ApiError, applyAsFreelancer, type FreelancerApplication } from '@/lib/api'
-import { resolveUtm } from '@/lib/utm'
+import { resolveAttribution } from '@/lib/utm'
 import { ChoiceField, FileField, LinksField, TextField } from '@/wizard/fields'
 import { Wizard, type Step } from '@/wizard/Wizard'
 
@@ -224,7 +224,7 @@ export function FreelancerWizard() {
     setSubmitting(true)
     setSubmitError(null)
     try {
-      await applyAsFreelancer(value, resolveUtm(searchStr))
+      await applyAsFreelancer(value, resolveAttribution(searchStr))
       void navigate({ to: '/grazie', search: { chi: 'freelance' } })
     } catch (error) {
       const failure = error instanceof ApiError ? error : null

--- a/projects/hub/apps/web/src/pages/admin/lists.tsx
+++ b/projects/hub/apps/web/src/pages/admin/lists.tsx
@@ -301,7 +301,7 @@ export function AdminFreelancerDetail() {
               </ul>
             ) : '—'}
           </Row>
-          <Row label="Arrivato">{formatDate(f.created_at)}{f.utm_source ? ` · da ${f.utm_source}` : ''}</Row>
+          <Row label="Arrivato">{formatDate(f.created_at)}{f.utm_source ? ` · da ${f.utm_source}` : ''}{f.origine ? ` · pagina ${f.origine}` : ''}</Row>
           <Row label="Provenienza">{f.provenienza}</Row>
           <Row label="Accessi">
             {f.accessi === 0 || f.ultimo_accesso === null
@@ -416,7 +416,7 @@ export function AdminCompanyDetail() {
           <Row label="Progetto"><p className="whitespace-pre-wrap">{c.progetto}</p></Row>
           <Row label="Periodo">dal {formatDate(c.periodo_da)}, {c.durata}</Row>
           <Row label="Budget a giornata">{formatEuro(c.budget_giornaliero)}</Row>
-          <Row label="Arrivata">{formatDate(c.created_at)}{c.utm_source ? ` · da ${c.utm_source}` : ''}</Row>
+          <Row label="Arrivata">{formatDate(c.created_at)}{c.utm_source ? ` · da ${c.utm_source}` : ''}{c.origine ? ` · pagina ${c.origine}` : ''}</Row>
         </dl>
         <StatusEditor
           states={COMPANY_STATES}

--- a/projects/hub/packages/core/migrations/versions/0009_origine.py
+++ b/projects/hub/packages/core/migrations/versions/0009_origine.py
@@ -1,0 +1,29 @@
+"""origine: which page of the site a freelancer or a company started from
+
+Revision ID: 0009
+Revises: 0008
+
+One nullable column on `freelancers` and one on `companies` (ORB-167): the slug of the
+page the person clicked through from, `home` or `pigrocrm`, beside the campaign the
+UTM columns already hold. Rows written before this stay NULL: nobody knows.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009"
+down_revision: str | Sequence[str] | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("freelancers", sa.Column("origine", sa.String(length=40), nullable=True))
+    op.add_column("companies", sa.Column("origine", sa.String(length=40), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("companies", "origine")
+    op.drop_column("freelancers", "origine")

--- a/projects/hub/packages/core/src/orbiters_core/models.py
+++ b/projects/hub/packages/core/src/orbiters_core/models.py
@@ -92,8 +92,16 @@ CV_MIME_MAX_LENGTH = 100
 CV_MAX_BYTES = 5 * 1024 * 1024
 
 
+ORIGINE_MAX_LENGTH = 40
+
+
 class UtmMixin:
-    """Where a submission came from, as the page's URL said it. Optional, written once."""
+    """Where a submission came from, as the page's URL said it. Optional, written once.
+    `origine` is the page of the site the person started from (`home`, `pigrocrm`), which
+    the landing's script puts on every door into the hub as `da=` (ORB-167): the campaign
+    says which ad, this says which page."""
+
+    origine: Mapped[str | None] = mapped_column(String(ORIGINE_MAX_LENGTH), default=None)
 
     utm_source: Mapped[str | None] = mapped_column(String(UTM_MAX_LENGTH), default=None)
     utm_medium: Mapped[str | None] = mapped_column(String(UTM_MAX_LENGTH), default=None)

--- a/projects/hub/packages/core/src/orbiters_core/schemas.py
+++ b/projects/hub/packages/core/src/orbiters_core/schemas.py
@@ -12,6 +12,7 @@ from orbiters_core.models import (
     DURATA_MAX_LENGTH,
     LINKEDIN_URL_MAX_LENGTH,
     NAME_MAX_LENGTH,
+    ORIGINE_MAX_LENGTH,
     POSIZIONE_MAX_LENGTH,
     UTM_MAX_LENGTH,
 )
@@ -57,6 +58,11 @@ class SignupUtm(BaseModel):
     utm_content: str | None = Field(default=None, max_length=UTM_MAX_LENGTH)
     utm_term: str | None = Field(default=None, max_length=UTM_MAX_LENGTH)
     utm_id: str | None = Field(default=None, max_length=UTM_MAX_LENGTH)
+    # The page of the site the person started from (`home`, `pigrocrm`), a slug and
+    # nothing else: it is ours, not an ad platform's, so it is held to a shape.
+    origine: str | None = Field(
+        default=None, max_length=ORIGINE_MAX_LENGTH, pattern=r"^[a-z0-9-]+$"
+    )
 
     def is_empty(self) -> bool:
         return not any(self.model_dump().values())
@@ -488,6 +494,7 @@ class FreelancerRead(BaseModel):
     # left its email on the landing («Iscrizioni»), «landing» otherwise. Derived by the
     # service from the two tables, never stored, so it cannot drift.
     provenienza: str = "landing"
+    origine: str | None = None
     utm_source: str | None = None
     utm_medium: str | None = None
     utm_campaign: str | None = None
@@ -529,6 +536,7 @@ class CompanyRead(BaseModel):
     budget_giornaliero: Decimal
     stato: str
     note: str | None
+    origine: str | None = None
     utm_source: str | None = None
     utm_medium: str | None = None
     utm_campaign: str | None = None

--- a/projects/hub/packages/core/src/orbiters_core/service.py
+++ b/projects/hub/packages/core/src/orbiters_core/service.py
@@ -27,7 +27,13 @@ class SignupService:
 
         # The first attribution of an address is the one that stays: a person who comes
         # back through another ad and types the same email is the same person.
-        utm = data.utm.model_dump() if data.utm is not None and not data.utm.is_empty() else {}
+        # The signups table predates `origine` and the community page has no door to name,
+        # so the page slug stays out of this row (ORB-167).
+        utm = (
+            data.utm.model_dump(exclude={"origine"})
+            if data.utm is not None and not data.utm.is_empty()
+            else {}
+        )
         row = Signup(
             email=email,
             nome=data.nome,

--- a/projects/website/e2e/site.spec.ts
+++ b/projects/website/e2e/site.spec.ts
@@ -439,19 +439,24 @@ test.describe('a visitor from a campaign', () => {
         expect(url.searchParams.get('utm_id'), href!).toBe('42')
         expect(url.searchParams.has('gclid'), href!).toBe(false)
       }
-      // The guide's door keeps its own key beside the campaign's.
+      // The guide's door keeps its own key beside the campaign's, and every door says
+      // which page it is on (ORB-167).
       expect(doors.some((href) => href!.startsWith('/hub/freelance?perk=guida&utm_source=linkedin'))).toBe(true)
+      for (const href of doors) expect(new URL(href!, 'https://joinorbiters.com').searchParams.get('da'), href!).toBe(path === '/' ? 'home' : 'pigrocrm')
+      expect(await page.evaluate(() => sessionStorage.getItem('orbiters.da'))).toBe(path === '/' ? 'home' : 'pigrocrm')
       // The rest of the page's links are what the markup says.
       expect(await page.locator('a[href="/privacy"]').count()).toBeGreaterThan(0)
       expect(await page.evaluate(() => sessionStorage.getItem('orbiters.utm'))).toBe('utm_source=linkedin&utm_campaign=orbita&utm_id=42')
     })
   }
 
-  test('/ without a campaign leaves the doors as the markup wrote them', async ({ page }) => {
+  test('/ without a campaign carries no UTM, only the page', async ({ page }) => {
     await page.goto('/', { waitUntil: 'networkidle' })
     const doors = await page.locator('a[href^="/hub/"]').evaluateAll((links) => links.map((a) => a.getAttribute('href')))
     expect(doors.filter((href) => href!.includes('utm_'))).toEqual([])
+    for (const href of doors) expect(new URL(href!, 'https://joinorbiters.com').searchParams.get('da'), href!).toBe('home')
     expect(await page.evaluate(() => sessionStorage.getItem('orbiters.utm'))).toBeNull()
+    expect(await page.evaluate(() => sessionStorage.getItem('orbiters.da'))).toBe('home')
   })
 })
 

--- a/projects/website/src/landing.js
+++ b/projects/website/src/landing.js
@@ -24,10 +24,21 @@
  * it dies with the tab, and the only thing it holds is the campaign, never the person.
  * Without JavaScript the links are what the markup says and the attribution is lost,
  * which is what happened before and is the honest fallback.
+ *
+ * Campaign or not, every door also says which page it is on (ORB-167): `da=home` from
+ * `/`, `da=pigrocrm` from `/pigrocrm`, so the hub can tell who came through the CRM's
+ * page from who came through the front door. Remembered for the tab as `orbiters.da`.
  */
 ;(function () {
   var UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'utm_id']
   var UTM_STORAGE_KEY = 'orbiters.utm'
+  var ORIGIN_STORAGE_KEY = 'orbiters.da'
+
+  /** The page's slug for `da=`: `home` for the front door, the path's own name otherwise. */
+  function pageSlug(pathname) {
+    var slug = (pathname || window.location.pathname).replace(/^\/+|\/+$/g, '')
+    return (slug || 'home').toLowerCase().replace(/[^a-z0-9-]/g, '-').slice(0, 40)
+  }
 
   /** The UTM keys in `search`, trimmed and capped at 200 characters like the hub does. */
   function readUtm(search) {
@@ -40,16 +51,17 @@
     return utm
   }
 
-  /** Appends the page's UTM keys to every link into the hub and remembers them for the
-   *  tab. Returns how many links were rewritten, for the test. */
-  function carryUtm(root, search) {
+  /** Appends the page's UTM keys and its own `da=` slug to every link into the hub, and
+   *  remembers both for the tab. Returns how many links were rewritten, for the test. */
+  function carryUtm(root, search, pathname) {
     var utm = readUtm(search === undefined ? window.location.search : search)
     var keys = Array.from(utm.keys())
-    if (!keys.length) return 0
+    var page = pageSlug(pathname)
     try {
-      window.sessionStorage.setItem(UTM_STORAGE_KEY, utm.toString())
+      if (keys.length) window.sessionStorage.setItem(UTM_STORAGE_KEY, utm.toString())
+      window.sessionStorage.setItem(ORIGIN_STORAGE_KEY, page)
     } catch {
-      /* storage refused: the links still carry the keys */
+      /* storage refused: the links still carry everything */
     }
     var rewritten = 0
     ;(root || document).querySelectorAll('a[href^="/hub/"]').forEach(function (link) {
@@ -57,13 +69,14 @@
       keys.forEach(function (key) {
         if (!url.searchParams.has(key)) url.searchParams.set(key, utm.get(key))
       })
+      if (!url.searchParams.has('da')) url.searchParams.set('da', page)
       link.setAttribute('href', url.pathname + url.search + url.hash)
       rewritten += 1
     })
     return rewritten
   }
 
-  window.__landing = { carryUtm: carryUtm, readUtm: readUtm, UTM_KEYS: UTM_KEYS, UTM_STORAGE_KEY: UTM_STORAGE_KEY }
+  window.__landing = { carryUtm: carryUtm, readUtm: readUtm, pageSlug: pageSlug, UTM_KEYS: UTM_KEYS, UTM_STORAGE_KEY: UTM_STORAGE_KEY, ORIGIN_STORAGE_KEY: ORIGIN_STORAGE_KEY }
 
   function reveal() {
     var blocks = document.querySelectorAll('[data-reveal]')

--- a/projects/website/src/landing.test.ts
+++ b/projects/website/src/landing.test.ts
@@ -3,17 +3,20 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 /**
- * landing.js carries the campaign a visitor landed with into the hub (ORB-166): the
- * six UTM keys go onto every link into `/hub/`, nothing else is touched, and the same
- * keys are remembered for the tab under the key the hub reads.
+ * landing.js carries where a visitor came from into the hub: the six UTM keys of the
+ * page's URL (ORB-166) and the page itself as `da=` (ORB-167) go onto every link into
+ * `/hub/`, nothing else is touched, and both are remembered for the tab under the keys
+ * the hub reads.
  */
 const source = readFileSync(join(__dirname, 'landing.js'), 'utf-8')
 
 interface Landing {
-  carryUtm: (root?: ParentNode, search?: string) => number
+  carryUtm: (root?: ParentNode, search?: string, pathname?: string) => number
   readUtm: (search: string) => URLSearchParams
+  pageSlug: (pathname?: string) => string
   UTM_KEYS: readonly string[]
   UTM_STORAGE_KEY: string
+  ORIGIN_STORAGE_KEY: string
 }
 
 function load(): Landing {
@@ -35,40 +38,51 @@ beforeEach(() => window.sessionStorage.clear())
 afterEach(() => window.sessionStorage.clear())
 
 describe('carryUtm', () => {
-  it('appends the UTM keys of the page to every link into the hub, and to nothing else', () => {
+  it('appends the UTM keys and the page to every link into the hub, and to nothing else', () => {
     const landing = load()
     const root = fixture(['/hub/freelance', '/hub/aziende', '/hub/freelance?perk=guida', '/privacy', 'https://pigro.joinorbiters.com/app/'])
-    const rewritten = landing.carryUtm(root, '?utm_source=linkedin&utm_campaign=orbita&utm_id=42&gclid=nope&utm_term=%20')
+    const rewritten = landing.carryUtm(root, '?utm_source=linkedin&utm_campaign=orbita&utm_id=42&gclid=nope&utm_term=%20', '/')
     expect(rewritten).toBe(3)
     expect(hrefsOf(root)).toEqual([
-      '/hub/freelance?utm_source=linkedin&utm_campaign=orbita&utm_id=42',
-      '/hub/aziende?utm_source=linkedin&utm_campaign=orbita&utm_id=42',
-      '/hub/freelance?perk=guida&utm_source=linkedin&utm_campaign=orbita&utm_id=42',
+      '/hub/freelance?utm_source=linkedin&utm_campaign=orbita&utm_id=42&da=home',
+      '/hub/aziende?utm_source=linkedin&utm_campaign=orbita&utm_id=42&da=home',
+      '/hub/freelance?perk=guida&utm_source=linkedin&utm_campaign=orbita&utm_id=42&da=home',
       '/privacy',
       'https://pigro.joinorbiters.com/app/',
     ])
   })
 
-  it('remembers the keys for the tab under the name the hub reads', () => {
+  it('remembers the campaign and the page for the tab under the names the hub reads', () => {
     const landing = load()
-    landing.carryUtm(fixture(['/hub/freelance']), '?utm_source=linkedin&utm_medium=paid')
+    landing.carryUtm(fixture(['/hub/freelance']), '?utm_source=linkedin&utm_medium=paid', '/pigrocrm')
     expect(landing.UTM_STORAGE_KEY).toBe('orbiters.utm')
+    expect(landing.ORIGIN_STORAGE_KEY).toBe('orbiters.da')
     expect(window.sessionStorage.getItem('orbiters.utm')).toBe('utm_source=linkedin&utm_medium=paid')
+    expect(window.sessionStorage.getItem('orbiters.da')).toBe('pigrocrm')
   })
 
   it('never overrides a key a link already carries', () => {
     const landing = load()
-    const root = fixture(['/hub/freelance?utm_source=newsletter'])
-    landing.carryUtm(root, '?utm_source=linkedin&utm_campaign=orbita')
-    expect(hrefsOf(root)).toEqual(['/hub/freelance?utm_source=newsletter&utm_campaign=orbita'])
+    const root = fixture(['/hub/freelance?utm_source=newsletter&da=altro'])
+    landing.carryUtm(root, '?utm_source=linkedin&utm_campaign=orbita', '/')
+    expect(hrefsOf(root)).toEqual(['/hub/freelance?utm_source=newsletter&da=altro&utm_campaign=orbita'])
   })
 
-  it('leaves the page alone when it was opened without a campaign', () => {
+  it('says the page even when there is no campaign, and remembers no campaign', () => {
     const landing = load()
     const root = fixture(['/hub/freelance', '/hub/aziende'])
-    expect(landing.carryUtm(root, '?ref=friend')).toBe(0)
-    expect(hrefsOf(root)).toEqual(['/hub/freelance', '/hub/aziende'])
+    expect(landing.carryUtm(root, '?ref=friend', '/pigrocrm')).toBe(2)
+    expect(hrefsOf(root)).toEqual(['/hub/freelance?da=pigrocrm', '/hub/aziende?da=pigrocrm'])
     expect(window.sessionStorage.getItem('orbiters.utm')).toBeNull()
+    expect(window.sessionStorage.getItem('orbiters.da')).toBe('pigrocrm')
+  })
+
+  it('names the page by its path, home for the front door', () => {
+    const landing = load()
+    expect(landing.pageSlug('/')).toBe('home')
+    expect(landing.pageSlug('/pigrocrm')).toBe('pigrocrm')
+    expect(landing.pageSlug('/pigrocrm/')).toBe('pigrocrm')
+    expect(landing.pageSlug('/Strana Pagina!')).toBe('strana-pagina-')
   })
 
   it('caps a value at 200 characters, like the hub does', () => {

--- a/projects/website/src/privacy.html
+++ b/projects/website/src/privacy.html
@@ -48,8 +48,9 @@
           quello che riguarda la community: quando apre e come partecipare, i progetti, gli
           strumenti, le persone che ne fanno parte. Per nient'altro. Se arrivi da una campagna
           salviamo anche i parametri della campagna (<code>utm_*</code>), così sappiamo da dove
-          sei arrivato: li portiamo con te dalla pagina su cui sei atterrato al form, nella stessa
-          scheda del browser, e li scriviamo solo se poi ti iscrivi. Base giuridica: il tuo consenso, dato compilando il form. Conserviamo
+          sei arrivato, e da quale pagina del sito sei partito (la home o quella di PigroCRM): li
+          portiamo con te dalla pagina su cui sei atterrato al form, nella stessa scheda del
+          browser, e li scriviamo solo se poi ti iscrivi. Base giuridica: il tuo consenso, dato compilando il form. Conserviamo
           questi dati finché resti in Orbiters, cioè finché non ci chiedi di toglierli, e non li
           cediamo a nessuno.
         </p>


### PR DESCRIPTION
## What this changes

Ivan, right after the campaign started following a visitor into the wizard (#79): «stessa cosa voglio sapere anche chi si iscrive da joinorbiters.com/pigrocrm invece». A direct visitor from the CRM's page and one from the home looked the same on the card, so:

- **The landing's doors say which page they are on.** `carryUtm` in `landing.js` now also puts `da=home` (from `/`) or `da=pigrocrm` (from `/pigrocrm`) on every link into `/hub/`, campaign or not, without overriding a `da` a link already carries, and remembers it for the tab as `orbiters.da` beside `orbiters.utm`.
- **The wizards send it.** `resolveAttribution(search)` in the hub's `lib/utm.ts` folds `resolveOrigin` (the URL's `da=` when it is a slug, else what the tab remembers) into the attribution object; both wizards use it, so the freelancer's multipart body and the company's JSON carry `origine`.
- **The hub stores and shows it.** `SignupUtm.origine`, a slug of at most 40 characters or nothing (anything else is a 422 naming the field); `UtmMixin.origine` on `freelancers` and `companies` via migration 0009; `FreelancerRead`/`CompanyRead` expose it, so the admin API, the member's own profile route and the MCP tools carry it; the admin's «Arrivato»/«Arrivata» row reads «11 set 2026 · da linkedin · pagina pigrocrm». The signups row (the community page's form) predates the column and has no door to name, so `SignupService` leaves the slug out.
- `privacy.html`'s sentence on `utm_*` now also names the page the person started from.

## How I verified it

Hub Python, against a testcontainers Postgres: `uv run pytest projects/hub/packages/core/tests projects/hub/apps/api/tests projects/hub/apps/mcp/tests` 208 passed (new: a freelancer posted with `origine=pigrocrm` is stored with it beside `utm_source`, `<script>` as origin is a 422 naming `origine`, a company posted with `utm.origine=home` stores it); `test_the_migrations_produce_exactly_the_models_schema` holds with 0009; `ruff check` and `ruff format --check` clean. Hub web: lint clean, 18 files / 87 tests (new: `readOrigin` accepts slugs only, `resolveOrigin` prefers the URL, remembers, falls back, refuses a non-slug in storage; `resolveAttribution` folds it in; the wizard test's multipart body now carries `origine=pigrocrm`), build green. Website: lint clean, 12 files / 223 tests (`landing.test.ts` rewritten for the page slug: appended with and without a campaign, remembered, never overriding, `pageSlug` for `/`, `/pigrocrm`, a trailing slash and a strange path), build green, e2e 54 passed (the campaign tests on `/` and `/pigrocrm` now also assert `da=` on every door and in the tab; the no-campaign test asserts `da=home` and nothing else).

## Migrations

`0009_origine`, revises 0008: `ALTER TABLE freelancers ADD COLUMN origine VARCHAR(40) NULL` and the same on `companies`. Nothing conditional, nothing backfilled: rows written before stay NULL, which is the truth. `compare_metadata` reports no difference. The API image runs `alembic upgrade head` on start.

## API changes

- `POST /api/hub/freelancers` (multipart): new optional form field `origine` (slug, ≤ 40).
- `POST /api/hub/companies` (JSON): `utm.origine`, same rule.
- `GET /api/hub/freelancers`, `/freelancers/{id}`, `/companies`, `/companies/{id}`, `/me`: responses gain `origine: string | null`. `projects/hub/apps/web/src/lib/api.ts` gains the field on `Freelancer` and `Company`.

## MCP surface

No tool added or renamed; `list_freelancers`, `get_freelancer`, `list_companies` and `get_company` carry `origine` in their rows through the shared schemas. `tests/test_tools.py` is unchanged and green.

## Anything a reviewer should look at twice

- `origine` lives in `SignupUtm` and `UtmMixin` rather than in a field of its own, because it is the same fact («where the submission came from, as the page's URL said it») and it rides the same path from the URL to the row. The price is the one `exclude={"origine"}` in `SignupService`, commented at the spot.
- Only the landing's own pages set `da=`; a link into the hub from anywhere else (an email, the pitch, LinkedIn) leaves it NULL rather than guessing.

## Screenshots

Nothing visible changes on the site: the doors gain `da=` in their `href`, which the e2e tests read. In the admin area the change is a few words on an existing row («· pagina pigrocrm»), asserted by the wizard and utm tests rather than pictured: no local stack was rebuilt for a suffix on a date line.

Linear: ORB-167.
