### PR TITLE
design(website): the market slide's third figure says 72% of Italian firms outsource their IT

### DIFF
--- a/projects/website/src/pitch.html
+++ b/projects/website/src/pitch.html
@@ -237,9 +237,9 @@
             <div class="stats" style="margin-top: 50px; gap: 60px;">
               <div data-reveal style="--d: 0.2s;"><div class="n" style="font-size: 190px;"><span data-count="494">494</span><small>k</small></div><div class="l">sviluppatori software in Italia</div></div>
               <div data-reveal style="--d: 0.4s;"><div class="n accent" style="font-size: 190px;"><span data-count="236">236</span><small>k</small></div><div class="l">professionisti ICT che mancano: una posizione su due resta scoperta</div></div>
-              <div data-reveal style="--d: 0.6s;"><div class="n" style="font-size: 190px;"><span data-count="79">79</span><small>%</small></div><div class="l">dei developer freelance trova i clienti con il passaparola</div></div>
+              <div data-reveal style="--d: 0.6s;"><div class="n" style="font-size: 190px;"><span data-count="72">72</span><small>%</small></div><div class="l">delle imprese italiane affida l'IT a fornitori esterni</div></div>
             </div>
-            <p class="label" data-reveal style="--d: 0.9s; margin-top: 70px; font-size: 20px; max-width: none;">Fonti: Bitboss, The State of Development in Italy (sviluppatori e passaparola); Osservatorio AICA, Anitec-Assinform, Assintel, nov. 2025 (posizioni ICT scoperte).</p>
+            <p class="label" data-reveal style="--d: 0.9s; margin-top: 70px; font-size: 20px; max-width: none;">Fonti: Bitboss, The State of Development in Italy (sviluppatori); Osservatorio AICA, Anitec-Assinform, Assintel, nov. 2025 (posizioni ICT scoperte); Eurostat, ICT usage in enterprises 2024, imprese con 10+ addetti (funzioni IT affidate a esterni).</p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## What this changes

Slide 13 of `/pitch` sizes the market with three figures, and the third one, «79% dei developer freelance trova i clienti con il passaparola», described how freelancers get by today rather than who needs them; Ivan read it as a number against the project («non mi sembra a favore del progetto»). I replaced it with a demand-side figure from Eurostat's 2024 survey on ICT usage in enterprises: **72% delle imprese italiane affida l'IT a fornitori esterni** (dataset `isoc_ske_fct`, enterprises with 10 or more persons employed, reference year 2023: 71,86% in Italy against 71,92% in the EU; only 21,2% of Italian firms have ICT functions performed by own employees, the lowest share in the EU). The sources line names Eurostat with the survey year and the size class. Nothing else on the page moves; the desk copy carries the same change.

## How I verified it

- `pnpm --filter website lint`: eslint clean.
- `pnpm --filter website test`: 12 files, 223 tests passed.
- `pnpm --filter website build`: built in 375 ms.
- `pnpm --filter website test:e2e`: 54 passed (12.0 s) against `vite preview` on 4173.
- The Eurostat values were read from the API (`isoc_ske_fct`, `geo=IT`, `size_emp` 10+, unit % of enterprises, 2024): 71.86 external suppliers, 57.0 only external, 21.2 own employees.
- Opened `http://localhost:4173/pitch?static=1` from this branch's build and read slide 13: the frame below.

## Anything a reviewer should look at twice

The 72% rounds 71,86%. The sharper Eurostat number, 57% of Italian firms with ICT functions performed *only* by external suppliers (EU 44,78%), was left out because it needs a qualifier the slide cannot carry. The survey covers firms with 10 or more persons employed, which the sources line says and the label does not.

## Screenshots

Before from `https://joinorbiters.com/pitch?static=1` as live today (`website-v0.8.3`), after from this branch's `vite preview`, both at 1920×1080.

**1. Slide 13, the market**
![Slide 13, before and after](https://github.com/user-attachments/assets/22f0386d-6881-493c-9d75-76de967426b2)

Linear: ORB-178.
