### PR TITLE
feat(web): the Home of a new space sells the assistant and lists the four first steps

### DIFF
--- a/projects/pigrocrm/apps/web/src/features/dashboard/DashboardPage.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/DashboardPage.test.tsx
@@ -7,9 +7,9 @@
  * handed back as a new search object for the route to push into the URL.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DashboardPage } from './DashboardPage'
 import type { DashboardSearch } from './search'
 import { api } from '@/lib/api'
@@ -22,6 +22,15 @@ vi.mock('@/lib/api', async (importOriginal) => {
 // The tabs link out (the fiscal card points at Impostazioni → Fiscale when a parameter is
 // missing), and a `<Link>` outside a router throws. What those destinations are is asserted
 // in each tab's own file; here the only question is which tab got mounted.
+// The first-steps panels read who is looking (`useAuth`) and whether they can act
+// (`useCanWrite`): an admin by default, a readonly or a collaboratore where a test says so.
+const auth = { user: { id: 'u1', email: 'ada@studio.it', nome: 'Ada', ruolo: 'admin' as string, attivo: true } }
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({ user: auth.user, isLoading: false, login: vi.fn(), logout: vi.fn(), enterWithLink: vi.fn() }),
+  useCanWrite: () => auth.user.ruolo !== 'readonly',
+  useIsAdmin: () => auth.user.ruolo === 'admin',
+}))
+
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ to, children }: { to: string; children: React.ReactNode }) => <a href={to}>{children}</a>,
 }))
@@ -111,6 +120,11 @@ function renderPage(search = SEARCH) {
   )
   return { onSearchChange }
 }
+
+afterEach(() => {
+  window.localStorage.clear()
+  auth.user.ruolo = 'admin'
+})
 
 beforeEach(() => {
   vi.mocked(api.GET).mockReset()
@@ -242,16 +256,19 @@ describe('DashboardPage, two tabs', () => {
   })
 
   describe('a new space (spec 2026-09-12 §6.7)', () => {
-    /** The stubs of a space in use: the same paths, with something in them. */
-    function withData(overrides: Record<string, unknown>) {
+    /** The stubs of a space in use: the same paths, with something in them, or an HTTP
+     *  error where a test wants one. */
+    function withData(overrides: Record<string, unknown>, failing: Record<string, number> = {}) {
       vi.mocked(api.GET).mockImplementation(
         ((path: string) =>
           Promise.resolve(
-            path in overrides
-              ? { data: overrides[path], response: new Response(null, { status: 200 }) }
-              : NOT_FOUND.has(path)
-                ? { error: { detail: 'Not Found' }, response: new Response(null, { status: 404 }) }
-                : { data: BY_PATH[path], response: new Response(null, { status: 200 }) },
+            path in failing
+              ? { error: { detail: 'boom' }, response: new Response(null, { status: failing[path] }) }
+              : path in overrides
+                ? { data: overrides[path], response: new Response(null, { status: 200 }) }
+                : NOT_FOUND.has(path)
+                  ? { error: { detail: 'Not Found' }, response: new Response(null, { status: 404 }) }
+                  : { data: BY_PATH[path], response: new Response(null, { status: 200 }) },
           )) as never,
       )
     }
@@ -265,7 +282,7 @@ describe('DashboardPage, two tabs', () => {
       )
       expect(screen.getByText('Primi passi')).toBeInTheDocument()
       expect(screen.getByText(/0 di 4/)).toBeInTheDocument()
-      expect(screen.getAllByLabelText('da fare')).toHaveLength(4)
+      expect(screen.getAllByText('Da fare:')).toHaveLength(4)
       expect(screen.getByRole('link', { name: 'I tuoi dati fiscali' })).toHaveAttribute(
         'href',
         '/app/impostazioni/emittente',
@@ -279,10 +296,17 @@ describe('DashboardPage, two tabs', () => {
       })
       renderPage()
       expect(await screen.findByText(/2 di 4/)).toBeInTheDocument()
-      expect(screen.getAllByLabelText('fatto')).toHaveLength(2)
+      expect(screen.getAllByText('Fatto:')).toHaveLength(2)
       // A done step is no longer a link: there is nothing left to do there.
       expect(screen.queryByRole('link', { name: 'Il primo cliente' })).toBeNull()
       expect(screen.getByRole('link', { name: 'Il primo deal, o le prime ore' })).toBeInTheDocument()
+    })
+
+    it('counts a step it could not read as done rather than nag about a broken request', async () => {
+      withData({}, { '/api/customers': 500 })
+      renderPage()
+      expect(await screen.findByText(/1 di 4/)).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Il primo cliente' })).toBeNull()
     })
 
     it('shows neither panel once everything is done and the assistant is connected', async () => {
@@ -294,20 +318,46 @@ describe('DashboardPage, two tabs', () => {
         '/api/tokens': [{ id: 'k1' }],
       })
       renderPage()
-      // The tab renders; the panels never appear.
       expect(await screen.findByRole('tab', { name: 'Commerciale' })).toBeInTheDocument()
-      await new Promise((resolve) => setTimeout(resolve, 30))
+      await waitFor(() => expect(api.GET).toHaveBeenCalledWith('/api/tokens'))
+      await waitFor(() => expect(api.GET).toHaveBeenCalledWith('/api/documents', expect.anything()))
       expect(screen.queryByTestId('new-space-panels')).toBeNull()
     })
 
-    it('hides the steps on «Nascondi» and keeps the assistant card', async () => {
+    it('hides the steps on «Nascondi», keeps the assistant card, and remembers it per space and user', async () => {
       renderPage()
       await screen.findByText('Primi passi')
       await userEvent.click(screen.getByRole('button', { name: 'Nascondi' }))
       expect(screen.queryByText('Primi passi')).toBeNull()
       expect(screen.getByText('Il CRM che lavora al posto tuo')).toBeInTheDocument()
-      expect(window.localStorage.getItem('pigrocrm.primi-passi.nascosto')).toBe('1')
-      window.localStorage.removeItem('pigrocrm.primi-passi.nascosto')
+      expect(window.localStorage.getItem('pigrocrm.primi-passi.nascosto:/:u1')).toBe('1')
+    })
+
+    it('reads only the token while the list is hidden', async () => {
+      window.localStorage.setItem('pigrocrm.primi-passi.nascosto:/:u1', '1')
+      renderPage()
+      expect(await screen.findByText('Il CRM che lavora al posto tuo')).toBeInTheDocument()
+      expect(screen.queryByText('Primi passi')).toBeNull()
+      expect(api.GET).not.toHaveBeenCalledWith('/api/customers', expect.anything())
+      expect(api.GET).not.toHaveBeenCalledWith('/api/emitter')
+    })
+
+    it('shows nothing to a readonly user, who could do none of it', async () => {
+      auth.user.ruolo = 'readonly'
+      renderPage()
+      expect(await screen.findByRole('tab', { name: 'Commerciale' })).toBeInTheDocument()
+      expect(screen.queryByTestId('new-space-panels')).toBeNull()
+      expect(api.GET).not.toHaveBeenCalledWith('/api/tokens')
+    })
+
+    it('does not link a collaboratore to the fiscal settings only an admin can open', async () => {
+      auth.user.ruolo = 'collaboratore'
+      renderPage()
+      expect(await screen.findByText('Primi passi')).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'I tuoi dati fiscali' })).toBeNull()
+      expect(screen.getByText('I tuoi dati fiscali')).toBeInTheDocument()
+      expect(screen.getByText(/Li imposta l.amministratore/)).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Il primo cliente' })).toBeInTheDocument()
     })
   })
 })

--- a/projects/pigrocrm/apps/web/src/features/dashboard/DashboardPage.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/DashboardPage.test.tsx
@@ -77,11 +77,22 @@ const EMPTY_ESTIMATE = {
 /** One mock for every endpoint the tabs read: which tab is mounted decides which are
  *  called. The economic one reads two -- the overview behind its cards and the estimate
  *  behind the «Stima fiscale» card under them. */
+const EMPTY_PAGE = { items: [], next_cursor: null }
+
+/** A space that has done nothing yet: every list empty, no emitter, no token. The
+ *  first-steps panels (spec 2026-09-12 §6.7) read these six. */
 const BY_PATH: Record<string, unknown> = {
   '/api/dashboard/commerciale': EMPTY_DASHBOARD,
   '/api/analytics/panoramica': EMPTY_OVERVIEW,
   '/api/analytics/fiscale': EMPTY_ESTIMATE,
+  '/api/customers': EMPTY_PAGE,
+  '/api/deals': EMPTY_PAGE,
+  '/api/time-entries': EMPTY_PAGE,
+  '/api/documents': EMPTY_PAGE,
+  '/api/tokens': [],
 }
+// `/api/emitter` answers 404 until the profile is saved once.
+const NOT_FOUND = new Set(['/api/emitter'])
 
 const SEARCH: DashboardSearch = {
   tab: 'commerciale',
@@ -105,10 +116,11 @@ beforeEach(() => {
   vi.mocked(api.GET).mockReset()
   vi.mocked(api.GET).mockImplementation(
     ((path: string) =>
-      Promise.resolve({
-        data: BY_PATH[path],
-        response: new Response(null, { status: 200 }),
-      })) as never,
+      Promise.resolve(
+        NOT_FOUND.has(path)
+          ? { error: { detail: 'Not Found' }, response: new Response(null, { status: 404 }) }
+          : { data: BY_PATH[path], response: new Response(null, { status: 200 }) },
+      )) as never,
   )
 })
 
@@ -227,5 +239,75 @@ describe('DashboardPage, two tabs', () => {
   it('shows the period picker on both tabs', () => {
     renderPage({ ...SEARCH, tab: 'economica' })
     expect(screen.getByLabelText('Dal')).toBeInTheDocument()
+  })
+
+  describe('a new space (spec 2026-09-12 §6.7)', () => {
+    /** The stubs of a space in use: the same paths, with something in them. */
+    function withData(overrides: Record<string, unknown>) {
+      vi.mocked(api.GET).mockImplementation(
+        ((path: string) =>
+          Promise.resolve(
+            path in overrides
+              ? { data: overrides[path], response: new Response(null, { status: 200 }) }
+              : NOT_FOUND.has(path)
+                ? { error: { detail: 'Not Found' }, response: new Response(null, { status: 404 }) }
+                : { data: BY_PATH[path], response: new Response(null, { status: 200 }) },
+          )) as never,
+      )
+    }
+
+    it('shows the assistant card and the four steps to do on an empty space', async () => {
+      renderPage()
+      expect(await screen.findByText('Il CRM che lavora al posto tuo')).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: /Collega l.assistente/ })).toHaveAttribute(
+        'href',
+        '/app/token',
+      )
+      expect(screen.getByText('Primi passi')).toBeInTheDocument()
+      expect(screen.getByText(/0 di 4/)).toBeInTheDocument()
+      expect(screen.getAllByLabelText('da fare')).toHaveLength(4)
+      expect(screen.getByRole('link', { name: 'I tuoi dati fiscali' })).toHaveAttribute(
+        'href',
+        '/app/impostazioni/emittente',
+      )
+    })
+
+    it('counts a step done when the thing exists, and only then', async () => {
+      withData({
+        '/api/emitter': { ragione_sociale: 'Ada', partita_iva: '01234567890', codice_fiscale: null },
+        '/api/customers': { items: [{ id: 'c1' }], next_cursor: null },
+      })
+      renderPage()
+      expect(await screen.findByText(/2 di 4/)).toBeInTheDocument()
+      expect(screen.getAllByLabelText('fatto')).toHaveLength(2)
+      // A done step is no longer a link: there is nothing left to do there.
+      expect(screen.queryByRole('link', { name: 'Il primo cliente' })).toBeNull()
+      expect(screen.getByRole('link', { name: 'Il primo deal, o le prime ore' })).toBeInTheDocument()
+    })
+
+    it('shows neither panel once everything is done and the assistant is connected', async () => {
+      withData({
+        '/api/emitter': { ragione_sociale: 'Ada', partita_iva: null, codice_fiscale: 'RSSMRA80A01H501U' },
+        '/api/customers': { items: [{ id: 'c1' }], next_cursor: null },
+        '/api/time-entries': { items: [{ id: 't1' }], next_cursor: null },
+        '/api/documents': { items: [{ id: 'd1' }], next_cursor: null },
+        '/api/tokens': [{ id: 'k1' }],
+      })
+      renderPage()
+      // The tab renders; the panels never appear.
+      expect(await screen.findByRole('tab', { name: 'Commerciale' })).toBeInTheDocument()
+      await new Promise((resolve) => setTimeout(resolve, 30))
+      expect(screen.queryByTestId('new-space-panels')).toBeNull()
+    })
+
+    it('hides the steps on «Nascondi» and keeps the assistant card', async () => {
+      renderPage()
+      await screen.findByText('Primi passi')
+      await userEvent.click(screen.getByRole('button', { name: 'Nascondi' }))
+      expect(screen.queryByText('Primi passi')).toBeNull()
+      expect(screen.getByText('Il CRM che lavora al posto tuo')).toBeInTheDocument()
+      expect(window.localStorage.getItem('pigrocrm.primi-passi.nascosto')).toBe('1')
+      window.localStorage.removeItem('pigrocrm.primi-passi.nascosto')
+    })
   })
 })

--- a/projects/pigrocrm/apps/web/src/features/dashboard/DashboardPage.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from '@/components/PageHeader'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { CommercialTab } from './CommercialTab'
 import { EconomicTab } from './EconomicTab'
+import { NewSpacePanels } from './NewSpacePanels'
 import { PeriodPicker } from './PeriodPicker'
 import { DASHBOARD_TABS, type DashboardSearch } from './search'
 
@@ -50,6 +51,9 @@ export function DashboardPage({
       />
 
       <div className="px-8 py-6">
+        {/* A new space first: the assistant and the first steps, read from the data and
+            gone on their own once the space is in use (spec 2026-09-12 §6.7). */}
+        <NewSpacePanels />
         {/* One tab is mounted at a time, deliberately. Rendering all three and hiding two
             would issue three requests -- three snapshot transactions, each holding two
             pooled connections on the API side -- to draw one screen. §17's placeholders that

--- a/projects/pigrocrm/apps/web/src/features/dashboard/NewSpacePanels.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/NewSpacePanels.tsx
@@ -1,0 +1,111 @@
+/**
+ * The two panels a new space sees above its dashboard (spec 2026-09-12 §6.7): the
+ * assistant first, because it is what the landing sells and what a space is for, then
+ * the four first steps. Both read their state from the data (`useFirstSteps`) and
+ * disappear on their own: the card when a token exists, the list at four of four or on
+ * «Nascondi», which is the one preference kept, and kept in the browser.
+ */
+import { Link } from '@tanstack/react-router'
+import { Bot, Check, ChevronRight, Circle } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { CONNECT_ASSISTANT_TO, hide, isHidden, useFirstSteps } from './newSpace'
+
+export function NewSpacePanels() {
+  const state = useFirstSteps()
+  const [hidden, setHidden] = useState(isHidden)
+  if (state.loading) return null
+  const showAssistant = !state.assistantConnected
+  const showSteps = !state.allDone && !hidden
+  if (!showAssistant && !showSteps) return null
+  return (
+    <div className="mb-6 space-y-4" data-testid="new-space-panels">
+      {showAssistant && <AssistantCard />}
+      {showSteps && (
+        <FirstStepsList
+          steps={state.steps}
+          doneCount={state.doneCount}
+          onHide={() => {
+            hide()
+            setHidden(true)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function AssistantCard() {
+  return (
+    <Card className="border-foreground border-2">
+      <CardHeader className="flex flex-row items-start gap-4">
+        <Bot className="mt-1 size-8 shrink-0 text-[var(--color-watermelon)]" aria-hidden />
+        <div className="space-y-1.5">
+          <CardTitle className="text-xl">Il CRM che lavora al posto tuo</CardTitle>
+          <CardDescription className="text-base">
+            Collega Claude al tuo spazio e chiedigli di registrare le ore, preparare
+            un&apos;offerta, riassumere la settimana. Tutto quello che fai qui lo può fare lui.
+          </CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Button asChild size="lg">
+          <Link to={CONNECT_ASSISTANT_TO}>
+            Collega l&apos;assistente
+            <ChevronRight className="ml-1 size-4" aria-hidden />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+function FirstStepsList({
+  steps,
+  doneCount,
+  onHide,
+}: {
+  steps: ReturnType<typeof useFirstSteps>['steps']
+  doneCount: number
+  onHide: () => void
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div className="space-y-1.5">
+          <CardTitle>Primi passi</CardTitle>
+          <CardDescription>
+            {doneCount} di {steps.length}. Nell&apos;ordine in cui il CRM li chiede.
+          </CardDescription>
+        </div>
+        <Button type="button" variant="ghost" size="sm" onClick={onHide}>
+          Nascondi
+        </Button>
+      </CardHeader>
+      <CardContent>
+        <ol className="divide-y">
+          {steps.map((step) => (
+            <li key={step.id} className="flex items-start gap-3 py-3">
+              {step.done ? (
+                <Check className="mt-0.5 size-5 shrink-0 text-emerald-600" aria-label="fatto" />
+              ) : (
+                <Circle className="text-muted-foreground mt-0.5 size-5 shrink-0" aria-label="da fare" />
+              )}
+              <div className="min-w-0 flex-1">
+                {step.done ? (
+                  <p className="text-muted-foreground line-through">{step.title}</p>
+                ) : (
+                  <Link to={step.to} className="font-medium underline-offset-4 hover:underline">
+                    {step.title}
+                  </Link>
+                )}
+                {!step.done && <p className="text-muted-foreground text-sm">{step.hint}</p>}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </CardContent>
+    </Card>
+  )
+}

--- a/projects/pigrocrm/apps/web/src/features/dashboard/NewSpacePanels.tsx
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/NewSpacePanels.tsx
@@ -2,19 +2,29 @@
  * The two panels a new space sees above its dashboard (spec 2026-09-12 §6.7): the
  * assistant first, because it is what the landing sells and what a space is for, then
  * the four first steps. Both read their state from the data (`useFirstSteps`) and
- * disappear on their own: the card when a token exists, the list at four of four or on
- * «Nascondi», which is the one preference kept, and kept in the browser.
+ * disappear on their own: the card when this user has a token, the list at four of four
+ * or on «Nascondi», the one preference kept, and kept in the browser. A readonly user
+ * sees neither: there is nothing here they could do.
  */
 import { Link } from '@tanstack/react-router'
 import { Bot, Check, ChevronRight, Circle } from 'lucide-react'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { CONNECT_ASSISTANT_TO, hide, isHidden, useFirstSteps } from './newSpace'
+import { useAuth, useCanWrite } from '@/lib/auth'
+import { CONNECT_ASSISTANT_TO, hide, isHidden, useFirstSteps, type FirstStep } from './newSpace'
 
 export function NewSpacePanels() {
-  const state = useFirstSteps()
-  const [hidden, setHidden] = useState(isHidden)
+  const canWrite = useCanWrite()
+  if (!canWrite) return null
+  return <Panels />
+}
+
+function Panels() {
+  const { user } = useAuth()
+  const userId = user?.id ?? ''
+  const [hidden, setHidden] = useState(() => isHidden(userId))
+  const state = useFirstSteps({ hidden })
   if (state.loading) return null
   const showAssistant = !state.assistantConnected
   const showSteps = !state.allDone && !hidden
@@ -27,7 +37,7 @@ export function NewSpacePanels() {
           steps={state.steps}
           doneCount={state.doneCount}
           onHide={() => {
-            hide()
+            hide(userId)
             setHidden(true)
           }}
         />
@@ -45,14 +55,14 @@ function AssistantCard() {
           <CardTitle className="text-xl">Il CRM che lavora al posto tuo</CardTitle>
           <CardDescription className="text-base">
             Collega Claude al tuo spazio e chiedigli di registrare le ore, preparare
-            un&apos;offerta, riassumere la settimana. Tutto quello che fai qui lo può fare lui.
+            un’offerta, riassumere la settimana. Tutto quello che fai qui lo può fare lui.
           </CardDescription>
         </div>
       </CardHeader>
       <CardContent>
         <Button asChild size="lg">
           <Link to={CONNECT_ASSISTANT_TO}>
-            Collega l&apos;assistente
+            Collega l’assistente
             <ChevronRight className="ml-1 size-4" aria-hidden />
           </Link>
         </Button>
@@ -66,7 +76,7 @@ function FirstStepsList({
   doneCount,
   onHide,
 }: {
-  steps: ReturnType<typeof useFirstSteps>['steps']
+  steps: FirstStep[]
   doneCount: number
   onHide: () => void
 }) {
@@ -76,7 +86,7 @@ function FirstStepsList({
         <div className="space-y-1.5">
           <CardTitle>Primi passi</CardTitle>
           <CardDescription>
-            {doneCount} di {steps.length}. Nell&apos;ordine in cui il CRM li chiede.
+            {doneCount} di {steps.length}. Nell’ordine in cui il CRM li chiede.
           </CardDescription>
         </div>
         <Button type="button" variant="ghost" size="sm" onClick={onHide}>
@@ -88,17 +98,20 @@ function FirstStepsList({
           {steps.map((step) => (
             <li key={step.id} className="flex items-start gap-3 py-3">
               {step.done ? (
-                <Check className="mt-0.5 size-5 shrink-0 text-emerald-600" aria-label="fatto" />
+                <Check className="text-foreground mt-0.5 size-5 shrink-0" aria-hidden />
               ) : (
-                <Circle className="text-muted-foreground mt-0.5 size-5 shrink-0" aria-label="da fare" />
+                <Circle className="text-muted-foreground mt-0.5 size-5 shrink-0" aria-hidden />
               )}
               <div className="min-w-0 flex-1">
+                <span className="sr-only">{step.done ? 'Fatto: ' : 'Da fare: '}</span>
                 {step.done ? (
                   <p className="text-muted-foreground line-through">{step.title}</p>
-                ) : (
+                ) : step.canDo ? (
                   <Link to={step.to} className="font-medium underline-offset-4 hover:underline">
                     {step.title}
                   </Link>
+                ) : (
+                  <p className="font-medium">{step.title}</p>
                 )}
                 {!step.done && <p className="text-muted-foreground text-sm">{step.hint}</p>}
               </div>

--- a/projects/pigrocrm/apps/web/src/features/dashboard/newSpace.ts
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/newSpace.ts
@@ -1,19 +1,30 @@
 /**
  * What a new space still has to do, read from the data and never stored (spec
- * 2026-09-12 §6.7): a step is done because the thing exists. Six cheap reads, one row
- * each, so the Home of an empty space can say what comes first without a table of its
- * own. The root and any space that has been used see nothing: every step is done.
+ * 2026-09-12 §6.7): a step is done because the thing exists. Six one-row reads, so the
+ * Home of an empty space can say what comes first without a table of its own. The root
+ * and any space that has been used see nothing: every step is done.
+ *
+ * The keys sit under the prefixes the rest of the app invalidates (`['customers', …]`,
+ * `['emitter', …]`, `['tokens', userId, …]`), so creating the first customer, saving
+ * the emitter or minting a token refreshes the panel on the next Home without waiting
+ * out `staleTime`.
  */
 import { useQuery } from '@tanstack/react-query'
-import { api } from '@/lib/api'
+import { api, toProblem } from '@/lib/api'
+import { useAuth } from '@/lib/auth'
+import { queryKeys } from '@/lib/query'
+import { tenantPrefix } from '@/lib/tenant'
 
 export type StepId = 'fiscali' | 'cliente' | 'lavoro' | 'documento'
+export type StepTarget = '/app/impostazioni/emittente' | '/app/clienti' | '/app/deal'
 
 export interface FirstStep {
   id: StepId
   title: string
   hint: string
-  to: string
+  to: StepTarget
+  /** Whether the person who is looking can do this step themselves. */
+  canDo: boolean
   done: boolean
 }
 
@@ -22,24 +33,28 @@ export interface FirstStepsState {
   steps: FirstStep[]
   doneCount: number
   allDone: boolean
-  /** Whether the space has at least one personal access token: the assistant is connected. */
+  /** Whether this user has a personal access token: their assistant is connected. */
   assistantConnected: boolean
 }
 
-/** The one preference this panel keeps, and it keeps it in the browser: whose it is. */
-export const HIDE_KEY = 'pigrocrm.primi-passi.nascosto'
+/** The one preference this panel keeps, in the browser, per space and per user: two
+ *  spaces share the origin (`/<slug>/app`), and «Nascondi» in one must not hide the
+ *  other's list. */
+export function hideKey(userId: string): string {
+  return `pigrocrm.primi-passi.nascosto:${tenantPrefix || '/'}:${userId}`
+}
 
-export function isHidden(): boolean {
+export function isHidden(userId: string): boolean {
   try {
-    return window.localStorage.getItem(HIDE_KEY) === '1'
+    return window.localStorage.getItem(hideKey(userId)) === '1'
   } catch {
     return false
   }
 }
 
-export function hide(): void {
+export function hide(userId: string): void {
   try {
-    window.localStorage.setItem(HIDE_KEY, '1')
+    window.localStorage.setItem(hideKey(userId), '1')
   } catch {
     // A browser that refuses storage shows the panel again next time. Fine.
   }
@@ -48,49 +63,88 @@ export function hide(): void {
 /** Where the «Collega l'assistente» button goes. ORB-170 is shipping the «Collega un
  *  agente» dialog in the sidebar; until the Home can open that dialog, the token page
  *  is the place where the assistant is connected today. */
-export const CONNECT_ASSISTANT_TO = '/app/token'
+export const CONNECT_ASSISTANT_TO = '/app/token' as const
 
-async function hasAny(path: '/api/customers' | '/api/deals' | '/api/time-entries' | '/api/documents'): Promise<boolean> {
-  const { data } = await api.GET(path, { params: { query: { limit: 1 } } } as never)
-  const page = data as { items?: unknown[] } | undefined
-  return (page?.items?.length ?? 0) > 0
+const SCOPE = { scope: 'first-steps', limit: 1 } as const
+
+/** Throws for any answer that is not 2xx, except the one the caller names as an
+ *  ordinary state (the emitter's 404). A step that could not be read counts as done
+ *  (`value` below): a panel that nags because a request broke would be the untrue thing
+ *  on the page, and the charts beside it already say when the API is down. */
+function settled<T>(
+  result: { data?: T; error?: unknown; response: Response },
+  okStatuses: readonly number[] = [],
+): T | undefined {
+  if (result.error !== undefined && !okStatuses.includes(result.response.status)) {
+    throw toProblem(result.error, result.response.status)
+  }
+  return result.data
+}
+
+async function hasCustomers(): Promise<boolean> {
+  const page = settled(await api.GET('/api/customers', { params: { query: { limit: 1 } } }))
+  return (page?.items.length ?? 0) > 0
+}
+
+async function hasDeals(): Promise<boolean> {
+  const page = settled(await api.GET('/api/deals', { params: { query: { limit: 1 } } }))
+  return (page?.items.length ?? 0) > 0
+}
+
+async function hasTimeEntries(): Promise<boolean> {
+  const page = settled(await api.GET('/api/time-entries', { params: { query: { limit: 1 } } }))
+  return (page?.items.length ?? 0) > 0
+}
+
+async function hasDocuments(): Promise<boolean> {
+  const page = settled(await api.GET('/api/documents', { params: { query: { limit: 1 } } }))
+  return (page?.items.length ?? 0) > 0
 }
 
 async function fiscalDataSaved(): Promise<boolean> {
   // 404 until the emitter profile is saved once: not an error here, a step to do.
-  const { data, response } = await api.GET('/api/emitter')
-  if (response.status === 404 || !data) return false
-  const profile = data as { partita_iva?: string | null; codice_fiscale?: string | null }
-  return Boolean(profile.partita_iva || profile.codice_fiscale)
+  const profile = settled(await api.GET('/api/emitter'), [404])
+  return Boolean(profile?.partita_iva || profile?.codice_fiscale)
 }
 
 async function hasToken(): Promise<boolean> {
-  const { data } = await api.GET('/api/tokens')
-  return Array.isArray(data) && data.length > 0
+  const tokens = settled(await api.GET('/api/tokens'))
+  return (tokens?.length ?? 0) > 0
 }
 
 const OPTIONS = { retry: false, staleTime: 30_000 } as const
 
-export function useFirstSteps(): FirstStepsState {
-  const fiscali = useQuery({ queryKey: ['first-steps', 'fiscali'], queryFn: fiscalDataSaved, ...OPTIONS })
-  const cliente = useQuery({ queryKey: ['first-steps', 'cliente'], queryFn: () => hasAny('/api/customers'), ...OPTIONS })
-  const deal = useQuery({ queryKey: ['first-steps', 'deal'], queryFn: () => hasAny('/api/deals'), ...OPTIONS })
-  const ore = useQuery({ queryKey: ['first-steps', 'ore'], queryFn: () => hasAny('/api/time-entries'), ...OPTIONS })
-  const documento = useQuery({ queryKey: ['first-steps', 'documento'], queryFn: () => hasAny('/api/documents'), ...OPTIONS })
-  const token = useQuery({ queryKey: ['first-steps', 'token'], queryFn: hasToken, ...OPTIONS })
+export function useFirstSteps({ hidden }: { hidden: boolean }): FirstStepsState {
+  const { user } = useAuth()
+  const userId = user?.id ?? ''
+  const isAdmin = user?.ruolo === 'admin'
+  // Only the token is read while the list is hidden: the card stays until the assistant
+  // is connected, the five other reads are not worth a request nobody will see.
+  const steps = { ...OPTIONS, enabled: !hidden }
+  const token = useQuery({
+    queryKey: [...queryKeys.tokens(userId), 'first-steps'],
+    queryFn: hasToken,
+    ...OPTIONS,
+  })
+  const fiscali = useQuery({ queryKey: [...queryKeys.emitter, 'first-steps'], queryFn: fiscalDataSaved, ...steps })
+  const cliente = useQuery({ queryKey: queryKeys.customers(SCOPE), queryFn: hasCustomers, ...steps })
+  const deal = useQuery({ queryKey: queryKeys.deals(SCOPE), queryFn: hasDeals, ...steps })
+  const ore = useQuery({ queryKey: queryKeys.timeEntries(SCOPE), queryFn: hasTimeEntries, ...steps })
+  const documento = useQuery({ queryKey: queryKeys.documents(SCOPE), queryFn: hasDocuments, ...steps })
 
-  const all = [fiscali, cliente, deal, ore, documento, token]
-  const loading = all.some((q) => q.isPending)
-  // A read that failed counts as done: a panel that nags because a request broke would
-  // be the untrue thing on the page. The charts beside it already say when the API is down.
+  const active = hidden ? [token] : [token, fiscali, cliente, deal, ore, documento]
+  const loading = active.some((q) => q.isPending)
   const value = (q: { data?: boolean; isError: boolean }) => (q.isError ? true : (q.data ?? false))
 
-  const steps: FirstStep[] = [
+  const list: FirstStep[] = [
     {
       id: 'fiscali',
       title: 'I tuoi dati fiscali',
-      hint: 'Partita IVA o codice fiscale, indirizzo, regime: finiscono su offerte e fatture.',
+      hint: isAdmin
+        ? 'Partita IVA o codice fiscale, indirizzo, regime: finiscono su offerte e fatture.'
+        : 'Li imposta l’amministratore dello spazio, in Impostazioni.',
       to: '/app/impostazioni/emittente',
+      canDo: isAdmin,
       done: value(fiscali),
     },
     {
@@ -98,6 +152,7 @@ export function useFirstSteps(): FirstStepsState {
       title: 'Il primo cliente',
       hint: 'Un’azienda o una persona per cui lavori. Tutto il resto parte da qui.',
       to: '/app/clienti',
+      canDo: true,
       done: value(cliente),
     },
     {
@@ -105,6 +160,7 @@ export function useFirstSteps(): FirstStepsState {
       title: 'Il primo deal, o le prime ore',
       hint: 'Una trattativa in corso, oppure le ore che hai già lavorato.',
       to: '/app/deal',
+      canDo: true,
       done: value(deal) || value(ore),
     },
     {
@@ -112,15 +168,16 @@ export function useFirstSteps(): FirstStepsState {
       title: 'La prima offerta',
       hint: 'Dal deal, «Crea documento»: il template «Offerta» è già pronto.',
       to: '/app/deal',
+      canDo: true,
       done: value(documento),
     },
   ]
-  const doneCount = steps.filter((s) => s.done).length
+  const doneCount = list.filter((s) => s.done).length
   return {
     loading,
-    steps,
+    steps: list,
     doneCount,
-    allDone: doneCount === steps.length,
+    allDone: doneCount === list.length,
     assistantConnected: value(token),
   }
 }

--- a/projects/pigrocrm/apps/web/src/features/dashboard/newSpace.ts
+++ b/projects/pigrocrm/apps/web/src/features/dashboard/newSpace.ts
@@ -1,0 +1,126 @@
+/**
+ * What a new space still has to do, read from the data and never stored (spec
+ * 2026-09-12 §6.7): a step is done because the thing exists. Six cheap reads, one row
+ * each, so the Home of an empty space can say what comes first without a table of its
+ * own. The root and any space that has been used see nothing: every step is done.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+
+export type StepId = 'fiscali' | 'cliente' | 'lavoro' | 'documento'
+
+export interface FirstStep {
+  id: StepId
+  title: string
+  hint: string
+  to: string
+  done: boolean
+}
+
+export interface FirstStepsState {
+  loading: boolean
+  steps: FirstStep[]
+  doneCount: number
+  allDone: boolean
+  /** Whether the space has at least one personal access token: the assistant is connected. */
+  assistantConnected: boolean
+}
+
+/** The one preference this panel keeps, and it keeps it in the browser: whose it is. */
+export const HIDE_KEY = 'pigrocrm.primi-passi.nascosto'
+
+export function isHidden(): boolean {
+  try {
+    return window.localStorage.getItem(HIDE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function hide(): void {
+  try {
+    window.localStorage.setItem(HIDE_KEY, '1')
+  } catch {
+    // A browser that refuses storage shows the panel again next time. Fine.
+  }
+}
+
+/** Where the «Collega l'assistente» button goes. ORB-170 is shipping the «Collega un
+ *  agente» dialog in the sidebar; until the Home can open that dialog, the token page
+ *  is the place where the assistant is connected today. */
+export const CONNECT_ASSISTANT_TO = '/app/token'
+
+async function hasAny(path: '/api/customers' | '/api/deals' | '/api/time-entries' | '/api/documents'): Promise<boolean> {
+  const { data } = await api.GET(path, { params: { query: { limit: 1 } } } as never)
+  const page = data as { items?: unknown[] } | undefined
+  return (page?.items?.length ?? 0) > 0
+}
+
+async function fiscalDataSaved(): Promise<boolean> {
+  // 404 until the emitter profile is saved once: not an error here, a step to do.
+  const { data, response } = await api.GET('/api/emitter')
+  if (response.status === 404 || !data) return false
+  const profile = data as { partita_iva?: string | null; codice_fiscale?: string | null }
+  return Boolean(profile.partita_iva || profile.codice_fiscale)
+}
+
+async function hasToken(): Promise<boolean> {
+  const { data } = await api.GET('/api/tokens')
+  return Array.isArray(data) && data.length > 0
+}
+
+const OPTIONS = { retry: false, staleTime: 30_000 } as const
+
+export function useFirstSteps(): FirstStepsState {
+  const fiscali = useQuery({ queryKey: ['first-steps', 'fiscali'], queryFn: fiscalDataSaved, ...OPTIONS })
+  const cliente = useQuery({ queryKey: ['first-steps', 'cliente'], queryFn: () => hasAny('/api/customers'), ...OPTIONS })
+  const deal = useQuery({ queryKey: ['first-steps', 'deal'], queryFn: () => hasAny('/api/deals'), ...OPTIONS })
+  const ore = useQuery({ queryKey: ['first-steps', 'ore'], queryFn: () => hasAny('/api/time-entries'), ...OPTIONS })
+  const documento = useQuery({ queryKey: ['first-steps', 'documento'], queryFn: () => hasAny('/api/documents'), ...OPTIONS })
+  const token = useQuery({ queryKey: ['first-steps', 'token'], queryFn: hasToken, ...OPTIONS })
+
+  const all = [fiscali, cliente, deal, ore, documento, token]
+  const loading = all.some((q) => q.isPending)
+  // A read that failed counts as done: a panel that nags because a request broke would
+  // be the untrue thing on the page. The charts beside it already say when the API is down.
+  const value = (q: { data?: boolean; isError: boolean }) => (q.isError ? true : (q.data ?? false))
+
+  const steps: FirstStep[] = [
+    {
+      id: 'fiscali',
+      title: 'I tuoi dati fiscali',
+      hint: 'Partita IVA o codice fiscale, indirizzo, regime: finiscono su offerte e fatture.',
+      to: '/app/impostazioni/emittente',
+      done: value(fiscali),
+    },
+    {
+      id: 'cliente',
+      title: 'Il primo cliente',
+      hint: 'Un’azienda o una persona per cui lavori. Tutto il resto parte da qui.',
+      to: '/app/clienti',
+      done: value(cliente),
+    },
+    {
+      id: 'lavoro',
+      title: 'Il primo deal, o le prime ore',
+      hint: 'Una trattativa in corso, oppure le ore che hai già lavorato.',
+      to: '/app/deal',
+      done: value(deal) || value(ore),
+    },
+    {
+      id: 'documento',
+      title: 'La prima offerta',
+      hint: 'Dal deal, «Crea documento»: il template «Offerta» è già pronto.',
+      to: '/app/deal',
+      done: value(documento),
+    },
+  ]
+  const doneCount = steps.filter((s) => s.done).length
+  return {
+    loading,
+    steps,
+    doneCount,
+    allDone: doneCount === steps.length,
+    assistantConnected: value(token),
+  }
+}


### PR DESCRIPTION
## What this changes

The Home of a new space showed two empty charts and said nothing about what to do first; the assistant the landing sells was a «Token» entry at the bottom of the sidebar. Now, above the dashboard of a space that has not been used yet, two panels read from the data and never stored: a wide card («Il CRM che lavora al posto tuo», «Collega l'assistente») that stays until the space has a personal access token, and «Primi passi», four items in the order the product needs them (the fiscal data, the first customer, the first deal or the first hours, the first offer), each a link and each done when the thing exists, with «2 di 4» and a «Nascondi» whose one preference lives in the browser. Six one-row reads (`/api/customers`, `/api/deals`, `/api/time-entries`, `/api/documents`, `/api/emitter`, `/api/tokens`); a read that fails counts as done so the panel never nags because a request broke. The root and any space in use see nothing. Spec `projects/pigrocrm/docs/superpowers/specs/2026-09-12-onboarding-product-led-design.md` §6.7.

## How I verified it

- `pnpm --filter web test` → `103 files, 1099 tests passed`, four of them new in `DashboardPage.test.tsx`: the empty space shows both panels with «0 di 4» and four «da fare»; a customer and an emitter with a VAT number make «2 di 4» and turn the two done steps from links into struck text; everything done plus a token shows neither panel; «Nascondi» removes the steps, keeps the card and writes `pigrocrm.primi-passi.nascosto`.
- `pnpm --filter web lint` clean; `pnpm --filter web build` (vite + `tsc --noEmit`) ok.
- The pair below was taken on two Vite dev servers (this branch and `origin/main`) with every `/api/*` answer mocked by Playwright to the same empty space, 1440×900, `scale: css`, sidebar cropped.

## What did not change, on purpose

The button goes to `/app/token` (`CONNECT_ASSISTANT_TO` in `newSpace.ts`). ORB-170 is shipping the «Collega un agente» dialog in the sidebar; when the Home can open that dialog the constant becomes the call, one line. `AppShell.tsx` is untouched for the same reason. No new API, table or migration; no sample data (spec §7).

## Anything a reviewer should look at twice

- The six extra requests on every Home load, cached 30 s. They are `limit=1` reads; the alternative, a server-side «attivazione» read, is in the spec's backlog (§7) and would move the cost, not remove it.
- «A failed read counts as done»: a space whose API is down sees the charts' own error and no panel, which is the honest state.

## Screenshots

**1. The Home of an empty space**
![The Home before and after: two empty charts, then the assistant card and the four first steps above them](https://github.com/user-attachments/assets/2720592c-fecc-4bd8-8214-79c6412ef281)

Linear: ORB-174.
