### PR TITLE
design(website): the pitch page counts 65 iscritti, 60 talenti, 18,2k views and 41 followers

### DIFF
--- a/projects/website/src/pitch.html
+++ b/projects/website/src/pitch.html
@@ -113,13 +113,13 @@
         <div class="pad center">
           <p class="kicker" data-reveal>Cinque giorni dopo</p>
           <div style="display: flex; align-items: flex-end; gap: 60px; margin-top: 30px;">
-            <div class="big" data-reveal style="--d: 0.2s; font-size: 380px;"><span data-count="63">63</span></div>
+            <div class="big" data-reveal style="--d: 0.2s; font-size: 380px;"><span data-count="65">65</span></div>
             <div data-reveal style="--d: 0.5s; padding-bottom: 40px;">
               <div class="label" style="font-size: 54px; color: #fff; font-weight: 600; line-height: 1.05;">iscritti.</div>
               <div class="label" style="font-size: 40px; margin-top: 14px;">Ne avevamo promessi tre.</div>
             </div>
           </div>
-          <p class="statement small" data-reveal style="--d: 0.9s; margin-top: 50px;"><span class="accent">58 talenti</span>, <span class="accent">5 aziende</span>, e il <span class="accent">primo match</span> già chiuso.</p>
+          <p class="statement small" data-reveal style="--d: 0.9s; margin-top: 50px;"><span class="accent">60 talenti</span>, <span class="accent">5 aziende</span>, e il <span class="accent">primo match</span> già chiuso.</p>
         </div>
         <div class="foot"><span>joinorbiters.com</span><span></span></div>
       </section>
@@ -132,9 +132,9 @@
           <div class="center" style="height: calc(100% - 60px);">
           <p class="kicker" data-reveal>I numeri della prima settimana</p>
           <div class="stats" style="margin-top: 60px; gap: 70px 48px;">
-            <div data-reveal style="--d: 0.2s;"><div class="n"><span data-count="17.5" data-decimals="1">17,5</span><small>k</small></div><div class="l">visualizzazioni su LinkedIn</div></div>
+            <div data-reveal style="--d: 0.2s;"><div class="n"><span data-count="18.2" data-decimals="1">18,2</span><small>k</small></div><div class="l">visualizzazioni su LinkedIn</div></div>
             <div data-reveal style="--d: 0.35s;"><div class="n"><span data-count="500">500</span><small>+</small></div><div class="l">visite uniche al giorno</div></div>
-            <div data-reveal style="--d: 0.5s;"><div class="n"><span data-count="40">40</span></div><div class="l">follower della pagina</div></div>
+            <div data-reveal style="--d: 0.5s;"><div class="n"><span data-count="41">41</span></div><div class="l">follower della pagina</div></div>
             <div data-reveal style="--d: 0.65s;"><div class="n"><span data-count="10">10</span></div><div class="l">stelle su GitHub</div></div>
             <div data-reveal style="--d: 0.8s;"><div class="n"><span data-count="5">5</span></div><div class="l">aziende con un progetto</div></div>
             <div data-reveal style="--d: 0.95s;"><div class="n accent"><span data-count="1">1</span></div><div class="l">match già chiuso</div></div>


### PR DESCRIPTION
## What this changes

The pitch page's numbers were three days behind the community again. Ivan's count of this morning: 60 talents, so 65 signups with the 5 companies; 18,2k views on the LinkedIn posts; 41 followers on the page. Slide 6 now counts to **65 iscritti** with «60 talenti, 5 aziende, e il primo match già chiuso» (was 63 and «58 talenti»), slide 7 counts to **18,2k** visualizzazioni and **41** follower (17,5k and 40). Both the animated counter and the value the markup falls back to without JavaScript changed. Nothing else on the page moves; the desk copy carries the same values.

## How I verified it

- `pnpm --filter website lint`: eslint clean.
- `pnpm --filter website test`: 12 files, 223 tests passed.
- `pnpm --filter website build`: built in 374 ms.
- `pnpm --filter website test:e2e`: 54 passed (12.1 s) against `vite preview` on 4173.
- `diff` of the `<body>` of the page against the desk copy: only the picture-path lines differ, as before.
- Opened `http://localhost:4173/pitch?static=1` from this branch's build and read slides 6 and 7: the frames below.

## Screenshots

Before from `https://joinorbiters.com/pitch?static=1` as live today (`website-v0.8.4`), after from this branch's `vite preview`, both at 1920×1080.

**1. Slide 6, the signups**
![Slide 6, before and after](https://github.com/user-attachments/assets/5140bf49-ac50-4476-86cc-d26249743943)

**2. Slide 7, the week's numbers**
![Slide 7, before and after](https://github.com/user-attachments/assets/c5b249d8-2df4-4cc4-93d5-b82006619c92)

Linear: ORB-179.
