### PR TITLE
design(website): the pitch page counts 18,5k LinkedIn views and 42 followers

### DIFF
--- a/projects/website/src/pitch.html
+++ b/projects/website/src/pitch.html
@@ -132,9 +132,9 @@
           <div class="center" style="height: calc(100% - 60px);">
           <p class="kicker" data-reveal>I numeri della prima settimana</p>
           <div class="stats" style="margin-top: 60px; gap: 70px 48px;">
-            <div data-reveal style="--d: 0.2s;"><div class="n"><span data-count="18.2" data-decimals="1">18,2</span><small>k</small></div><div class="l">visualizzazioni su LinkedIn</div></div>
+            <div data-reveal style="--d: 0.2s;"><div class="n"><span data-count="18.5" data-decimals="1">18,5</span><small>k</small></div><div class="l">visualizzazioni su LinkedIn</div></div>
             <div data-reveal style="--d: 0.35s;"><div class="n"><span data-count="500">500</span><small>+</small></div><div class="l">visite uniche al giorno</div></div>
-            <div data-reveal style="--d: 0.5s;"><div class="n"><span data-count="41">41</span></div><div class="l">follower della pagina</div></div>
+            <div data-reveal style="--d: 0.5s;"><div class="n"><span data-count="42">42</span></div><div class="l">follower della pagina</div></div>
             <div data-reveal style="--d: 0.65s;"><div class="n"><span data-count="10">10</span></div><div class="l">stelle su GitHub</div></div>
             <div data-reveal style="--d: 0.8s;"><div class="n"><span data-count="5">5</span></div><div class="l">aziende con un progetto</div></div>
             <div data-reveal style="--d: 0.95s;"><div class="n accent"><span data-count="1">1</span></div><div class="l">match già chiuso</div></div>


### PR DESCRIPTION
## What this changes

Two counters on slide 7 of `/pitch` were behind Ivan's count of later this morning: the LinkedIn posts reached **18,5k** views (the page said 18,2k) and the page has **42** followers (41). Both the animated counter and the value the markup falls back to without JavaScript changed. The 60 talents he also named were already on slide 6 since #88. Nothing else moves; the desk copy carries the same values.

## How I verified it

- `pnpm --filter website lint`: eslint clean.
- `pnpm --filter website test`: 12 files, 223 tests passed.
- `pnpm --filter website build`: built in 518 ms.
- `pnpm --filter website test:e2e`: 54 passed (12.1 s) against `vite preview` on 4173.
- `diff` of the `<body>` of the page against the desk copy: only the picture-path lines differ, as before.
- Opened `http://localhost:4173/pitch?static=1` from this branch's build and read slide 7: the frame below.

## Screenshots

Before from `https://joinorbiters.com/pitch?static=1` as live today (`website-v0.8.5`), after from this branch's `vite preview`, both at 1920×1080.

**1. Slide 7, the week's numbers**
![Slide 7, before and after](https://github.com/user-attachments/assets/fc0c2806-56e3-4c99-b6eb-0aceb28fde74)

Linear: ORB-181.
