### PR TITLE
feat(web): every first step comes with a prompt to copy into the assistant

### DIFF
--- a/projects/pigrocrm/apps/web/src/features/get-started/CopyPrompt.tsx
+++ b/projects/pigrocrm/apps/web/src/features/get-started/CopyPrompt.tsx
@@ -1,0 +1,34 @@
+/**
+ * A ready prompt for the assistant, readable and selectable on the page, with a button
+ * that copies it (ORB-182). Collapsed behind a native `<details>`: the step's own line
+ * stays short, and the prompt is one click away with no state to keep.
+ */
+import { Copy } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+
+export function CopyPrompt({ text, summary = 'Prompt per l’assistente' }: { text: string; summary?: string }) {
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success('Prompt copiato')
+    } catch {
+      // A browser that refuses the clipboard: the text is on the page, select it.
+      toast.error('Non riesco a copiare: seleziona il testo qui sotto')
+    }
+  }
+  return (
+    <details className="mt-2 text-sm">
+      <summary className="text-muted-foreground cursor-pointer select-none underline-offset-4 hover:underline">
+        {summary}
+      </summary>
+      <div className="mt-2 space-y-2">
+        <p className="bg-muted/50 whitespace-pre-wrap rounded-md border p-3 leading-relaxed">{text}</p>
+        <Button type="button" variant="outline" size="sm" onClick={() => void copy()}>
+          <Copy className="mr-2 size-4" aria-hidden />
+          Copia il prompt
+        </Button>
+      </div>
+    </details>
+  )
+}

--- a/projects/pigrocrm/apps/web/src/features/get-started/GetStartedPage.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/get-started/GetStartedPage.test.tsx
@@ -4,12 +4,12 @@
  * the Home's one-time redirect. The API client is stubbed by path, `useAuth` by role.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { toast } from 'sonner'
 import { api } from '@/lib/api'
 import { GetStartedPage } from './GetStartedPage'
-import { INTRO_PROMPT, STEP_PROMPTS } from './prompts'
+import { FISCAL_PROMPT_FULL_ACCESS, INTRO_PROMPT, STEP_PROMPTS } from './prompts'
 
 vi.mock('@/lib/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/api')>()
@@ -49,6 +49,7 @@ const EMPTY: Record<string, unknown> = {
   '/api/time-entries': EMPTY_PAGE,
   '/api/documents': EMPTY_PAGE,
   '/api/tokens': [],
+  '/api/settings/space': { mcp_full_access: false },
 }
 
 /** Stubs by path: `overrides` win, `/api/emitter` is 404 unless overridden, `failing`
@@ -168,17 +169,39 @@ describe('Get started', () => {
     answers({ '/api/customers': { items: [{ id: 'c1' }], next_cursor: null } })
     renderPage()
     await screen.findByText(/1 di 4/)
-    // Three steps to do, one done: three step prompts, plus the card's own.
-    expect(screen.getAllByText('Prompt per l’assistente')).toHaveLength(3)
+    // Three steps to do, one done: three step prompts, each named after its step, plus
+    // the card's own.
+    expect(screen.getAllByText(/^Prompt per l’assistente: /)).toHaveLength(3)
     expect(screen.getByText('Il primo prompt, appena collegato')).toBeInTheDocument()
     expect(screen.getByText(INTRO_PROMPT)).toBeInTheDocument()
-    expect(screen.getByText(STEP_PROMPTS.fiscali)).toBeInTheDocument()
     expect(screen.queryByText(STEP_PROMPTS.cliente)).toBeNull()
-    const copies = screen.getAllByRole('button', { name: 'Copia il prompt' })
-    expect(copies).toHaveLength(4)
-    await userEvent.click(copies[1] as HTMLElement)
+    // The prompt is one click away, behind the step's disclosure.
+    const summary = screen.getByText('Prompt per l’assistente: I tuoi dati fiscali')
+    const details = summary.closest('details') as HTMLDetailsElement
+    expect(details.open).toBe(false)
+    await userEvent.click(summary)
+    expect(details.open).toBe(true)
+    expect(screen.getByText(STEP_PROMPTS.fiscali)).toBeInTheDocument()
+    await userEvent.click(within(details).getByRole('button', { name: 'Copia il prompt' }))
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(STEP_PROMPTS.fiscali)
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Prompt copiato'))
+  })
+
+  it('asks the assistant to write the fiscal profile only where the space grants it full access', async () => {
+    answers({ '/api/settings/space': { mcp_full_access: true } })
+    renderPage()
+    await screen.findByText(/0 di 4/)
+    expect(await screen.findByText(FISCAL_PROMPT_FULL_ACCESS)).toBeInTheDocument()
+    expect(screen.queryByText(STEP_PROMPTS.fiscali)).toBeNull()
+  })
+
+  it('does not read the space settings for a collaboratore, who has no fiscal step to prompt', async () => {
+    if (auth.user) auth.user.ruolo = 'collaboratore'
+    renderPage()
+    await screen.findByText(/0 di 4/)
+    expect(api.GET).not.toHaveBeenCalledWith('/api/settings/space')
+    expect(screen.queryByText(/Prompt per l’assistente: I tuoi dati fiscali/)).toBeNull()
+    expect(screen.getByText('Prompt per l’assistente: Il primo cliente')).toBeInTheDocument()
   })
 
   it('says so when the clipboard is refused, and leaves the text on the page', async () => {
@@ -186,6 +209,18 @@ describe('Get started', () => {
     Object.assign(navigator, { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('no')) } })
     renderPage()
     await screen.findByText(/0 di 4/)
+    await userEvent.click(screen.getByText('Il primo prompt, appena collegato'))
+    await userEvent.click(screen.getAllByRole('button', { name: 'Copia il prompt' })[0] as HTMLElement)
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(screen.getByText(INTRO_PROMPT)).toBeInTheDocument()
+  })
+
+  it('survives a browser with no clipboard at all, as on a plain http origin', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    Object.assign(navigator, { clipboard: undefined })
+    renderPage()
+    await screen.findByText(/0 di 4/)
+    await userEvent.click(screen.getByText('Il primo prompt, appena collegato'))
     await userEvent.click(screen.getAllByRole('button', { name: 'Copia il prompt' })[0] as HTMLElement)
     await waitFor(() => expect(toast.error).toHaveBeenCalled())
     expect(screen.getByText(INTRO_PROMPT)).toBeInTheDocument()
@@ -195,6 +230,6 @@ describe('Get started', () => {
     if (auth.user) auth.user.ruolo = 'readonly'
     renderPage()
     await screen.findByText(/0 di 4/)
-    expect(screen.queryAllByText('Prompt per l’assistente')).toHaveLength(0)
+    expect(screen.queryAllByText(/^Prompt per l’assistente/)).toHaveLength(0)
   })
 })

--- a/projects/pigrocrm/apps/web/src/features/get-started/GetStartedPage.test.tsx
+++ b/projects/pigrocrm/apps/web/src/features/get-started/GetStartedPage.test.tsx
@@ -6,8 +6,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
 import { api } from '@/lib/api'
 import { GetStartedPage } from './GetStartedPage'
+import { INTRO_PROMPT, STEP_PROMPTS } from './prompts'
 
 vi.mock('@/lib/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/api')>()
@@ -28,6 +30,8 @@ vi.mock('@/lib/auth', () => ({
   useCanWrite: () => auth.user?.ruolo !== 'readonly',
   useIsAdmin: () => auth.user?.ruolo === 'admin',
 }))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ to, children, className }: { to: string; children: React.ReactNode; className?: string }) => (
@@ -75,6 +79,9 @@ function renderPage() {
 
 beforeEach(() => {
   vi.mocked(api.GET).mockReset()
+  vi.mocked(toast.success).mockReset()
+  vi.mocked(toast.error).mockReset()
+  Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
   answers()
 })
 
@@ -154,5 +161,40 @@ describe('Get started', () => {
     renderPage()
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(window.localStorage.length).toBe(0)
+  })
+
+  it('offers a prompt to copy for each step still to do, and one for the first conversation', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    answers({ '/api/customers': { items: [{ id: 'c1' }], next_cursor: null } })
+    renderPage()
+    await screen.findByText(/1 di 4/)
+    // Three steps to do, one done: three step prompts, plus the card's own.
+    expect(screen.getAllByText('Prompt per l’assistente')).toHaveLength(3)
+    expect(screen.getByText('Il primo prompt, appena collegato')).toBeInTheDocument()
+    expect(screen.getByText(INTRO_PROMPT)).toBeInTheDocument()
+    expect(screen.getByText(STEP_PROMPTS.fiscali)).toBeInTheDocument()
+    expect(screen.queryByText(STEP_PROMPTS.cliente)).toBeNull()
+    const copies = screen.getAllByRole('button', { name: 'Copia il prompt' })
+    expect(copies).toHaveLength(4)
+    await userEvent.click(copies[1] as HTMLElement)
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(STEP_PROMPTS.fiscali)
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Prompt copiato'))
+  })
+
+  it('says so when the clipboard is refused, and leaves the text on the page', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('no')) } })
+    renderPage()
+    await screen.findByText(/0 di 4/)
+    await userEvent.click(screen.getAllByRole('button', { name: 'Copia il prompt' })[0] as HTMLElement)
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(screen.getByText(INTRO_PROMPT)).toBeInTheDocument()
+  })
+
+  it('gives a readonly user no prompt: there is nothing they could ask the assistant to change', async () => {
+    if (auth.user) auth.user.ruolo = 'readonly'
+    renderPage()
+    await screen.findByText(/0 di 4/)
+    expect(screen.queryAllByText('Prompt per l’assistente')).toHaveLength(0)
   })
 })

--- a/projects/pigrocrm/apps/web/src/features/get-started/GetStartedPage.tsx
+++ b/projects/pigrocrm/apps/web/src/features/get-started/GetStartedPage.tsx
@@ -1,6 +1,7 @@
 /**
  * «Get started» (ORB-180): the assistant first, because it is what the landing sells and
- * what a space is for, then the four first steps with their state. Both read from the data
+ * what a space is for, then the four first steps with their state, each with a prompt to
+ * copy into the assistant (ORB-182). Both read from the data
  * (`useFirstSteps`) and nothing is stored: the card stays until this user has a token, the
  * steps stay with their ticks. The Home sends a person here once, after the first login;
  * the sidebar brings them back whenever they want.
@@ -12,7 +13,9 @@ import { PageHeader } from '@/components/PageHeader'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { useAuth, useCanWrite } from '@/lib/auth'
+import { CopyPrompt } from './CopyPrompt'
 import { CONNECT_ASSISTANT_TO, markGetStartedSeen, useFirstSteps, type FirstStep } from './firstSteps'
+import { INTRO_PROMPT, STEP_PROMPTS } from './prompts'
 
 export function GetStartedPage() {
   const { user } = useAuth()
@@ -65,6 +68,8 @@ function AssistantCard() {
             <ChevronRight className="ml-1 size-4" aria-hidden />
           </Link>
         </Button>
+        {/* What to say first, once connected (ORB-182). */}
+        <CopyPrompt text={INTRO_PROMPT} summary="Il primo prompt, appena collegato" />
       </CardContent>
     </Card>
   )
@@ -117,6 +122,9 @@ function FirstStepsList({
                       {canWrite ? step.hint : 'Lo fa chi può scrivere nello spazio.'}
                     </p>
                   )}
+                  {/* The same step, said to the assistant (ORB-182): only for a step still
+                      to do, and only for someone who may do it. */}
+                  {linkable && <CopyPrompt text={STEP_PROMPTS[step.id]} />}
                 </div>
               </li>
             )

--- a/projects/pigrocrm/apps/web/src/features/get-started/GetStartedPage.tsx
+++ b/projects/pigrocrm/apps/web/src/features/get-started/GetStartedPage.tsx
@@ -8,20 +8,34 @@
  */
 import { Link } from '@tanstack/react-router'
 import { Bot, Check, ChevronRight, Circle, Rocket } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { PageHeader } from '@/components/PageHeader'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { useAuth, useCanWrite } from '@/lib/auth'
+import { SPACE_SETTINGS_KEY } from '@/features/settings/SpacePanel'
+import { api, unwrap } from '@/lib/api'
+import { useAuth, useCanWrite, useIsAdmin } from '@/lib/auth'
 import { CopyPrompt } from './CopyPrompt'
 import { CONNECT_ASSISTANT_TO, markGetStartedSeen, useFirstSteps, type FirstStep } from './firstSteps'
-import { INTRO_PROMPT, STEP_PROMPTS } from './prompts'
+import { INTRO_PROMPT, promptFor } from './prompts'
 
 export function GetStartedPage() {
   const { user } = useAuth()
   const userId = user?.id ?? ''
   const canWrite = useCanWrite()
+  const isAdmin = useIsAdmin()
   const state = useFirstSteps()
+  // Whether the agent may write the fiscal profile in this space: the settings are an
+  // admin's read, and the fiscal step is an admin's step, so nobody else asks.
+  const settings = useQuery({
+    queryKey: SPACE_SETTINGS_KEY,
+    queryFn: () => unwrap(api.GET('/api/settings/space')),
+    enabled: isAdmin,
+    retry: false,
+    staleTime: 30_000,
+  })
+  const fullAccess = settings.data?.mcp_full_access === true
 
   // Being here is what the Home's one-time redirect remembers, however one arrived:
   // through the redirect or through the sidebar. Either way the page has been seen.
@@ -40,7 +54,12 @@ export function GetStartedPage() {
         {state.loading ? null : (
           <>
             {!state.assistantConnected && <AssistantCard />}
-            <FirstStepsList steps={state.steps} doneCount={state.doneCount} canWrite={canWrite} />
+            <FirstStepsList
+              steps={state.steps}
+              doneCount={state.doneCount}
+              canWrite={canWrite}
+              fullAccess={fullAccess}
+            />
           </>
         )}
       </div>
@@ -79,10 +98,12 @@ function FirstStepsList({
   steps,
   doneCount,
   canWrite,
+  fullAccess,
 }: {
   steps: FirstStep[]
   doneCount: number
   canWrite: boolean
+  fullAccess: boolean
 }) {
   const allDone = doneCount === steps.length
   return (
@@ -123,8 +144,14 @@ function FirstStepsList({
                     </p>
                   )}
                   {/* The same step, said to the assistant (ORB-182): only for a step still
-                      to do, and only for someone who may do it. */}
-                  {linkable && <CopyPrompt text={STEP_PROMPTS[step.id]} />}
+                      to do, and only for someone who may do it. Named after the step, so
+                      three disclosures on one page read apart. */}
+                  {linkable && (
+                    <CopyPrompt
+                      text={promptFor(step.id, { fullAccess })}
+                      summary={`Prompt per l’assistente: ${step.title}`}
+                    />
+                  )}
                 </div>
               </li>
             )

--- a/projects/pigrocrm/apps/web/src/features/get-started/prompts.test.ts
+++ b/projects/pigrocrm/apps/web/src/features/get-started/prompts.test.ts
@@ -1,0 +1,28 @@
+/** The prompts a person copies into the assistant (ORB-182): one per step, honest about
+ *  what the MCP can and cannot do. */
+import { describe, expect, it } from 'vitest'
+import { INTRO_PROMPT, STEP_PROMPTS } from './prompts'
+
+describe('the ready prompts', () => {
+  it('cover every step and leave the values to fill in marked', () => {
+    for (const id of ['fiscali', 'cliente', 'lavoro', 'documento'] as const) {
+      expect(STEP_PROMPTS[id]).toContain('«')
+      expect(STEP_PROMPTS[id].length).toBeGreaterThan(80)
+    }
+  })
+
+  it('never promise the assistant will set the emitter, which the MCP cannot do', () => {
+    // The emitter's identity is a deliberate exclusion of the agent surface: the prompt
+    // asks for the fiscal profile and names Impostazioni → Emittente as the person's job.
+    expect(STEP_PROMPTS.fiscali).toContain('profilo fiscale')
+    expect(STEP_PROMPTS.fiscali).toContain('Impostazioni → Emittente')
+    expect(STEP_PROMPTS.fiscali).toMatch(/non la puoi fare tu/)
+  })
+
+  it('ask for a preview and a confirmation before anything is written or generated', () => {
+    expect(INTRO_PROMPT).toMatch(/aspetta il mio ok/)
+    expect(STEP_PROMPTS.fiscali).toMatch(/chiedimi conferma/)
+    expect(STEP_PROMPTS.documento).toMatch(/anteprima/)
+    expect(STEP_PROMPTS.cliente).toMatch(/non inventare/)
+  })
+})

--- a/projects/pigrocrm/apps/web/src/features/get-started/prompts.test.ts
+++ b/projects/pigrocrm/apps/web/src/features/get-started/prompts.test.ts
@@ -1,7 +1,7 @@
 /** The prompts a person copies into the assistant (ORB-182): one per step, honest about
- *  what the MCP can and cannot do. */
+ *  what the MCP can and cannot do in this space. */
 import { describe, expect, it } from 'vitest'
-import { INTRO_PROMPT, STEP_PROMPTS } from './prompts'
+import { FISCAL_PROMPT_FULL_ACCESS, INTRO_PROMPT, promptFor, STEP_PROMPTS } from './prompts'
 
 describe('the ready prompts', () => {
   it('cover every step and leave the values to fill in marked', () => {
@@ -9,19 +9,33 @@ describe('the ready prompts', () => {
       expect(STEP_PROMPTS[id]).toContain('«')
       expect(STEP_PROMPTS[id].length).toBeGreaterThan(80)
     }
+    expect(FISCAL_PROMPT_FULL_ACCESS).toContain('«')
   })
 
   it('never promise the assistant will set the emitter, which the MCP cannot do', () => {
-    // The emitter's identity is a deliberate exclusion of the agent surface: the prompt
-    // asks for the fiscal profile and names Impostazioni → Emittente as the person's job.
-    expect(STEP_PROMPTS.fiscali).toContain('profilo fiscale')
-    expect(STEP_PROMPTS.fiscali).toContain('Impostazioni → Emittente')
-    expect(STEP_PROMPTS.fiscali).toMatch(/non la puoi fare tu/)
+    // The emitter's identity is a deliberate exclusion of the agent surface: both fiscal
+    // prompts name Impostazioni → Emittente as the person's job.
+    for (const prompt of [STEP_PROMPTS.fiscali, FISCAL_PROMPT_FULL_ACCESS]) {
+      expect(prompt).toContain('profilo fiscale')
+      expect(prompt).toContain('Impostazioni → Emittente')
+      expect(prompt).toMatch(/non la puoi fare tu/)
+    }
+  })
+
+  it('ask the assistant to write the fiscal profile only where the space grants it full access', () => {
+    // `update_fiscal_profile` exists only with `mcp_full_access`, off by default: the
+    // default prompt reads and explains, the full-access one writes the whole profile.
+    expect(promptFor('fiscali', { fullAccess: false })).toMatch(/^Leggi il mio profilo fiscale/)
+    expect(promptFor('fiscali', { fullAccess: false })).not.toMatch(/Imposta il mio profilo/)
+    expect(promptFor('fiscali', { fullAccess: false })).toContain('Impostazioni → Fiscale')
+    expect(promptFor('fiscali', { fullAccess: true })).toBe(FISCAL_PROMPT_FULL_ACCESS)
+    expect(FISCAL_PROMPT_FULL_ACCESS).toMatch(/riepilogo dell’intero profilo/)
+    expect(promptFor('cliente', { fullAccess: true })).toBe(STEP_PROMPTS.cliente)
   })
 
   it('ask for a preview and a confirmation before anything is written or generated', () => {
     expect(INTRO_PROMPT).toMatch(/aspetta il mio ok/)
-    expect(STEP_PROMPTS.fiscali).toMatch(/chiedimi conferma/)
+    expect(FISCAL_PROMPT_FULL_ACCESS).toMatch(/chiedimi conferma/)
     expect(STEP_PROMPTS.documento).toMatch(/anteprima/)
     expect(STEP_PROMPTS.cliente).toMatch(/non inventare/)
   })

--- a/projects/pigrocrm/apps/web/src/features/get-started/prompts.ts
+++ b/projects/pigrocrm/apps/web/src/features/get-started/prompts.ts
@@ -2,22 +2,39 @@
  * The prompts a person copies into the assistant they just connected (ORB-182): one
  * for the first conversation, one per first step. Written the way a person talks to
  * their assistant, with every value to fill in marked as «…», and naming only what the
- * MCP can do: the emitter's identity is a deliberate exclusion of the agent surface
- * (`test_mcp_surface_coverage.py`, «identita' fiscale dell'emittente»), so the fiscal
- * prompt asks for the fiscal profile and says plainly that the emitter is typed by hand.
+ * MCP can do in this space: the emitter's identity is a deliberate exclusion of the agent
+ * surface (`test_mcp_surface_coverage.py`, «identita' fiscale dell'emittente»), and
+ * `update_fiscal_profile` is registered only where the space grants the agent full access
+ * (`mcp_full_access`, off by default). So the fiscal prompt has two voices: read and
+ * explain by default, write the whole profile where the switch is on; both say plainly
+ * that the emitter is typed by hand.
  */
 import type { StepId } from './firstSteps'
 
 export const INTRO_PROMPT =
   'Ciao! Sei collegato al mio spazio PigroCRM. Presentati in due righe, dimmi cosa vedi nello spazio (clienti, deal, ore, documenti, il profilo fiscale) e cosa puoi fare per me. Poi proponimi i primi tre passi per partire, nell’ordine giusto, e aspetta il mio ok prima di fare qualsiasi modifica.'
 
+/** The fiscal step where the agent may only read (the default of every space). */
+const FISCAL_PROMPT_READ =
+  'Leggi il mio profilo fiscale su PigroCRM e dimmi com’è impostato: regime, coefficiente di redditività, imposta sostitutiva, contributi INPS, modalità e scadenza di pagamento, IBAN. Io sono in regime «forfettario», coefficiente «78» %, imposta «5» %, INPS «26,07» %, pagamento «bonifico» a «30» giorni, IBAN «IT…»: dimmi cosa non corrisponde e cosa devo cambiare io in Impostazioni → Fiscale. Poi ricordami cosa devo compilare a mano in Impostazioni → Emittente (ragione sociale, partita IVA o codice fiscale, indirizzo, PEC, codice SDI): quella parte non la puoi fare tu.'
+
+/** The fiscal step where the space grants the agent full access: it writes the whole
+ *  profile, so the summary is of the whole profile, not only of the values named. */
+export const FISCAL_PROMPT_FULL_ACCESS =
+  'Imposta il mio profilo fiscale su PigroCRM. Regime «forfettario» (codice «RF19»), coefficiente di redditività «78» %, imposta sostitutiva «5» %, contributi INPS «26,07» %. Pagamenti: «bonifico», scadenza a «30» giorni, IBAN «IT…». Prima di salvare mostrami un riepilogo dell’intero profilo, anche dei campi che non ti ho dato, e chiedimi conferma. Poi ricordami cosa devo compilare io a mano in Impostazioni → Emittente (ragione sociale, partita IVA o codice fiscale, indirizzo, PEC, codice SDI): quella parte non la puoi fare tu.'
+
 export const STEP_PROMPTS: Record<StepId, string> = {
-  fiscali:
-    'Imposta il mio profilo fiscale su PigroCRM. Sono in regime forfettario (codice RF19), coefficiente di redditività «78» %, imposta sostitutiva «5» %, contributi INPS «26,07» %. Pagamenti: «bonifico», scadenza a «30» giorni, IBAN «IT…». Prima di salvare mostrami un riepilogo e chiedimi conferma. Poi ricordami cosa devo compilare io a mano in Impostazioni → Emittente (ragione sociale, partita IVA o codice fiscale, indirizzo, PEC, codice SDI): quella parte non la puoi fare tu.',
+  fiscali: FISCAL_PROMPT_READ,
   cliente:
     'Crea su PigroCRM un nuovo cliente: «Ragione sociale S.r.l.», partita IVA «…», indirizzo «via …, CAP, città (provincia)», email «…», PEC «…», codice SDI «…». Aggiungi come referente «Nome Cognome», ruolo «…», email «…», telefono «…». Se un campo non lo sai, lascialo vuoto e dimmelo: non inventare niente.',
   lavoro:
-    'Sul cliente «…» crea un deal chiamato «…», valore previsto «… €», nello stato «Offerta», probabilità «50» %. Poi registra le ore che ho già lavorato su quel deal: «gg/mm/aaaa», «2» ore, «cosa ho fatto». Alla fine dimmi il totale delle ore e il valore della pipeline aperta.',
+    'Sul cliente «…» crea un deal chiamato «…», valore previsto «… €», nello stato «Offerta», con chiusura prevista il «gg/mm/aaaa». Poi registra le ore che ho già lavorato su quel deal: «gg/mm/aaaa», «2» ore, «cosa ho fatto». Alla fine dimmi il totale delle ore e il valore della pipeline aperta.',
   documento:
     'Prepara un’offerta per il deal «…» del cliente «…» usando il template «Offerta». Oggetto: «…». Ambito e obiettivi: «…». Attività: «…». Condizioni economiche: «…». Fatturazione e pagamento: «…». Mostrami l’anteprima del testo e aspetta il mio ok prima di generare il PDF.',
+}
+
+/** The prompt for a step, in the voice the space allows: the fiscal one writes only
+ *  where the agent has full access. */
+export function promptFor(id: StepId, { fullAccess }: { fullAccess: boolean }): string {
+  return id === 'fiscali' && fullAccess ? FISCAL_PROMPT_FULL_ACCESS : STEP_PROMPTS[id]
 }

--- a/projects/pigrocrm/apps/web/src/features/get-started/prompts.ts
+++ b/projects/pigrocrm/apps/web/src/features/get-started/prompts.ts
@@ -1,0 +1,23 @@
+/**
+ * The prompts a person copies into the assistant they just connected (ORB-182): one
+ * for the first conversation, one per first step. Written the way a person talks to
+ * their assistant, with every value to fill in marked as «…», and naming only what the
+ * MCP can do: the emitter's identity is a deliberate exclusion of the agent surface
+ * (`test_mcp_surface_coverage.py`, «identita' fiscale dell'emittente»), so the fiscal
+ * prompt asks for the fiscal profile and says plainly that the emitter is typed by hand.
+ */
+import type { StepId } from './firstSteps'
+
+export const INTRO_PROMPT =
+  'Ciao! Sei collegato al mio spazio PigroCRM. Presentati in due righe, dimmi cosa vedi nello spazio (clienti, deal, ore, documenti, il profilo fiscale) e cosa puoi fare per me. Poi proponimi i primi tre passi per partire, nell’ordine giusto, e aspetta il mio ok prima di fare qualsiasi modifica.'
+
+export const STEP_PROMPTS: Record<StepId, string> = {
+  fiscali:
+    'Imposta il mio profilo fiscale su PigroCRM. Sono in regime forfettario (codice RF19), coefficiente di redditività «78» %, imposta sostitutiva «5» %, contributi INPS «26,07» %. Pagamenti: «bonifico», scadenza a «30» giorni, IBAN «IT…». Prima di salvare mostrami un riepilogo e chiedimi conferma. Poi ricordami cosa devo compilare io a mano in Impostazioni → Emittente (ragione sociale, partita IVA o codice fiscale, indirizzo, PEC, codice SDI): quella parte non la puoi fare tu.',
+  cliente:
+    'Crea su PigroCRM un nuovo cliente: «Ragione sociale S.r.l.», partita IVA «…», indirizzo «via …, CAP, città (provincia)», email «…», PEC «…», codice SDI «…». Aggiungi come referente «Nome Cognome», ruolo «…», email «…», telefono «…». Se un campo non lo sai, lascialo vuoto e dimmelo: non inventare niente.',
+  lavoro:
+    'Sul cliente «…» crea un deal chiamato «…», valore previsto «… €», nello stato «Offerta», probabilità «50» %. Poi registra le ore che ho già lavorato su quel deal: «gg/mm/aaaa», «2» ore, «cosa ho fatto». Alla fine dimmi il totale delle ore e il valore della pipeline aperta.',
+  documento:
+    'Prepara un’offerta per il deal «…» del cliente «…» usando il template «Offerta». Oggetto: «…». Ambito e obiettivi: «…». Attività: «…». Condizioni economiche: «…». Fatturazione e pagamento: «…». Mostrami l’anteprima del testo e aspetta il mio ok prima di generare il PDF.',
+}


### PR DESCRIPTION
## What this changes

Every first step on «Get started» that is still to do now comes with a ready prompt to copy into the assistant, and the assistant card carries one more for the moment right after connecting («presentati, dimmi cosa vedi, proponimi i primi tre passi»). The prompts are in Italian, in the voice of a person talking to their assistant, with the values to fill in marked as «…»; each one names only what the MCP can do in this space. The fiscal prompt has two voices: by default the agent may only read the profile (`update_fiscal_profile` exists only under `mcp_full_access`, off by default), so it asks the assistant to read it and say what to change in Impostazioni → Fiscale; where an admin has switched on full access for the agent's tokens, it asks to write the whole profile with a summary before saving. Both say plainly that the emitter's identity is typed by hand in Impostazioni → Emittente, which the MCP excludes on purpose. A «Copia il prompt» button writes to the clipboard with a toast; the text stays readable on the page so it can be selected by hand where the clipboard is refused. Each step's disclosure is named after its step. Readonly users and done steps get no prompt. Ivan's ask on 2026-09-12: «nei primi passi dai anche dei prompt già fatti da poter copiare per fare il setup».

## How I verified it

From `projects/pigrocrm/apps/web`: `pnpm exec vitest run src/features/get-started` → 3 files, 23 tests passed (`prompts.test.ts`: every step has a prompt with «…» placeholders, both fiscal prompts name Impostazioni → Emittente as the person's job, the default one does not ask to write; `GetStartedPage.test.tsx`: three named disclosures with one step done, the fiscal one opened before its copy button is clicked and the clipboard receiving the read prompt with the «Prompt copiato» toast, the writing prompt only with `mcp_full_access: true`, no settings read for a collaboratore, a refused clipboard and a missing clipboard both showing the error toast with the text still on the page, no prompt for readonly). Full web suite before the review commit: 108 files, 1124 tests. `pnpm lint` and `pnpm build` (vite + tsc) clean. Looked at the page in a dev server with the API mocked: the details open under each step, the copy lands in the clipboard.

## Anything a reviewer should look at twice

The prompt texts themselves: they carry filled placeholders for a forfettario («78» %, «5» %, «26,07» %, «RF19») so the assistant knows the shape of the answer; a person in another regime overwrites them. The settings read for the full-access switch is made only for admins, since the endpoint is admin-only and so is the fiscal step. The «Collega l'assistente» button still targets `/app/token` until ORB-170 lands, untouched here.

## Screenshots

Before and after, the «Get started» page with one step done and the fiscal prompt opened (boxed in the after).

![pair-1-getstarted-182](https://github.com/user-attachments/assets/24cf2a77-844f-49f9-b613-4c5702113724)