### PR TITLE
feat(web): report pageviews, sessions and the funnel to PostHog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@dnd-kit/core':
         specifier: 6.3.1
         version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@orbiters/analytics':
+        specifier: workspace:*
+        version: link:../../../../shared/analytics
       '@orbiters/brand':
         specifier: workspace:*
         version: link:../../../../shared/brand

--- a/projects/pigrocrm/Dockerfile.web
+++ b/projects/pigrocrm/Dockerfile.web
@@ -14,9 +14,11 @@ WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY projects/pigrocrm/apps/web/package.json projects/pigrocrm/apps/web/
 COPY shared/brand/package.json shared/brand/
+COPY shared/analytics/package.json shared/analytics/
 RUN pnpm install --frozen-lockfile --filter web...
 
 COPY shared/brand ./shared/brand
+COPY shared/analytics ./shared/analytics
 COPY projects/pigrocrm/apps/web ./projects/pigrocrm/apps/web
 RUN pnpm --filter web build
 

--- a/projects/pigrocrm/apps/web/package.json
+++ b/projects/pigrocrm/apps/web/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",
+    "@orbiters/analytics": "workspace:*",
     "@orbiters/brand": "workspace:*",
     "@tailwindcss/vite": "4.3.3",
     "@tanstack/react-query": "5.101.4",

--- a/projects/pigrocrm/apps/web/src/lib/analytics.test.ts
+++ b/projects/pigrocrm/apps/web/src/lib/analytics.test.ts
@@ -1,0 +1,143 @@
+import createClient from 'openapi-fetch'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@orbiters/analytics/browser', () => ({
+  capture: vi.fn(),
+  identifyGroup: vi.fn(),
+  identifyUser: vi.fn(),
+  resetUser: vi.fn(),
+}))
+
+import { capture, identifyGroup, identifyUser } from '@orbiters/analytics/browser'
+import type { paths } from './api-types'
+import { analyticsMiddleware, eventFor, identifySession, installAnalyticsMiddleware } from './analytics'
+
+// Absolute, because a `Request` needs a base to resolve against and the middleware
+// reads the pathname off `request.url`, the way it does in a browser where
+// `openapi-fetch` resolved `/<slug>/api/...` against the page's origin.
+const ORIGIN = 'http://pigrocrm.test'
+
+/** One call through the middleware alone: the request as the client would have built
+ *  it, the response as the server answered. */
+async function answered(method: string, path: string, status: number, prefix = '') {
+  const middleware = analyticsMiddleware(prefix)
+  await middleware.onResponse?.({
+    request: new Request(`${ORIGIN}${path}`, { method }),
+    response: new Response(null, { status }),
+  } as never)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('the funnel table', () => {
+  it.each([
+    ['POST', '/api/tenants/', 'spazio_creato'],
+    ['POST', '/api/auth/entra', 'entrato_con_link'],
+    ['POST', '/api/customers', 'cliente_creato'],
+    ['POST', '/api/deals', 'deal_creato'],
+    ['POST', '/api/documents', 'documento_creato'],
+    ['POST', '/api/time-entries', 'ore_registrate'],
+    ['POST', '/api/invoices', 'fattura_emessa'],
+    ['POST', '/api/tokens', 'assistente_collegato'],
+    ['PUT', '/api/emitter', 'profilo_emittente_salvato'],
+  ])('%s %s on a 2xx is exactly one %s', async (method, path, event) => {
+    await answered(method, path, 201)
+    expect(capture).toHaveBeenCalledTimes(1)
+    expect(capture).toHaveBeenCalledWith(event)
+  })
+
+  it.each([400, 401, 409, 422, 500, 503])('a %i is not an event', async (status) => {
+    await answered('POST', '/api/customers', status)
+    await answered('PUT', '/api/emitter', status)
+    expect(capture).not.toHaveBeenCalled()
+  })
+
+  it('leaves out everything the table does not name', async () => {
+    // A read, an update, a nested write, a sibling route and a wrong method on a
+    // listed path: none of them is an activation step.
+    await answered('GET', '/api/customers', 200)
+    await answered('PUT', '/api/customers/c1', 200)
+    await answered('POST', '/api/deals/d1/stage', 200)
+    await answered('POST', '/api/documents/from-template', 201)
+    await answered('POST', '/api/invoices/import', 201)
+    await answered('POST', '/api/emitter', 200)
+    await answered('POST', '/api/auth/login', 200)
+    await answered('POST', '/api/auth/logout', 200)
+    expect(capture).not.toHaveBeenCalled()
+  })
+
+  it('reads the path under a space with the prefix removed', async () => {
+    await answered('POST', '/studio/api/customers', 201, '/studio')
+    expect(capture).toHaveBeenCalledWith('cliente_creato')
+  })
+
+  it('does not mistake another space for this one', async () => {
+    // Only this space's own prefix is removed: another slug is left in the path and
+    // matches nothing, rather than counting as `/api/customers` here.
+    await answered('POST', '/studio-rossi/api/customers', 201, '/studio')
+    expect(capture).not.toHaveBeenCalled()
+  })
+
+  it('ignores a trailing slash either way', () => {
+    expect(eventFor('POST', '/api/tenants', '')).toBe('spazio_creato')
+    expect(eventFor('POST', '/api/tenants/', '')).toBe('spazio_creato')
+    expect(eventFor('POST', '/api/customers/', '')).toBe('cliente_creato')
+    expect(eventFor('post', '/studio/api/customers/', '/studio')).toBe('cliente_creato')
+  })
+})
+
+describe('on the real client', () => {
+  it('sees the request as openapi-fetch built it and counts a created customer once', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ id: 'c1' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const client = createClient<paths>({ baseUrl: `${ORIGIN}/studio`, fetch: fetchMock })
+    installAnalyticsMiddleware(client, '/studio')
+
+    await client.POST('/api/customers', { body: { ragione_sociale: 'Ada' } as never })
+    await client.GET('/api/customers')
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(capture).toHaveBeenCalledTimes(1)
+    expect(capture).toHaveBeenCalledWith('cliente_creato')
+  })
+
+  it('counts nothing when the API refused', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ detail: 'Dati non validi' }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const client = createClient<paths>({ baseUrl: ORIGIN, fetch: fetchMock })
+    installAnalyticsMiddleware(client, '')
+
+    await client.POST('/api/customers', { body: { ragione_sociale: '' } as never })
+
+    expect(capture).not.toHaveBeenCalled()
+  })
+})
+
+describe('identifySession', () => {
+  const ADA = { id: 'u1', email: 'ada@studio.it', nome: 'Ada', ruolo: 'admin' as const }
+
+  it('names the person with what Ivan chose to see, and the root installation as root', () => {
+    identifySession(ADA, '')
+    expect(identifyUser).toHaveBeenCalledWith('u1', {
+      email: 'ada@studio.it',
+      nome: 'Ada',
+      ruolo: 'admin',
+    })
+    expect(identifyGroup).toHaveBeenCalledWith('spazio', 'root')
+  })
+
+  it('names a space by its slug, without the slash', () => {
+    identifySession(ADA, '/studio')
+    expect(identifyGroup).toHaveBeenCalledWith('spazio', 'studio')
+  })
+})

--- a/projects/pigrocrm/apps/web/src/lib/analytics.test.ts
+++ b/projects/pigrocrm/apps/web/src/lib/analytics.test.ts
@@ -8,9 +8,9 @@ vi.mock('@orbiters/analytics/browser', () => ({
   resetUser: vi.fn(),
 }))
 
-import { capture, identifyGroup, identifyUser } from '@orbiters/analytics/browser'
+import { capture, identifyGroup, identifyUser, resetUser } from '@orbiters/analytics/browser'
 import type { paths } from './api-types'
-import { analyticsMiddleware, eventFor, identifySession, installAnalyticsMiddleware } from './analytics'
+import { analyticsMiddleware, eventFor, forgetSession, identifySession } from './analytics'
 
 // Absolute, because a `Request` needs a base to resolve against and the middleware
 // reads the pathname off `request.url`, the way it does in a browser where
@@ -97,7 +97,7 @@ describe('on the real client', () => {
       }),
     )
     const client = createClient<paths>({ baseUrl: `${ORIGIN}/studio`, fetch: fetchMock })
-    installAnalyticsMiddleware(client, '/studio')
+    client.use(analyticsMiddleware('/studio'))
 
     await client.POST('/api/customers', { body: { ragione_sociale: 'Ada' } as never })
     await client.GET('/api/customers')
@@ -115,7 +115,7 @@ describe('on the real client', () => {
       }),
     )
     const client = createClient<paths>({ baseUrl: ORIGIN, fetch: fetchMock })
-    installAnalyticsMiddleware(client, '')
+    client.use(analyticsMiddleware(''))
 
     await client.POST('/api/customers', { body: { ragione_sociale: '' } as never })
 
@@ -139,5 +139,10 @@ describe('identifySession', () => {
   it('names a space by its slug, without the slash', () => {
     identifySession(ADA, '/studio')
     expect(identifyGroup).toHaveBeenCalledWith('spazio', 'studio')
+  })
+
+  it('is undone by forgetSession', () => {
+    forgetSession()
+    expect(resetUser).toHaveBeenCalledTimes(1)
   })
 })

--- a/projects/pigrocrm/apps/web/src/lib/analytics.ts
+++ b/projects/pigrocrm/apps/web/src/lib/analytics.ts
@@ -8,10 +8,10 @@
  * action counts only when the API said yes: a 422 on «Nuovo cliente» is not a customer.
  *
  * Identity follows the session the same way: `AuthProvider` calls `identifySession`
- * when `me` answers a person, and `resetUser` when they leave.
+ * when `me` answers a person, and `forgetSession` when they leave or the session is gone.
  * Design: docs/design/2026-09-12-posthog-analytics-design.md, «The CRM (ORB-184)».
  */
-import { capture, identifyGroup, identifyUser } from '@orbiters/analytics/browser'
+import { capture, identifyGroup, identifyUser, resetUser } from '@orbiters/analytics/browser'
 import type { Middleware } from 'openapi-fetch'
 import type { SessionUser } from './auth'
 import { tenantPrefix } from './tenant'
@@ -52,9 +52,11 @@ export function eventFor(method: string, pathname: string, prefix: string): stri
 }
 
 /**
- * The middleware itself. `onResponse` sees the response after `sendRefreshingSession`
- * has already retried an expired session, so a call that succeeded on the second try
- * counts once, and a call that stayed 401 does not count at all.
+ * The middleware itself, registered from `main.tsx` rather than inside `lib/api.ts` so
+ * the client stays a plain typed fetch in every test that stubs it. `onResponse` sees
+ * the response after `sendRefreshingSession` has already retried an expired session,
+ * so a call that succeeded on the second try counts once, and a call that stayed 401
+ * does not count at all.
  */
 export function analyticsMiddleware(prefix: string = tenantPrefix): Middleware {
   return {
@@ -64,15 +66,6 @@ export function analyticsMiddleware(prefix: string = tenantPrefix): Middleware {
       if (event !== undefined) capture(event)
     },
   }
-}
-
-/** Registered from `main.tsx`, not inside `lib/api.ts`, so the client stays a plain
- *  typed fetch in every test that stubs it. */
-export function installAnalyticsMiddleware(
-  client: { use(...middleware: Middleware[]): void },
-  prefix: string = tenantPrefix,
-): void {
-  client.use(analyticsMiddleware(prefix))
 }
 
 /** The group key for a space: its slug, or `root` for the installation with no prefix. */
@@ -88,4 +81,9 @@ export function identifySession(
 ): void {
   identifyUser(user.id, { email: user.email, nome: user.nome, ruolo: user.ruolo })
   identifyGroup('spazio', spaceKey(prefix))
+}
+
+/** Forgets the person: on logout, and when the session vanished without one. */
+export function forgetSession(): void {
+  resetUser()
 }

--- a/projects/pigrocrm/apps/web/src/lib/analytics.ts
+++ b/projects/pigrocrm/apps/web/src/lib/analytics.ts
@@ -1,0 +1,91 @@
+/**
+ * What the CRM tells PostHog beyond pageviews and clicks, and where it says it.
+ *
+ * The activation funnel is read off the API client rather than written into the
+ * features. `lib/api.ts` is the one `openapi-fetch` client, and every write the funnel
+ * cares about goes through it, so one middleware on that client turns a closed table of
+ * successful calls into named events. A feature file never mentions analytics, and an
+ * action counts only when the API said yes: a 422 on «Nuovo cliente» is not a customer.
+ *
+ * Identity follows the session the same way: `AuthProvider` calls `identifySession`
+ * when `me` answers a person, and `resetUser` when they leave.
+ * Design: docs/design/2026-09-12-posthog-analytics-design.md, «The CRM (ORB-184)».
+ */
+import { capture, identifyGroup, identifyUser } from '@orbiters/analytics/browser'
+import type { Middleware } from 'openapi-fetch'
+import type { SessionUser } from './auth'
+import { tenantPrefix } from './tenant'
+
+/**
+ * `METHOD /path` as the OpenAPI document spells it, with the space's prefix and any
+ * trailing slash removed first. Closed on purpose: nothing else the client does is an
+ * event, and «first customer» or «activated within seven days» are funnels PostHog
+ * computes from these, not something the code decides.
+ */
+const EVENTS: ReadonlyMap<string, string> = new Map([
+  ['POST /api/tenants', 'spazio_creato'],
+  ['POST /api/auth/entra', 'entrato_con_link'],
+  ['POST /api/customers', 'cliente_creato'],
+  ['POST /api/deals', 'deal_creato'],
+  ['POST /api/documents', 'documento_creato'],
+  ['POST /api/time-entries', 'ore_registrate'],
+  ['POST /api/invoices', 'fattura_emessa'],
+  ['POST /api/tokens', 'assistente_collegato'],
+  ['PUT /api/emitter', 'profilo_emittente_salvato'],
+])
+
+/**
+ * The pathname the table is keyed on. Under a space every request is `/<slug>/api/...`
+ * (the client's `baseUrl`, lib/api.ts), so the prefix goes first; the trailing slash
+ * goes because `/api/tenants/` is served with one and its siblings are not, and the
+ * table should not have to remember which is which.
+ */
+function tablePath(pathname: string, prefix: string): string {
+  const own = prefix !== '' && (pathname === prefix || pathname.startsWith(`${prefix}/`))
+  const bare = own ? pathname.slice(prefix.length) : pathname
+  return bare.length > 1 ? bare.replace(/\/+$/, '') : bare
+}
+
+/** The event a successful call earns, or undefined for everything the table leaves out. */
+export function eventFor(method: string, pathname: string, prefix: string): string | undefined {
+  return EVENTS.get(`${method.toUpperCase()} ${tablePath(pathname, prefix)}`)
+}
+
+/**
+ * The middleware itself. `onResponse` sees the response after `sendRefreshingSession`
+ * has already retried an expired session, so a call that succeeded on the second try
+ * counts once, and a call that stayed 401 does not count at all.
+ */
+export function analyticsMiddleware(prefix: string = tenantPrefix): Middleware {
+  return {
+    onResponse({ request, response }) {
+      if (!response.ok) return
+      const event = eventFor(request.method, new URL(request.url).pathname, prefix)
+      if (event !== undefined) capture(event)
+    },
+  }
+}
+
+/** Registered from `main.tsx`, not inside `lib/api.ts`, so the client stays a plain
+ *  typed fetch in every test that stubs it. */
+export function installAnalyticsMiddleware(
+  client: { use(...middleware: Middleware[]): void },
+  prefix: string = tenantPrefix,
+): void {
+  client.use(analyticsMiddleware(prefix))
+}
+
+/** The group key for a space: its slug, or `root` for the installation with no prefix. */
+export function spaceKey(prefix: string): string {
+  return prefix === '' ? 'root' : prefix.slice(1)
+}
+
+/** The person and the space they are in. Email and name are sent on purpose: Ivan
+ *  chose to see who a session belongs to (design, «What was decided»). */
+export function identifySession(
+  user: Pick<SessionUser, 'id' | 'email' | 'nome' | 'ruolo'>,
+  prefix: string = tenantPrefix,
+): void {
+  identifyUser(user.id, { email: user.email, nome: user.nome, ruolo: user.ruolo })
+  identifyGroup('spazio', spaceKey(prefix))
+}

--- a/projects/pigrocrm/apps/web/src/lib/auth.test.tsx
+++ b/projects/pigrocrm/apps/web/src/lib/auth.test.tsx
@@ -1,13 +1,21 @@
+import { identifyGroup, identifyUser, resetUser } from '@orbiters/analytics/browser'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { AuthProvider, useIsAdmin } from './auth'
+import { AuthProvider, useAuth, useIsAdmin } from './auth'
 import { api } from './api'
 
 vi.mock('./api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./api')>()
   return { ...actual, api: { ...actual.api, GET: vi.fn(), POST: vi.fn() } }
 })
+
+vi.mock('@orbiters/analytics/browser', () => ({
+  capture: vi.fn(),
+  identifyGroup: vi.fn(),
+  identifyUser: vi.fn(),
+  resetUser: vi.fn(),
+}))
 
 function ok(data: unknown) {
   return { data, response: new Response(null, { status: 200 }) } as never
@@ -18,7 +26,15 @@ const DEMOTED = { ...ADMIN, ruolo: 'collaboratore' }
 
 function Probe() {
   const isAdmin = useIsAdmin()
-  return <div>{isAdmin ? 'admin' : 'not-admin'}</div>
+  const { logout } = useAuth()
+  return (
+    <div>
+      {isAdmin ? 'admin' : 'not-admin'}
+      {/* `AppShell` fires `void logout()`; here the rejection is caught so a refused
+          logout is asserted on rather than reported as an unhandled one. */}
+      <button onClick={() => void logout().catch(() => undefined)}>Esci</button>
+    </div>
+  )
 }
 
 function renderProbe() {
@@ -33,7 +49,9 @@ function renderProbe() {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks()
   vi.mocked(api.GET).mockReset()
+  vi.mocked(api.POST).mockReset()
   // `shouldAdvanceTime` keeps real wall-clock progress ticking the fake clock
   // forward too -- without it, @testing-library's own `findBy*`/`waitFor`
   // polling (built on `setTimeout`) never sees time pass at all and every
@@ -44,6 +62,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllGlobals()
 })
 
 describe('AuthProvider — session freshness', () => {
@@ -81,5 +100,70 @@ describe('AuthProvider — session freshness', () => {
     // `refetchInterval` guard (`query.state.data ? 30_000 : false`) is what
     // keeps a `null` session from being polled at all.
     expect(api.GET).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('AuthProvider — who PostHog sees', () => {
+  it('identifies the person and the space once the session is known, and not again on every poll', async () => {
+    vi.mocked(api.GET).mockReturnValue(Promise.resolve(ok(ADMIN)))
+    renderProbe()
+    expect(await screen.findByText('admin')).toBeInTheDocument()
+
+    expect(identifyUser).toHaveBeenCalledTimes(1)
+    expect(identifyUser).toHaveBeenCalledWith('u1', { email: 'a@p.it', nome: 'Admin', ruolo: 'admin' })
+    // jsdom's page lives at `/`, which is the root installation, not a space.
+    expect(identifyGroup).toHaveBeenCalledTimes(1)
+    expect(identifyGroup).toHaveBeenCalledWith('spazio', 'root')
+
+    // The thirty-second re-read answers the same person as a new object.
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(api.GET).toHaveBeenCalledTimes(2)
+    expect(identifyUser).toHaveBeenCalledTimes(1)
+    expect(identifyGroup).toHaveBeenCalledTimes(1)
+  })
+
+  it('identifies nobody while there is no session', async () => {
+    vi.mocked(api.GET).mockReturnValue(
+      Promise.resolve({ error: { detail: 'Autenticazione richiesta' }, response: new Response(null, { status: 401 }) } as never),
+    )
+    renderProbe()
+    await screen.findByText('not-admin')
+    expect(identifyUser).not.toHaveBeenCalled()
+    expect(identifyGroup).not.toHaveBeenCalled()
+  })
+
+  it('forgets the person on logout, before the page leaves', async () => {
+    const assign = vi.fn()
+    vi.stubGlobal('location', { pathname: '/', assign })
+    vi.mocked(api.GET).mockReturnValue(Promise.resolve(ok(ADMIN)))
+    vi.mocked(api.POST).mockReturnValue(Promise.resolve(ok(undefined)))
+    renderProbe()
+    await screen.findByText('admin')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Esci' }))
+
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/app/login'))
+    expect(resetUser).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(resetUser).mock.invocationCallOrder[0]).toBeLessThan(
+      assign.mock.invocationCallOrder[0] ?? 0,
+    )
+  })
+
+  it('forgets the person even when the server refused the logout, as it still leaves', async () => {
+    const assign = vi.fn()
+    vi.stubGlobal('location', { pathname: '/', assign })
+    vi.mocked(api.GET).mockReturnValue(Promise.resolve(ok(ADMIN)))
+    // `{ error, response }` rather than a rejected promise: `unwrap` is what throws,
+    // as it does against the real client.
+    vi.mocked(api.POST).mockReturnValue(
+      Promise.resolve({ error: { detail: 'boom' }, response: new Response(null, { status: 500 }) } as never),
+    )
+    renderProbe()
+    await screen.findByText('admin')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Esci' }))
+
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/app/login'))
+    expect(resetUser).toHaveBeenCalledTimes(1)
   })
 })

--- a/projects/pigrocrm/apps/web/src/lib/auth.test.tsx
+++ b/projects/pigrocrm/apps/web/src/lib/auth.test.tsx
@@ -105,7 +105,7 @@ describe('AuthProvider — session freshness', () => {
 
 describe('AuthProvider — who PostHog sees', () => {
   it('identifies the person and the space once the session is known, and not again on every poll', async () => {
-    vi.mocked(api.GET).mockReturnValue(Promise.resolve(ok(ADMIN)))
+    vi.mocked(api.GET).mockImplementation(() => Promise.resolve(ok({ ...ADMIN })))
     renderProbe()
     expect(await screen.findByText('admin')).toBeInTheDocument()
 
@@ -130,6 +130,30 @@ describe('AuthProvider — who PostHog sees', () => {
     await screen.findByText('not-admin')
     expect(identifyUser).not.toHaveBeenCalled()
     expect(identifyGroup).not.toHaveBeenCalled()
+    // A visitor's first `null` is not a reset: the login pageview has to merge into
+    // the person they become.
+    expect(resetUser).not.toHaveBeenCalled()
+  })
+
+  it('forgets the person once when the session vanishes without a logout here', async () => {
+    // Another tab logged out, or the account was deactivated: the poll answers 401 and
+    // `app.tsx` router-pushes to the login page without a reload, so the identified
+    // id would otherwise stay in memory and own the login page's pageviews.
+    vi.mocked(api.GET).mockReturnValueOnce(Promise.resolve(ok(ADMIN)))
+    renderProbe()
+    expect(await screen.findByText('admin')).toBeInTheDocument()
+
+    vi.mocked(api.GET).mockReturnValue(
+      Promise.resolve({ error: { detail: 'Autenticazione richiesta' }, response: new Response(null, { status: 401 }) } as never),
+    )
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(await screen.findByText('not-admin')).toBeInTheDocument()
+
+    expect(resetUser).toHaveBeenCalledTimes(1)
+    // No session, no poll (the interval guard), and nothing left to forget either way.
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(resetUser).toHaveBeenCalledTimes(1)
+    expect(identifyUser).toHaveBeenCalledTimes(1)
   })
 
   it('forgets the person on logout, before the page leaves', async () => {

--- a/projects/pigrocrm/apps/web/src/lib/auth.tsx
+++ b/projects/pigrocrm/apps/web/src/lib/auth.tsx
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { createContext, use, type ReactNode } from 'react'
+import { resetUser } from '@orbiters/analytics/browser'
+import { createContext, use, useEffect, type ReactNode } from 'react'
+import { identifySession } from './analytics'
 import { api, unwrap } from './api'
 import { queryKeys } from './query'
 import { tenantPrefix } from './tenant'
@@ -62,8 +64,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     mutationFn: () => unwrap(api.POST('/api/auth/logout')),
   })
 
+  const user = (data as SessionUser | null) ?? null
+
+  // Keyed on the four values PostHog receives, never on `user` itself: `me` is re-read
+  // every thirty seconds and each answer is a new object, so an effect on the object
+  // would re-identify the same person on every poll. A change of role does re-run it,
+  // which is right: the person property should say what they are now.
+  const userId = user?.id
+  const email = user?.email
+  const nome = user?.nome
+  const ruolo = user?.ruolo
+  useEffect(() => {
+    if (userId === undefined || email === undefined || nome === undefined || ruolo === undefined) {
+      return
+    }
+    identifySession({ id: userId, email, nome, ruolo })
+  }, [userId, email, nome, ruolo])
+
   const value: AuthValue = {
-    user: (data as SessionUser | null) ?? null,
+    user,
     isLoading,
     login: async (email, password) => {
       await loginMutation.mutateAsync({ email, password })
@@ -90,6 +109,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         await logoutMutation.mutateAsync()
       } finally {
+        // Before the page leaves, and in the `finally` for the same reason the
+        // navigation is: the person asked to be forgotten here too, and the next login
+        // on this browser must not be stitched onto them.
+        resetUser()
         queryClient.clear()
         window.location.assign(`${tenantPrefix}/app/login`)
       }

--- a/projects/pigrocrm/apps/web/src/lib/auth.tsx
+++ b/projects/pigrocrm/apps/web/src/lib/auth.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { resetUser } from '@orbiters/analytics/browser'
-import { createContext, use, useEffect, type ReactNode } from 'react'
-import { identifySession } from './analytics'
+import { createContext, use, useEffect, useRef, type ReactNode } from 'react'
+import { forgetSession, identifySession } from './analytics'
 import { api, unwrap } from './api'
 import { queryKeys } from './query'
 import { tenantPrefix } from './tenant'
@@ -66,18 +65,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const user = (data as SessionUser | null) ?? null
 
-  // Keyed on the four values PostHog receives, never on `user` itself: `me` is re-read
-  // every thirty seconds and each answer is a new object, so an effect on the object
-  // would re-identify the same person on every poll. A change of role does re-run it,
-  // which is right: the person property should say what they are now.
+  // The effect keys are the properties PostHog receives: a role change re-identifies,
+  // a new object from the thirty-second poll does not. `identified` remembers who, so a
+  // session that vanishes without a logout here (another tab logged out, a
+  // deactivation, a revoked refresh) is forgotten once, before the router shows the
+  // login page to what would otherwise still be that person. An anonymous visitor's
+  // first `null` is not a reset: that would break the merge of their login pageview
+  // into the person they are about to become.
+  const identified = useRef<string | undefined>(undefined)
+  const forget = () => {
+    identified.current = undefined
+    forgetSession()
+  }
   const userId = user?.id
   const email = user?.email
   const nome = user?.nome
   const ruolo = user?.ruolo
   useEffect(() => {
     if (userId === undefined || email === undefined || nome === undefined || ruolo === undefined) {
+      if (identified.current !== undefined) forget()
       return
     }
+    identified.current = userId
     identifySession({ id: userId, email, nome, ruolo })
   }, [userId, email, nome, ruolo])
 
@@ -111,8 +120,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       } finally {
         // Before the page leaves, and in the `finally` for the same reason the
         // navigation is: the person asked to be forgotten here too, and the next login
-        // on this browser must not be stitched onto them.
-        resetUser()
+        // on this browser must not be stitched onto them. Leaving matters more than
+        // forgetting, so a third-party call that throws cannot keep the page here.
+        try {
+          forget()
+        } catch {
+          // deliberately ignored
+        }
         queryClient.clear()
         window.location.assign(`${tenantPrefix}/app/login`)
       }

--- a/projects/pigrocrm/apps/web/src/main.tsx
+++ b/projects/pigrocrm/apps/web/src/main.tsx
@@ -3,7 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { installAnalyticsMiddleware } from './lib/analytics'
+import { analyticsMiddleware } from './lib/analytics'
 import { api } from './lib/api'
 import { AuthProvider } from './lib/auth'
 import { queryClient } from './lib/query'
@@ -27,7 +27,7 @@ declare module '@tanstack/react-router' {
 // recording of the CRM shows where a person clicks and stops, never an invoice
 // amount or a customer's name.
 initAnalytics({ maskText: true })
-installAnalyticsMiddleware(api)
+api.use(analyticsMiddleware())
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/projects/pigrocrm/apps/web/src/main.tsx
+++ b/projects/pigrocrm/apps/web/src/main.tsx
@@ -1,7 +1,10 @@
+import { initAnalytics } from '@orbiters/analytics/browser'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { installAnalyticsMiddleware } from './lib/analytics'
+import { api } from './lib/api'
 import { AuthProvider } from './lib/auth'
 import { queryClient } from './lib/query'
 import { tenantPrefix } from './lib/tenant'
@@ -17,6 +20,14 @@ declare module '@tanstack/react-router' {
     router: typeof router
   }
 }
+
+// Once, before anything renders: `initAnalytics` decides on the hostname whether this
+// page is measured at all (nothing on localhost), and every wrapper after it is a
+// no-op until it has. Every text in a replay is masked, not only the inputs: a
+// recording of the CRM shows where a person clicks and stops, never an invoice
+// amount or a customer's name.
+initAnalytics({ maskText: true })
+installAnalyticsMiddleware(api)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## What this changes

Nobody could see how a space is used: the activation metric of the onboarding spec (first customer, activated within seven days) had no events behind it, and the CRM sent nothing to PostHog at all. Now the SPA initialises the shared PostHog project from `@orbiters/analytics` once in `main.tsx` with `maskText: true`, so pageviews, autocapture and session replay arrive with every text and every input masked: a recording shows where a person clicks and stops, never an invoice amount or a customer's name.

The funnel is read off the API client rather than written into the features. `main.tsx` registers one `openapi-fetch` middleware from `lib/analytics.ts` on the client in `lib/api.ts`, with a closed table of nine successful calls to named events: `POST /api/tenants/` is `spazio_creato`, `POST /api/auth/entra` is `entrato_con_link`, `POST /api/customers` is `cliente_creato`, `POST /api/deals` is `deal_creato`, `POST /api/documents` is `documento_creato`, `POST /api/time-entries` is `ore_registrate`, `POST /api/invoices` is `fattura_emessa`, `POST /api/tokens` is `assistente_collegato`, `PUT /api/emitter` is `profilo_emittente_salvato`. The space's prefix (`/<slug>/api/...`) and any trailing slash are removed before the lookup; a 4xx or 5xx counts nothing; nothing outside the table emits.

`AuthProvider` calls `identifyUser(id, { email, nome, ruolo })` and `identifyGroup('spazio', slug)` (`root` for the installation with no prefix) when `me` answers a person, and `resetUser()` on logout, in the `finally`, before `window.location.assign`. The web image copies `shared/analytics/package.json` before `pnpm install` and the directory before the build, next to the two `shared/brand` lines, or the workspace link cannot resolve inside the image.

**Adjacent:** ORB-183 (the site) is merged and already rewrote the privacy page for this; ORB-185 (the hub) is the same package on the other SPA, in its own worktree; ORB-186 (the MCP server) is server-side and its own card.

## How I verified it

From the repository root:

- `pnpm install --frozen-lockfile`: `Already up to date`, exit 0 (the lockfile gained the one `link:../../../../shared/analytics` entry).
- `pnpm --filter web lint`: `eslint .`, no output, exit 0.
- `pnpm --filter web test`: `Test Files 109 passed (109)`, `Tests 1153 passed (1153)`. New: `src/lib/analytics.test.ts` (23 tests: each of the nine rows emits exactly its event on a 2xx; 400/401/409/422/500/503 emit nothing; a read, an update, `POST /api/documents/from-template`, `POST /api/invoices/import`, `POST /api/emitter` and the session endpoints emit nothing; the prefix is stripped under `/studio` and another slug is not; trailing slashes are ignored; one run through a real `createClient` with a stubbed `fetch` proves the request reaches the middleware as `openapi-fetch` builds it; `identifySession` names `root` and `studio`). `auth.test.tsx` gained four: identify and group once when the session appears and not again after the thirty-second poll answers the same person; nobody identified on a 401; `resetUser` before `assign('/app/login')` on logout; the same when the server answered 500.
- `pnpm --filter web build`: `vite build` built in 788 ms and `tsc --noEmit` passed, exit 0.
- `pnpm --filter @orbiters/analytics test`: `Test Files 2 passed (2)`, `Tests 9 passed (9)`.

Not verified: the image build (`docker compose build web`) was not run here; the two `COPY` lines mirror the `shared/brand` pair exactly, and the trunk's image job will prove it. Not verified either: an event arriving in PostHog, which needs the preview deploy (the hostname rule makes localhost silent by design); that check is written on the card after the deploy, as the design's Verification section says.

## Anything a reviewer should look at twice

- The identify effect depends on `[userId, email, nome, ruolo]` rather than on `[user?.id]` alone. `user` is a new object on every thirty-second poll, so the object cannot be the key; the four primitives are, and `react-hooks/exhaustive-deps` stays clean without a disable. The consequence is that a role change re-identifies the person with the new `ruolo`, which is what a person property should do. The test proves the poll alone does not re-identify.
- Under a space, a bare `/api/customers` reaching the space's client would still match the table, because there is no prefix to strip. The client's `baseUrl` makes that request impossible, so I did not add a rule for it; another slug's prefix is left in place and matches nothing (tested).
- `identifySession` sends email and name, as Ivan decided in the design (`What was decided, and by whom`). If that decision moves, the one place to change is `lib/analytics.ts`.
- The middleware is registered from `main.tsx`, not inside `lib/api.ts`, so every test that stubs `fetch` around the client keeps seeing a plain typed client.

## What did not change, on purpose

- No feature file mentions analytics: the table in `lib/analytics.ts` is the whole contract, as the design says.
- The MCP server is ORB-186 (server-side, `posthog` Python SDK, after ORB-170), not this card.
- The privacy page and `docs/design/DECISIONS.md` were rewritten by ORB-183 (#95) and already describe what the CRM records.
- `spazio_creato` carries no group: the space does not exist until the API answers, and PostHog computes the funnel per person from the `spazio_creato` timestamp (design, «The CRM»). Confirmed by the review as design-level, not a gap here.
- `POST /api/documents/from-template` and `POST /api/invoices/import` are not events: the table names `POST /api/documents` and `POST /api/invoices` and nothing else, and widening it is a design change rather than an implementation one.

## Screenshots

Nothing a person can see changed: PostHog has no UI inside the CRM, there is no banner (the person is signed in and the privacy page says what is recorded), and the masking only affects the recording PostHog stores. The section is kept on purpose.

Linear: ORB-184.

