### PR TITLE
design(website): the pitch page lists the five things that went online, and counts 61 talents and 44 followers

### DIFF
--- a/projects/website/src/pitch.css
+++ b/projects/website/src/pitch.css
@@ -145,10 +145,9 @@ h1, .h1 { font-size: 168px; font-weight: 600; line-height: 0.96; letter-spacing:
 .list .row .n { font-size: 44px; font-weight: 600; color: var(--melon); }
 .list .row .t { font-size: 60px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.05; }
 .list .row .t small { display: block; font-size: 30px; font-weight: 400; color: var(--quiet); letter-spacing: 0; margin-top: 6px; }
-.list.five { gap: 14px; }
-.list.five .row { padding-bottom: 12px; }
-.list.five .row .t { font-size: 46px; }
-.list.five .row .t small { font-size: 24px; margin-top: 2px; }
+.list.five { gap: 18px; }
+.list.five .row { padding-bottom: 16px; }
+.list.five .row .t { font-size: 54px; }
 
 /* Three columns of one word. */
 .cols { display: grid; grid-template-columns: repeat(3, 1fr); gap: 48px; }

--- a/projects/website/src/pitch.css
+++ b/projects/website/src/pitch.css
@@ -145,6 +145,10 @@ h1, .h1 { font-size: 168px; font-weight: 600; line-height: 0.96; letter-spacing:
 .list .row .n { font-size: 44px; font-weight: 600; color: var(--melon); }
 .list .row .t { font-size: 60px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.05; }
 .list .row .t small { display: block; font-size: 30px; font-weight: 400; color: var(--quiet); letter-spacing: 0; margin-top: 6px; }
+.list.five { gap: 14px; }
+.list.five .row { padding-bottom: 12px; }
+.list.five .row .t { font-size: 46px; }
+.list.five .row .t small { font-size: 24px; margin-top: 2px; }
 
 /* Three columns of one word. */
 .cols { display: grid; grid-template-columns: repeat(3, 1fr); gap: 48px; }

--- a/projects/website/src/pitch.html
+++ b/projects/website/src/pitch.html
@@ -151,11 +151,11 @@
           <p class="kicker" data-reveal style="margin-top: 40px;">Cosa è andato online</p>
           <h2 class="statement small" data-reveal style="--d: 0.15s; margin-top: 12px;">Cinque cose, in cinque giorni.</h2>
           <div class="list five" style="margin-top: 40px;">
-            <div class="row" data-reveal style="--d: 0.4s;"><span class="n">01</span><span class="t">Build in public<small>Un post al giorno su quello che stiamo costruendo.</small></span></div>
-            <div class="row" data-reveal style="--d: 0.7s;"><span class="n">02</span><span class="t">Validazione via form &amp; landing<small>La pagina e il modulo: chi siamo, cosa offriamo, chi si iscrive.</small></span></div>
-            <div class="row" data-reveal style="--d: 1.0s;"><span class="n">03</span><span class="t">Iscrizioni &amp; conversione dei lead<small>Un percorso per i talenti, uno per le aziende, e l'area privata.</small></span></div>
-            <div class="row" data-reveal style="--d: 1.3s;"><span class="n">04</span><span class="t">Pannello amministrativo per la valutazione dell'impatto<small>Talenti e aziende in un'unica vista, per fare i primi match.</small></span></div>
-            <div class="row" data-reveal style="--d: 1.6s; border-bottom: 0;"><span class="n">05</span><span class="t">AI tool per i membri<small>PigroCRM: offerte, fatture e pagamenti. Più la guida per chi inizia.</small></span></div>
+            <div class="row" data-reveal style="--d: 0.4s;"><span class="n">01</span><span class="t">Build in public</span></div>
+            <div class="row" data-reveal style="--d: 0.7s;"><span class="n">02</span><span class="t">Validazione via form &amp; landing</span></div>
+            <div class="row" data-reveal style="--d: 1.0s;"><span class="n">03</span><span class="t">Iscrizioni &amp; conversione dei lead</span></div>
+            <div class="row" data-reveal style="--d: 1.3s;"><span class="n">04</span><span class="t">Pannello amministrativo per la valutazione dell'impatto</span></div>
+            <div class="row" data-reveal style="--d: 1.6s; border-bottom: 0;"><span class="n">05</span><span class="t">AI tool per i membri</span></div>
           </div>
         </div>
       </section>

--- a/projects/website/src/pitch.html
+++ b/projects/website/src/pitch.html
@@ -113,13 +113,13 @@
         <div class="pad center">
           <p class="kicker" data-reveal>Cinque giorni dopo</p>
           <div style="display: flex; align-items: flex-end; gap: 60px; margin-top: 30px;">
-            <div class="big" data-reveal style="--d: 0.2s; font-size: 380px;"><span data-count="65">65</span></div>
+            <div class="big" data-reveal style="--d: 0.2s; font-size: 380px;"><span data-count="66">66</span></div>
             <div data-reveal style="--d: 0.5s; padding-bottom: 40px;">
               <div class="label" style="font-size: 54px; color: #fff; font-weight: 600; line-height: 1.05;">iscritti.</div>
               <div class="label" style="font-size: 40px; margin-top: 14px;">Ne avevamo promessi tre.</div>
             </div>
           </div>
-          <p class="statement small" data-reveal style="--d: 0.9s; margin-top: 50px;"><span class="accent">60 talenti</span>, <span class="accent">5 aziende</span>, e il <span class="accent">primo match</span> già chiuso.</p>
+          <p class="statement small" data-reveal style="--d: 0.9s; margin-top: 50px;"><span class="accent">61 talenti</span>, <span class="accent">5 aziende</span>, e il <span class="accent">primo match</span> già chiuso.</p>
         </div>
         <div class="foot"><span>joinorbiters.com</span><span></span></div>
       </section>
@@ -134,7 +134,7 @@
           <div class="stats" style="margin-top: 60px; gap: 70px 48px;">
             <div data-reveal style="--d: 0.2s;"><div class="n"><span data-count="18.5" data-decimals="1">18,5</span><small>k</small></div><div class="l">visualizzazioni su LinkedIn</div></div>
             <div data-reveal style="--d: 0.35s;"><div class="n"><span data-count="500">500</span><small>+</small></div><div class="l">visite uniche al giorno</div></div>
-            <div data-reveal style="--d: 0.5s;"><div class="n"><span data-count="42">42</span></div><div class="l">follower della pagina</div></div>
+            <div data-reveal style="--d: 0.5s;"><div class="n"><span data-count="44">44</span></div><div class="l">follower della pagina</div></div>
             <div data-reveal style="--d: 0.65s;"><div class="n"><span data-count="10">10</span></div><div class="l">stelle su GitHub</div></div>
             <div data-reveal style="--d: 0.8s;"><div class="n"><span data-count="5">5</span></div><div class="l">aziende con un progetto</div></div>
             <div data-reveal style="--d: 0.95s;"><div class="n accent"><span data-count="1">1</span></div><div class="l">match già chiuso</div></div>
@@ -149,12 +149,13 @@
         <div class="box" style="left: 120px; right: 120px; top: 72px; bottom: 116px; padding: 56px 84px;">
           <div class="brand" style="position: static;"><span class="glyph"></span>Orbiters</div>
           <p class="kicker" data-reveal style="margin-top: 40px;">Cosa è andato online</p>
-          <h2 class="statement small" data-reveal style="--d: 0.15s; margin-top: 12px;">Quattro cose, in cinque giorni.</h2>
-          <div class="list" style="margin-top: 50px;">
-            <div class="row" data-reveal style="--d: 0.4s;"><span class="n">01</span><span class="t">Landing page</span></div>
-            <div class="row" data-reveal style="--d: 0.55s;"><span class="n">02</span><span class="t">Iscrizione e area privata</span></div>
-            <div class="row" data-reveal style="--d: 0.7s;"><span class="n">03</span><span class="t">Pannello amministrativo</span></div>
-            <div class="row" data-reveal style="--d: 0.85s; border-bottom: 0;"><span class="n">04</span><span class="t">PigroCRM per i membri</span></div>
+          <h2 class="statement small" data-reveal style="--d: 0.15s; margin-top: 12px;">Cinque cose, in cinque giorni.</h2>
+          <div class="list five" style="margin-top: 40px;">
+            <div class="row" data-reveal style="--d: 0.4s;"><span class="n">01</span><span class="t">Build in public<small>Un post al giorno su quello che stiamo costruendo.</small></span></div>
+            <div class="row" data-reveal style="--d: 0.7s;"><span class="n">02</span><span class="t">Validazione via form &amp; landing<small>La pagina e il modulo: chi siamo, cosa offriamo, chi si iscrive.</small></span></div>
+            <div class="row" data-reveal style="--d: 1.0s;"><span class="n">03</span><span class="t">Iscrizioni &amp; conversione dei lead<small>Un percorso per i talenti, uno per le aziende, e l'area privata.</small></span></div>
+            <div class="row" data-reveal style="--d: 1.3s;"><span class="n">04</span><span class="t">Pannello amministrativo per la valutazione dell'impatto<small>Talenti e aziende in un'unica vista, per fare i primi match.</small></span></div>
+            <div class="row" data-reveal style="--d: 1.6s; border-bottom: 0;"><span class="n">05</span><span class="t">AI tool per i membri<small>PigroCRM: offerte, fatture e pagamenti. Più la guida per chi inizia.</small></span></div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## What this changes

Slide 8 of `/pitch` said «Quattro cose, in cinque giorni» and listed four things. Ivan wants the five as he tells them, entering one after the other: **Build in public**, **Validazione via form & landing**, **Iscrizioni & conversione dei lead**, **Pannello amministrativo per la valutazione dell'impatto**, **AI tool per i membri**, titles alone, as the four were. The rows reveal 0,3 s apart. Five rows do not fit at the list's 60px title, so `pitch.css` gains a `.list.five` variant (54px title, tighter gap); the four-row list style is untouched. Slides 6 and 7 carry this afternoon's numbers: **66 iscritti** with «61 talenti» (was 65 and 60) and **44** follower (was 42). The desk copy carries the same changes.

## How I verified it

- `pnpm --filter website lint`: eslint clean.
- `pnpm --filter website test`: 12 files, 229 tests passed.
- `pnpm --filter website build`: built in 520 ms.
- `pnpm --filter website test:e2e`: 54 passed (12.5 s) against `vite preview` on 4173.
- `diff` of the `<body>` of the page against the desk copy: only the picture-path lines differ, as before.
- Opened `http://localhost:4173/pitch?static=1` from this branch's build and read slides 6, 7 and 8: the frames below.

## Anything a reviewer should look at twice

The fourth title, «Pannello amministrativo per la valutazione dell'impatto», is the longest line on the slide; at 54px it fits on one line at 1920px, and the static frame below shows it does.

## Screenshots

Before from `https://joinorbiters.com/pitch?static=1` as live today (`website-v0.8.6`), after from this branch's `vite preview`, both at 1920×1080.

**1. Slide 6, the signups**
![Slide 6, before and after](https://github.com/user-attachments/assets/4739117d-b061-47bd-944b-de594f164227)

**2. Slide 7, the week's numbers**
![Slide 7, before and after](https://github.com/user-attachments/assets/2a3c4d23-820e-4a4f-bfe6-933d34482be2)

**3. Slide 8, the five things**
![Slide 8, before and after](https://github.com/user-attachments/assets/e35209e9-2d20-4afd-97fc-dd6b423bd255)

Linear: ORB-191.
