### PR TITLE
design(website): the landing, guide and CRM slides each say how many people used them

### DIFF
--- a/projects/website/src/pitch.html
+++ b/projects/website/src/pitch.html
@@ -190,7 +190,7 @@
         <div style="position: absolute; left: 120px; top: 240px; width: 560px;">
           <p class="kicker" data-reveal>La porta d'ingresso</p>
           <h2 class="statement" data-reveal style="--d: 0.15s; margin-top: 24px; font-size: 84px;">60 secondi per entrare.</h2>
-          <p class="label" data-reveal style="--d: 0.5s; margin-top: 30px; font-size: 26px; font-weight: 600; color: var(--melon);">joinorbiters.com</p>
+          <p class="label" data-reveal style="--d: 0.5s; margin-top: 30px; font-size: 32px; font-weight: 600; color: var(--melon);">+40 anagrafiche completate.</p>
         </div>
         <div class="mac" data-reveal style="--d: 0.3s; left: 760px; right: 120px; top: 140px; bottom: 116px;"><div class="bar"><i></i><i></i><i></i><span>joinorbiters.com</span></div><img src="./pitch/shots-landing.webp" alt="La landing page di Orbiters" /></div>
         <div class="foot"><span>joinorbiters.com</span><span></span></div>
@@ -203,6 +203,7 @@
         <div style="position: absolute; left: 120px; top: 240px; width: 560px;">
           <p class="kicker" data-reveal>Il primo perk</p>
           <h2 class="statement" data-reveal style="--d: 0.15s; margin-top: 24px; font-size: 76px;">La guida per iniziare ad essere un freelance.</h2>
+          <p class="label" data-reveal style="--d: 0.5s; margin-top: 30px; font-size: 32px; font-weight: 600; color: var(--melon);">11 download.</p>
         </div>
         <div class="mac pdf" data-reveal style="--d: 0.3s; left: 760px; right: 120px; top: 140px; bottom: 116px;">
           <div class="bar"><i></i><i></i><i></i><span><b>PDF</b> guida-primi-passi.pdf</span><em>7 pagine</em></div>
@@ -222,7 +223,7 @@
           <p class="kicker" data-reveal>Il secondo perk</p>
           <h2 class="statement" data-reveal style="--d: 0.15s; margin-top: 24px; font-size: 84px;">PigroCRM.</h2>
           <p class="lead" data-reveal style="--d: 0.35s; margin-top: 30px; font-size: 36px;">Clienti, offerte, fatture e pagamenti in un posto solo. Un assistente AI fa il lavoro noioso.</p>
-          <p class="label" data-reveal style="--d: 0.5s; margin-top: 30px; font-size: 32px; font-weight: 600; color: var(--melon);">Gratis per chi è dentro.</p>
+          <p class="label" data-reveal style="--d: 0.5s; margin-top: 30px; font-size: 32px; font-weight: 600; color: var(--melon);">10 utenti attivi. Gratis per chi è dentro.</p>
         </div>
         <div class="mac" data-reveal style="--d: 0.3s; left: 760px; right: 120px; top: 140px; bottom: 116px;"><div class="bar"><i></i><i></i><i></i><span>pigro.joinorbiters.com</span></div><img src="./pitch/shots-crm-home.webp" alt="La home di uno spazio PigroCRM" /></div>
         <div class="foot"><span>joinorbiters.com</span><span></span></div>


### PR DESCRIPTION
## What this changes

Slides 10, 11 and 12 of `/pitch` show the landing, the guide and PigroCRM, and only the last one closed with a line in the accent colour («Gratis per chi è dentro.»). Ivan asked for the same line on all three, with the numbers of today: slide 10 says **«+40 anagrafiche completate.»** in place of the URL, which the browser bar of the screenshot beside it already shows; slide 11 gains **«11 download.»** under the title; slide 12's line becomes **«10 utenti attivi. Gratis per chi è dentro.»**. Same element, same 32px, same reveal timing. The desk copy carries the same change.

## How I verified it

- `pnpm --filter website lint`: eslint clean.
- `pnpm --filter website test`: 12 files, 229 tests passed.
- `pnpm --filter website build`: built in 780 ms.
- `pnpm --filter website test:e2e`: 54 passed (14.9 s) against `vite preview` on 4173.
- `diff` of the `<body>` of the page against the desk copy: only the picture-path lines differ, as before.
- Opened `http://localhost:4173/pitch?static=1` from this branch's build and read the three slides: the frames below.

## Screenshots

Before from `https://joinorbiters.com/pitch?static=1` as live today (`website-v0.9.0`), after from this branch's `vite preview`, both at 1920×1080.

**1. Slide 10, the landing**
![Slide 10, before and after](https://github.com/user-attachments/assets/81727ef4-7c53-43c2-a879-5691d1c5a490)

**2. Slide 11, the guide**
![Slide 11, before and after](https://github.com/user-attachments/assets/c886e595-9ab9-4207-aa5c-246445b4f063)

**3. Slide 12, PigroCRM**
![Slide 12, before and after](https://github.com/user-attachments/assets/8420896e-06b8-4ed9-9787-351e9f9d180a)

Linear: ORB-192.
